### PR TITLE
Fix replay scoreboard

### DIFF
--- a/ratoa_gamecode/Makefile
+++ b/ratoa_gamecode/Makefile
@@ -1701,6 +1701,7 @@ Q3CGOBJ_ = \
   $(B)/baseq3/cgame/cg_scoreboard.o \
   $(B)/baseq3/cgame/cg_servercmds.o \
   $(B)/baseq3/cgame/cg_snapshot.o \
+  $(B)/baseq3/cgame/cg_demo_history.o \
   $(B)/baseq3/cgame/cg_unlagged.o \
   $(B)/baseq3/cgame/cg_view.o \
   $(B)/baseq3/cgame/cg_weapons.o \
@@ -1746,6 +1747,7 @@ MPCGOBJ_ = \
   $(B)/missionpack/cgame/cg_scoreboard.o \
   $(B)/missionpack/cgame/cg_servercmds.o \
   $(B)/missionpack/cgame/cg_snapshot.o \
+  $(B)/missionpack/cgame/cg_demo_history.o \
   $(B)/missionpack/cgame/cg_unlagged.o \
   $(B)/missionpack/cgame/cg_view.o \
   $(B)/missionpack/cgame/cg_weapons.o \

--- a/ratoa_gamecode/code/cgame/cg_consolecmds.c
+++ b/ratoa_gamecode/code/cgame/cg_consolecmds.c
@@ -240,18 +240,27 @@ static void CG_ScoresDown_f( void ) {
 		// so request new ones
 		cg.scoresRequestTime = cg.time;
 
-		trap_SendClientCommand( "score" );
+		if ( cg.demoPlayback ) {
+			CG_BuildDemoScores();
+		} else {
+			trap_SendClientCommand( "score" );
+		}
 
 		// leave the current scores up if they were already
 		// displayed, but if this is the first hit, clear them out
 		if ( !cg.showScores ) {
 			cg.showScores = qtrue;
-			cg.numScores = 0;
+			if ( !cg.demoPlayback ) {
+				cg.numScores = 0;
+			}
 		}
 	} else {
 		// show the cached contents even if they just pressed if it
 		// is within two seconds
 		cg.showScores = qtrue;
+		if ( cg.demoPlayback ) {
+			CG_BuildDemoScores();
+		}
 	}
 
 	if (cg.predictedPlayerState.pm_type == PM_INTERMISSION) {

--- a/ratoa_gamecode/code/cgame/cg_demo_history.c
+++ b/ratoa_gamecode/code/cgame/cg_demo_history.c
@@ -1,0 +1,90 @@
+/*
+===========================================================================
+Demo playback snapshot history (ring buffer).
+
+Deep-copies each authoritative snapshot_t when it becomes current during
+demo playback (initial snapshot and each transition). Inactive during
+live play; buffer is cleared when demo playback ends.
+===========================================================================
+*/
+
+#include "cg_local.h"
+
+/* Match server unlagged window scale (~17 samples @ 20Hz); allow slack */
+#define CG_DEMO_HISTORY_CAPACITY 40
+
+static snapshot_t cg_demoHistoryBuf[CG_DEMO_HISTORY_CAPACITY];
+static int cg_demoHistoryHead;
+static int cg_demoHistoryCount;
+static int cg_demoHistoryLastServerTime;
+static qboolean cg_demoHistoryPrevPlayback;
+
+void CG_DemoHistory_Clear( void ) {
+	cg_demoHistoryHead = 0;
+	cg_demoHistoryCount = 0;
+	cg_demoHistoryLastServerTime = -1;
+	Com_Memset( cg_demoHistoryBuf, 0, sizeof( cg_demoHistoryBuf ) );
+}
+
+void CG_DemoHistory_Init( void ) {
+	CG_DemoHistory_Clear();
+	cg_demoHistoryPrevPlayback = qfalse;
+}
+
+void CG_DemoHistory_Frame( void ) {
+	if ( cg_demoHistoryPrevPlayback && !cg.demoPlayback ) {
+		CG_DemoHistory_Clear();
+	}
+	cg_demoHistoryPrevPlayback = cg.demoPlayback;
+}
+
+void CG_DemoHistory_OnSnapshot( const snapshot_t *snap ) {
+	int slot;
+
+	if ( !cg.demoPlayback || !snap ) {
+		return;
+	}
+
+	if ( cg_demoHistoryCount > 0 && snap->serverTime < cg_demoHistoryLastServerTime ) {
+		CG_DemoHistory_Clear();
+	}
+
+	if ( snap->serverTime == cg_demoHistoryLastServerTime ) {
+		return;
+	}
+
+	if ( cg_demoHistoryCount < CG_DEMO_HISTORY_CAPACITY ) {
+		slot = ( cg_demoHistoryHead + cg_demoHistoryCount ) % CG_DEMO_HISTORY_CAPACITY;
+		cg_demoHistoryCount++;
+	} else {
+		slot = cg_demoHistoryHead;
+		cg_demoHistoryHead = ( cg_demoHistoryHead + 1 ) % CG_DEMO_HISTORY_CAPACITY;
+	}
+
+	Com_Memcpy( &cg_demoHistoryBuf[slot], snap, sizeof( snapshot_t ) );
+	cg_demoHistoryLastServerTime = snap->serverTime;
+}
+
+int CG_DemoHistory_GetCount( void ) {
+	return cg_demoHistoryCount;
+}
+
+const snapshot_t *CG_DemoHistory_GetNewest( void ) {
+	int idx;
+
+	if ( cg_demoHistoryCount <= 0 ) {
+		return NULL;
+	}
+	idx = ( cg_demoHistoryHead + cg_demoHistoryCount - 1 ) % CG_DEMO_HISTORY_CAPACITY;
+	return &cg_demoHistoryBuf[idx];
+}
+
+const snapshot_t *CG_DemoHistory_GetByFramesAgo( int framesAgo ) {
+	int idx;
+
+	if ( framesAgo < 0 || framesAgo >= cg_demoHistoryCount ) {
+		return NULL;
+	}
+	idx = ( cg_demoHistoryHead + cg_demoHistoryCount - 1 - framesAgo ) % CG_DEMO_HISTORY_CAPACITY;
+	return &cg_demoHistoryBuf[idx];
+}

--- a/ratoa_gamecode/code/cgame/cg_demo_history.h
+++ b/ratoa_gamecode/code/cgame/cg_demo_history.h
@@ -8,7 +8,7 @@ Only populated while cg.demoPlayback is true.
 #ifndef CG_DEMO_HISTORY_H
 #define CG_DEMO_HISTORY_H
 
-#include "cg_public.h"
+/* snapshot_t is defined in cg_public.h — include cg_local.h (or cg_public.h) before this header */
 
 void CG_DemoHistory_Init( void );
 void CG_DemoHistory_Clear( void );

--- a/ratoa_gamecode/code/cgame/cg_demo_history.h
+++ b/ratoa_gamecode/code/cgame/cg_demo_history.h
@@ -1,0 +1,22 @@
+/*
+===========================================================================
+Demo playback: ring buffer of past snapshots for pseudo delag (step 1).
+Only populated while cg.demoPlayback is true.
+===========================================================================
+*/
+
+#ifndef CG_DEMO_HISTORY_H
+#define CG_DEMO_HISTORY_H
+
+#include "cg_public.h"
+
+void CG_DemoHistory_Init( void );
+void CG_DemoHistory_Clear( void );
+void CG_DemoHistory_OnSnapshot( const snapshot_t *snap );
+void CG_DemoHistory_Frame( void );
+
+int CG_DemoHistory_GetCount( void );
+const snapshot_t *CG_DemoHistory_GetNewest( void );
+const snapshot_t *CG_DemoHistory_GetByFramesAgo( int framesAgo );
+
+#endif

--- a/ratoa_gamecode/code/cgame/cg_local.h
+++ b/ratoa_gamecode/code/cgame/cg_local.h
@@ -24,6 +24,7 @@ Foundation, Inc., 51 Franklin St, Fifth Floor, Boston, MA  02110-1301  USA
 #include "../renderer/tr_types.h"
 #include "../game/bg_public.h"
 #include "cg_public.h"
+#include "cg_demo_history.h"
 
 #include "../game/challenges.h"
 
@@ -2033,6 +2034,10 @@ void CG_SpurtBlood( vec3_t origin, vec3_t velocity, int hard );
 void CG_PingLocation( centity_t *cent );
 void CG_PingHudMarker ( vec3_t pingOrigin, float alpha, qhandle_t shader );
 void CG_HudBorderMarker ( vec3_t origin, float alpha, float radius, qhandle_t shader, int baseAngle );
+
+//
+// cg_demo_history.c (declarations in cg_demo_history.h)
+//
 
 //
 // cg_snapshot.c

--- a/ratoa_gamecode/code/cgame/cg_local.h
+++ b/ratoa_gamecode/code/cgame/cg_local.h
@@ -447,6 +447,9 @@ typedef struct {
 
 } score_t;
 
+/* Demo scoreboard: slot not yet filled from ratscores/scores ping fields */
+#define	CG_DEMO_PING_UNSET	(-2)
+
 // each client has an associated clientInfo_t
 // that contains media references necessary to present the
 // client model and other color coded effects
@@ -715,6 +718,10 @@ typedef struct {
 
 	// scoreboard
 	int			scoresRequestTime;
+	int			demoScoreboardPing;		/* smoothed POV ping during demo playback */
+	qboolean	demoScoreboardPingValid;
+	qboolean	demoScoreboardRatscores;	/* demo has applied ratscores/scores from stream */
+	int			demoClientPing[MAX_CLIENTS];	/* last ping from score cmds; CG_DEMO_PING_UNSET if unknown */
 	int			numScores;
 	qboolean		medals_available;
 	qboolean		stats_available;
@@ -2059,6 +2066,9 @@ void CG_DrawInformation( void );
 // cg_scoreboard.c
 //
 qboolean CG_DrawOldScoreboard( void );
+void CG_DemoResetScorePingCache( void );
+void CG_DemoCachePingsFromScores( const score_t *rows, int count );
+void CG_BuildDemoScores( void );
 qboolean CG_DrawRatScoreboard( void );
 void CG_DrawOldTourneyScoreboard( void );
 

--- a/ratoa_gamecode/code/cgame/cg_main.c
+++ b/ratoa_gamecode/code/cgame/cg_main.c
@@ -2566,6 +2566,8 @@ void CG_Init( int serverMessageNum, int serverCommandSequence, int clientNum ) {
 	memset( cg_weapons, 0, sizeof(cg_weapons) );
 	memset( cg_items, 0, sizeof(cg_items) );
 
+	CG_DemoHistory_Init();
+
 	cg.clientNum = clientNum;
 
 	cgs.processedSnapshotNum = serverMessageNum;
@@ -2693,6 +2695,7 @@ Called before every level change or subsystem restart
 void CG_Shutdown( void ) {
 	// some mods may need to do cleanup work here,
 	// like closing files or archiving session data
+	CG_DemoHistory_Clear();
 	challenges_save();
 }
 

--- a/ratoa_gamecode/code/cgame/cg_main.c
+++ b/ratoa_gamecode/code/cgame/cg_main.c
@@ -2566,6 +2566,8 @@ void CG_Init( int serverMessageNum, int serverCommandSequence, int clientNum ) {
 	memset( cg_weapons, 0, sizeof(cg_weapons) );
 	memset( cg_items, 0, sizeof(cg_items) );
 
+	CG_DemoResetScorePingCache();
+
 	CG_DemoHistory_Init();
 
 	cg.clientNum = clientNum;

--- a/ratoa_gamecode/code/cgame/cg_scoreboard.c
+++ b/ratoa_gamecode/code/cgame/cg_scoreboard.c
@@ -24,6 +24,48 @@ Foundation, Inc., 51 Franklin St, Fifth Floor, Boston, MA  02110-1301  USA
 #include "cg_local.h"
 
 
+/*
+=================
+CG_DemoResetScorePingCache
+=================
+ */
+void CG_DemoResetScorePingCache( void ) {
+	int	i;
+
+	for ( i = 0 ; i < MAX_CLIENTS ; i++ ) {
+		cg.demoClientPing[i] = CG_DEMO_PING_UNSET;
+	}
+}
+
+/*
+=================
+CG_DemoCachePingsFromScores
+
+Called when ratscores/scores servercmds are parsed so demo synthetic rows can
+show other clients' pings before (or without) a full multipart merge.
+=================
+ */
+void CG_DemoCachePingsFromScores( const score_t *rows, int count ) {
+	int	i, c, p;
+
+	if ( !cg.demoPlayback || !rows || count <= 0 ) {
+		return;
+	}
+
+	for ( i = 0 ; i < count && i < MAX_CLIENTS ; i++ ) {
+		c = rows[i].client;
+		if ( c < 0 || c >= MAX_CLIENTS ) {
+			continue;
+		}
+		p = rows[i].ping;
+		if ( p < -1 || p > 999 ) {
+			continue;
+		}
+		cg.demoClientPing[c] = p;
+	}
+}
+
+
 #define	SCOREBOARD_X		(0)
 
 #define SB_HEADER			86
@@ -805,6 +847,134 @@ static int ShowScoreboardNum(void) {
 
 /*
 =================
+CG_BuildDemoScores
+
+During demo playback the server does not answer the "score" client command, and
+the first scoreboard key press clears cg.numScores. Rebuild cg.scores from
+snapshot and configstrings so the scoreboard can list clients. Only the
+followed / POV client has full playerState stats; other rows show names and
+teams with neutral placeholder stats where the demo stream does not carry them.
+=================
+ */
+void CG_BuildDemoScores( void ) {
+	int				i, j, n;
+	int				matchSeconds;
+	int				powerups;
+	const playerState_t	*ps;
+	score_t			*s;
+	centity_t		*cent;
+
+	if ( !cg.demoPlayback || !cg.snap ) {
+		return;
+	}
+
+	/* After match end the demo replays full ratscores; do not clobber with synthetic rows. */
+	if ( cg.snap->ps.pm_type == PM_INTERMISSION
+			|| cg.predictedPlayerState.pm_type == PM_INTERMISSION ) {
+		return;
+	}
+
+	/* Server score strings in the demo provide all clients; keep that data until map/snap reset. */
+	if ( cg.demoScoreboardRatscores ) {
+		return;
+	}
+
+	memset( cg.scores, 0, sizeof( cg.scores ) );
+	ps = &cg.snap->ps;
+
+	matchSeconds = 0;
+	if ( cgs.levelStartTime > 0 && cg.snap->serverTime > cgs.levelStartTime ) {
+		matchSeconds = ( cg.snap->serverTime - cgs.levelStartTime ) / 1000;
+		if ( matchSeconds < 0 ) {
+			matchSeconds = 0;
+		}
+		if ( matchSeconds > 999 * 60 ) {
+			matchSeconds = 999 * 60;
+		}
+	}
+
+	if ( CG_IsTeamGametype() && cgs.scores1 != SCORE_NOT_PRESENT && cgs.scores2 != SCORE_NOT_PRESENT ) {
+		cg.teamScores[0] = cgs.scores1;
+		cg.teamScores[1] = cgs.scores2;
+	}
+
+	n = 0;
+	for ( i = 0 ; i < cgs.maxclients ; i++ ) {
+		if ( !cgs.clientinfo[i].infoValid ) {
+			continue;
+		}
+
+		s = &cg.scores[n];
+		memset( s, 0, sizeof( *s ) );
+		s->client = i;
+		s->team = cgs.clientinfo[i].team;
+#ifdef WITH_MULTITOURNAMENT
+		s->gameId = cgs.clientinfo[i].gameId;
+#endif
+
+		if ( i == ps->clientNum ) {
+			s->score = ps->persistant[PERS_SCORE];
+			if ( cg.demoPlayback && cg.demoScoreboardPingValid ) {
+				s->ping = cg.demoScoreboardPing;
+			} else if ( cg.demoPlayback ) {
+				s->ping = ps->ping;
+			} else {
+				s->ping = cg.snap->ping;
+			}
+			if ( s->ping < 0 ) {
+				s->ping = 0;
+			} else if ( s->ping > 999 ) {
+				s->ping = 999;
+			}
+			s->time = matchSeconds;
+			s->captures = ps->persistant[PERS_CAPTURES];
+			s->impressiveCount = ps->persistant[PERS_IMPRESSIVE_COUNT];
+			s->excellentCount = ps->persistant[PERS_EXCELLENT_COUNT];
+			s->defendCount = ps->persistant[PERS_DEFEND_COUNT];
+			s->assistCount = ps->persistant[PERS_ASSIST_COUNT];
+			s->guantletCount = ps->persistant[PERS_GAUNTLET_FRAG_COUNT];
+			s->deaths = ps->persistant[PERS_KILLED];
+			s->dmgGiven = ps->persistant[PERS_DAMAGE_DONE];
+			s->isDead = ( ps->stats[STAT_HEALTH] <= 0 ) ? 1 : 0;
+
+			powerups = 0;
+			for ( j = 0 ; j < MAX_POWERUPS ; j++ ) {
+				if ( ps->powerups[j] ) {
+					powerups |= 1 << j;
+				}
+			}
+			cgs.clientinfo[i].powerups = powerups;
+			cgs.clientinfo[i].score = s->score;
+			cgs.clientinfo[i].isDead = s->isDead;
+		} else {
+			cent = &cg_entities[i];
+			if ( cent->currentValid && cent->currentState.eType == ET_PLAYER ) {
+				s->isDead = ( cent->currentState.eFlags & EF_DEAD ) ? 1 : 0;
+			} else {
+				s->isDead = 0;
+			}
+			if ( cg.demoClientPing[i] != CG_DEMO_PING_UNSET ) {
+				s->ping = cg.demoClientPing[i];
+				if ( s->ping > 999 ) {
+					s->ping = 999;
+				}
+			} else {
+				s->ping = 0;
+			}
+			s->time = matchSeconds;
+		}
+
+		n++;
+		if ( n >= MAX_CLIENTS ) {
+			break;
+		}
+	}
+
+	cg.numScores = n;
+}
+
+/*
+=================
 CG_RatTeamScoreboard
 =================
  */
@@ -923,11 +1093,28 @@ qboolean CG_DrawRatScoreboard(void) {
 		fade = *fadeColor;
 	}
 
+	if ( cg.demoPlayback && cg.snap && cg.numScores == 0
+			&& !cg.demoScoreboardRatscores
+			&& cg.snap->ps.pm_type != PM_INTERMISSION
+			&& cg.predictedPlayerState.pm_type != PM_INTERMISSION
+			&& ( cg.showScores || cg.predictedPlayerState.pm_type == PM_DEAD ) ) {
+		CG_BuildDemoScores();
+	}
+
 	if ( cg.scoresRequestTime + 1000 < cg.time ) {
 		// the scores are more than 1s out of data,
 		// so request new ones
 		cg.scoresRequestTime = cg.time;
-		trap_SendClientCommand( "score" );
+		if ( cg.demoPlayback ) {
+			if ( !cg.demoScoreboardRatscores
+					&& cg.snap
+					&& cg.snap->ps.pm_type != PM_INTERMISSION
+					&& cg.predictedPlayerState.pm_type != PM_INTERMISSION ) {
+				CG_BuildDemoScores();
+			}
+		} else {
+			trap_SendClientCommand( "score" );
+		}
 	}
 
 
@@ -1557,6 +1744,28 @@ qboolean CG_DrawOldScoreboard( void ) {
 		fade = *fadeColor;
 	}
 
+	if ( cg.demoPlayback && cg.snap && cg.numScores == 0
+			&& !cg.demoScoreboardRatscores
+			&& cg.snap->ps.pm_type != PM_INTERMISSION
+			&& cg.predictedPlayerState.pm_type != PM_INTERMISSION
+			&& ( cg.showScores || cg.predictedPlayerState.pm_type == PM_DEAD ) ) {
+		CG_BuildDemoScores();
+	}
+
+	if ( cg.scoresRequestTime + 1000 < cg.time ) {
+		cg.scoresRequestTime = cg.time;
+		if ( cg.demoPlayback ) {
+			if ( !cg.demoScoreboardRatscores
+					&& cg.snap
+					&& cg.snap->ps.pm_type != PM_INTERMISSION
+					&& cg.predictedPlayerState.pm_type != PM_INTERMISSION ) {
+				CG_BuildDemoScores();
+			}
+		} else {
+			trap_SendClientCommand( "score" );
+		}
+	}
+
 
 	// fragged by ... line
 	if ( cg.killerName[0] ) {
@@ -1713,7 +1922,15 @@ void CG_DrawOldTourneyScoreboard( void ) {
 	// request more scores regularly
 	if ( cg.scoresRequestTime + 2000 < cg.time ) {
 		cg.scoresRequestTime = cg.time;
-		trap_SendClientCommand( "score" );
+		if ( cg.demoPlayback ) {
+			if ( !cg.demoScoreboardRatscores
+					&& cg.snap && cg.snap->ps.pm_type != PM_INTERMISSION
+					&& cg.predictedPlayerState.pm_type != PM_INTERMISSION ) {
+				CG_BuildDemoScores();
+			}
+		} else {
+			trap_SendClientCommand( "score" );
+		}
 	}
 
 	// draw the dialog background

--- a/ratoa_gamecode/code/cgame/cg_servercmds.c
+++ b/ratoa_gamecode/code/cgame/cg_servercmds.c
@@ -149,6 +149,12 @@ static void CG_ParseRatScores( void ) {
 
 		cg.scores[i].team = cgs.clientinfo[cg.scores[i].client].team;
 	}
+
+	CG_DemoCachePingsFromScores( cg.scores, cg.numScores );
+
+	if ( cg.demoPlayback ) {
+		cg.demoScoreboardRatscores = qtrue;
+	}
 }
 
 
@@ -168,6 +174,12 @@ static void CG_CheckScoreUpdate(void) {
 	cg.numScores = cg.numScores_buf;
 	cg.medals_available = (cg.received_ratscores >= 4);
 	cg.stats_available = cg.weaponPU_available = (cg.received_ratscores == 5); //mrd
+
+	if ( cg.demoPlayback ) {
+		cg.demoScoreboardRatscores = qtrue;
+	}
+
+	CG_DemoCachePingsFromScores( cg.scores, cg.numScores );
 
 	CG_PurgeScoreBuf();
 }
@@ -246,6 +258,8 @@ static void CG_ParseRatScores1( void ) {
 
 		cg.scores_buf[i].team = cgs.clientinfo[cg.scores_buf[i].client].team;
 	}
+
+	CG_DemoCachePingsFromScores( cg.scores_buf, numScores );
 
 	CG_CheckScoreUpdate();
 }
@@ -519,9 +533,16 @@ static void CG_ParseScores( void ) {
 
 		cg.scores[i].team = cgs.clientinfo[cg.scores[i].client].team;
 	}
+
+	CG_DemoCachePingsFromScores( cg.scores, cg.numScores );
+
 #ifdef MISSIONPACK
 	CG_SetScoreSelection(NULL);
 #endif
+
+	if ( cg.demoPlayback ) {
+		cg.demoScoreboardRatscores = qtrue;
+	}
 
 }
 

--- a/ratoa_gamecode/code/cgame/cg_snapshot.c
+++ b/ratoa_gamecode/code/cgame/cg_snapshot.c
@@ -145,6 +145,8 @@ void CG_SetInitialSnapshot( snapshot_t *snap ) {
 		// check for events
 		CG_CheckEvents( cent );
 	}
+
+	CG_DemoHistory_OnSnapshot( cg.snap );
 }
 
 
@@ -216,6 +218,8 @@ static void CG_TransitionSnapshot( void ) {
 			CG_TransitionPlayerState( ps, ops );
 		}
 	}
+
+	CG_DemoHistory_OnSnapshot( cg.snap );
 
 }
 

--- a/ratoa_gamecode/code/cgame/cg_snapshot.c
+++ b/ratoa_gamecode/code/cgame/cg_snapshot.c
@@ -117,6 +117,14 @@ void CG_SetInitialSnapshot( snapshot_t *snap ) {
 
 	cg.snap = snap;
 
+	cg.demoScoreboardRatscores = qfalse;
+	CG_DemoResetScorePingCache();
+
+	if ( cg.demoPlayback ) {
+		cg.demoScoreboardPingValid = qfalse;
+		cg.demoScoreboardPing = 0;
+	}
+
 	BG_PlayerStateToEntityState( &snap->ps, &cg_entities[ snap->ps.clientNum ].currentState, qfalse );
 	cg_entities[ cg.snap->ps.clientNum ].quiet = qfalse;
 
@@ -184,6 +192,30 @@ static void CG_TransitionSnapshot( void ) {
 
 	// move nextSnap to snap and do the transitions
 	oldFrame = cg.snap;
+
+	if ( cg.demoPlayback && oldFrame && cg.nextSnap ) {
+		int	op, np, d, p;
+
+		op = oldFrame->ping;
+		np = cg.nextSnap->ping;
+		d = np - op;
+		/* During demo playback some clients store a running sum in snapshot ping; use per-step delta. */
+		if ( d > 0 && d <= 400 ) {
+			if ( !cg.demoScoreboardPingValid ) {
+				cg.demoScoreboardPing = d;
+			} else {
+				cg.demoScoreboardPing = ( cg.demoScoreboardPing * 7 + d ) / 8;
+			}
+			cg.demoScoreboardPingValid = qtrue;
+		} else {
+			p = cg.nextSnap->ps.ping;
+			if ( p >= 0 && p <= 400 ) {
+				cg.demoScoreboardPing = p;
+				cg.demoScoreboardPingValid = qtrue;
+			}
+		}
+	}
+
 	cg.snap = cg.nextSnap;
 
 	BG_PlayerStateToEntityState( &cg.snap->ps, &cg_entities[ cg.snap->ps.clientNum ].currentState, qfalse );

--- a/ratoa_gamecode/code/cgame/cg_view.c
+++ b/ratoa_gamecode/code/cgame/cg_view.c
@@ -999,6 +999,8 @@ void CG_DrawActiveFrame( int serverTime, stereoFrame_t stereoView, qboolean demo
 	cg.time = serverTime;
 	cg.demoPlayback = demoPlayback;
 
+	CG_DemoHistory_Frame();
+
 	// update cvars
 	CG_UpdateCvars();
 

--- a/ratoa_gamecode/windows_scripts/cgame.q3asm
+++ b/ratoa_gamecode/windows_scripts/cgame.q3asm
@@ -17,6 +17,7 @@ cg_predict
 cg_scoreboard
 cg_servercmds
 cg_snapshot
+cg_demo_history
 cg_unlagged
 cg_view
 cg_weapons

--- a/ratoa_gamecode/windows_scripts/cgame_mp.q3asm
+++ b/ratoa_gamecode/windows_scripts/cgame_mp.q3asm
@@ -18,6 +18,7 @@ cg_predict
 cg_scoreboard
 cg_servercmds
 cg_snapshot
+cg_demo_history
 cg_unlagged
 cg_view
 cg_weapons

--- a/ratoa_gamecode/windows_scripts/windows_compile_cgame.bat
+++ b/ratoa_gamecode/windows_scripts/windows_compile_cgame.bat
@@ -36,6 +36,7 @@ cd windows\build\cgame
 %cc%  ../../../code/cgame/cg_scoreboard.c
 %cc%  ../../../code/cgame/cg_servercmds.c
 %cc%  ../../../code/cgame/cg_snapshot.c
+%cc%  ../../../code/cgame/cg_demo_history.c
 %cc%  ../../../code/cgame/cg_unlagged.c
 %cc%  ../../../code/cgame/cg_view.c
 %cc%  ../../../code/cgame/cg_weapons.c

--- a/ratoa_gamecode/windows_scripts/windows_compile_cgame_missionpack.bat
+++ b/ratoa_gamecode/windows_scripts/windows_compile_cgame_missionpack.bat
@@ -36,6 +36,7 @@ cd windows\build\cgame
 %cc%  ../../../code/cgame/cg_scoreboard.c
 %cc%  ../../../code/cgame/cg_servercmds.c
 %cc%  ../../../code/cgame/cg_snapshot.c
+%cc%  ../../../code/cgame/cg_demo_history.c
 %cc%  ../../../code/cgame/cg_unlagged.c
 %cc%  ../../../code/cgame/cg_view.c
 %cc%  ../../../code/cgame/cg_weapons.c


### PR DESCRIPTION
This change fixes the blank scoreboard when playing back demos. Scoreboard code was calling trap_SendClientCommand("score") which invokes a response from the server. Since there is no server during demo playback, nothing answered that call.
So now, we gather that data synthetically during demo file playback when the information we need is read from the replayed network traffic.

A few scoreboard fields are still not properly populated - Accuracy is pulled in from rat code and without fully re-creating it, that information is not provided in replay data. Likewise opponent player pings (anyone who is not the recording party) is not pulled in from regular replay information and can only be obtained when one of the scores servercmds was invoked during live play (typically, only when the player brought up the scoreboard, or died). So opponent pings start at a false value of zero, and this is only updated if/when the info becomes available during the replay playback. In some cases it just won't be (if the player never dies or checks the scoreboard).

End-of-match scores always functioned correctly (server pumps out scoreboard data to all clients at intermission) and so these new code paths mostly terminate when level.intermissiontime is set.

_**Note:** There's also a bit of scaffolding in this change for another change coming later (implementing a client-side ring buffer that mimics the server-side one used for delag wind-back functions during live gameplay). That's only present in this fix because I started out working on that and became sidetracked with fixing the scoreboard ;P_