### PR TITLE
Add GitHub workflows to test the build and get temporary compiled stuff weekly

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -1,0 +1,44 @@
+name: Build
+on: [push]
+
+jobs:
+
+  build-linux:
+    runs-on: ubuntu-latest
+
+    steps:
+    - uses: actions/checkout@v3
+    - name: Update
+      run: |
+        sudo apt-get update
+
+    - name: Build QVM
+      run: |
+        make -j12
+      env:
+        ARCHIVE: 1
+
+    - name: Set artifact name
+      run: |
+        git fetch --tags
+        FILENAME_HERE=$(ls build/)
+        GIT_DESCRIBECOMMIT=$(git describe --tags --always)
+        ARTIFACT_NAME="${FILENAME_HERE%.*}-${GIT_DESCRIBECOMMIT##*-}"
+        echo "ARTIFACT_NAME=$ARTIFACT_NAME" >> $GITHUB_ENV
+
+    - name: Store pk3 artifact
+      uses: actions/upload-artifact@v3
+      with:
+        name: ${{ env.ARTIFACT_NAME }}
+        path: |
+          build/*.pk3
+        if-no-files-found: error
+        retention-days: 7
+
+    - name: Publish a release
+      if: startsWith(github.ref, 'refs/tags/')
+      uses: softprops/action-gh-release@v1
+      env:
+        GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+        files: |
+          build/*.pk3


### PR DESCRIPTION
This adds the workflows to test if, after committing the changes in the repository, it suceeds or fails when compiling.

**What is this?**

The artifacts are resources where the users can download in GitHub without doing a task in the repository like compiling and getting the compiled resources. Eases the development progress and gives access to the testers.

Contains the compiled pk3 file to test in the mod. Only available temporarily after the build in such action, the built artifact expires in 1 week in such action.

Every time it gets commits, the workflow runs and upload artifacts to download.

In the GitHub repository, go to:
![image](https://github.com/alcachofass/devotion/assets/49716252/2cc767c0-06fc-4bbb-a94a-331fc5645dcf)

**Select workflow (select the build one, not the tests) or click View Workflow file from suspension points button** >>
![image](https://github.com/alcachofass/devotion/assets/49716252/54be38fb-9218-49b3-b19d-86131d86ce93)

**Scroll down and you'll see the artifacts to download** >> **Download the artifact to test**
![image](https://github.com/alcachofass/devotion/assets/49716252/362ba2a9-fce9-4276-9c10-863351be5b89)
