### PR TITLE
Implement pseudo-delag for demo playback

### DIFF
--- a/ratoa_gamecode/Makefile
+++ b/ratoa_gamecode/Makefile
@@ -1701,6 +1701,7 @@ Q3CGOBJ_ = \
   $(B)/baseq3/cgame/cg_scoreboard.o \
   $(B)/baseq3/cgame/cg_servercmds.o \
   $(B)/baseq3/cgame/cg_snapshot.o \
+  $(B)/baseq3/cgame/cg_demo_history.o \
   $(B)/baseq3/cgame/cg_unlagged.o \
   $(B)/baseq3/cgame/cg_view.o \
   $(B)/baseq3/cgame/cg_weapons.o \
@@ -1746,6 +1747,7 @@ MPCGOBJ_ = \
   $(B)/missionpack/cgame/cg_scoreboard.o \
   $(B)/missionpack/cgame/cg_servercmds.o \
   $(B)/missionpack/cgame/cg_snapshot.o \
+  $(B)/missionpack/cgame/cg_demo_history.o \
   $(B)/missionpack/cgame/cg_unlagged.o \
   $(B)/missionpack/cgame/cg_view.o \
   $(B)/missionpack/cgame/cg_weapons.o \

--- a/ratoa_gamecode/code/cgame/cg_cvar.h
+++ b/ratoa_gamecode/code/cgame/cg_cvar.h
@@ -348,6 +348,7 @@ CG_CVAR( cg_leiSuperGoreyAwesome, "cg_leiSuperGoreyAwesome", "0", CVAR_ARCHIVE )
 CG_CVAR( cg_oldPlasma, "cg_oldPlasma", "1", CVAR_ARCHIVE )
 //unlagged - client options
 CG_CVAR( cg_delag, "cg_delag", "1", CVAR_ARCHIVE | CVAR_USERINFO )
+CG_CVAR( cg_demoDelag, "cg_demoDelag", "1", CVAR_ARCHIVE )
 //CG_CVAR( cg_debugDelag, "cg_debugDelag", "0", CVAR_USERINFO | CVAR_CHEAT )
 //CG_CVAR( cg_drawBBox, "cg_drawBBox", "0", CVAR_CHEAT )
 CG_CVAR( cg_cmdTimeNudge, "cg_cmdTimeNudge", "0", CVAR_ARCHIVE | CVAR_USERINFO )

--- a/ratoa_gamecode/code/cgame/cg_demo_history.c
+++ b/ratoa_gamecode/code/cgame/cg_demo_history.c
@@ -1,0 +1,90 @@
+/*
+===========================================================================
+Demo playback snapshot history (ring buffer).
+
+Deep-copies each authoritative snapshot_t when it becomes current during
+demo playback (initial snapshot and each transition). Inactive during
+live play; buffer is cleared when demo playback ends.
+===========================================================================
+*/
+
+#include "cg_local.h"
+
+/* Match server unlagged window scale (~17 samples @ 20Hz); allow slack */
+#define CG_DEMO_HISTORY_CAPACITY 40
+
+static snapshot_t cg_demoHistoryBuf[CG_DEMO_HISTORY_CAPACITY];
+static int cg_demoHistoryHead;
+static int cg_demoHistoryCount;
+static int cg_demoHistoryLastServerTime;
+static qboolean cg_demoHistoryPrevPlayback;
+
+void CG_DemoHistory_Clear( void ) {
+	cg_demoHistoryHead = 0;
+	cg_demoHistoryCount = 0;
+	cg_demoHistoryLastServerTime = -1;
+	Com_Memset( cg_demoHistoryBuf, 0, sizeof( cg_demoHistoryBuf ) );
+}
+
+void CG_DemoHistory_Init( void ) {
+	CG_DemoHistory_Clear();
+	cg_demoHistoryPrevPlayback = qfalse;
+}
+
+void CG_DemoHistory_Frame( void ) {
+	if ( cg_demoHistoryPrevPlayback && !cg.demoPlayback ) {
+		CG_DemoHistory_Clear();
+	}
+	cg_demoHistoryPrevPlayback = cg.demoPlayback;
+}
+
+void CG_DemoHistory_OnSnapshot( const snapshot_t *snap ) {
+	int slot;
+
+	if ( !cg.demoPlayback || !snap ) {
+		return;
+	}
+
+	if ( cg_demoHistoryCount > 0 && snap->serverTime < cg_demoHistoryLastServerTime ) {
+		CG_DemoHistory_Clear();
+	}
+
+	if ( snap->serverTime == cg_demoHistoryLastServerTime ) {
+		return;
+	}
+
+	if ( cg_demoHistoryCount < CG_DEMO_HISTORY_CAPACITY ) {
+		slot = ( cg_demoHistoryHead + cg_demoHistoryCount ) % CG_DEMO_HISTORY_CAPACITY;
+		cg_demoHistoryCount++;
+	} else {
+		slot = cg_demoHistoryHead;
+		cg_demoHistoryHead = ( cg_demoHistoryHead + 1 ) % CG_DEMO_HISTORY_CAPACITY;
+	}
+
+	Com_Memcpy( &cg_demoHistoryBuf[slot], snap, sizeof( snapshot_t ) );
+	cg_demoHistoryLastServerTime = snap->serverTime;
+}
+
+int CG_DemoHistory_GetCount( void ) {
+	return cg_demoHistoryCount;
+}
+
+const snapshot_t *CG_DemoHistory_GetNewest( void ) {
+	int idx;
+
+	if ( cg_demoHistoryCount <= 0 ) {
+		return NULL;
+	}
+	idx = ( cg_demoHistoryHead + cg_demoHistoryCount - 1 ) % CG_DEMO_HISTORY_CAPACITY;
+	return &cg_demoHistoryBuf[idx];
+}
+
+const snapshot_t *CG_DemoHistory_GetByFramesAgo( int framesAgo ) {
+	int idx;
+
+	if ( framesAgo < 0 || framesAgo >= cg_demoHistoryCount ) {
+		return NULL;
+	}
+	idx = ( cg_demoHistoryHead + cg_demoHistoryCount - 1 - framesAgo ) % CG_DEMO_HISTORY_CAPACITY;
+	return &cg_demoHistoryBuf[idx];
+}

--- a/ratoa_gamecode/code/cgame/cg_demo_history.c
+++ b/ratoa_gamecode/code/cgame/cg_demo_history.c
@@ -19,6 +19,15 @@ static int cg_demoHistoryLastServerTime;
 static qboolean cg_demoHistoryPrevPlayback;
 static int cg_demoDelagPingSmoothed = -1;
 
+typedef struct {
+	centity_t *cent;
+	vec3_t savedLerp;
+	int savedSolid;
+} demoRewindSave_t;
+
+static demoRewindSave_t cg_demoRewindSaves[MAX_CLIENTS];
+static int cg_demoRewindSaveCount;
+
 static int demoDelagPingRawAlongInterpolation( void );
 static qboolean demoDelagResolvePingMs( int *outPing );
 
@@ -28,6 +37,7 @@ void CG_DemoHistory_Clear( void ) {
 	cg_demoHistoryHead = 0;
 	cg_demoHistoryCount = 0;
 	cg_demoHistoryLastServerTime = -1;
+	cg_demoRewindSaveCount = 0;
 	cg_demoDelagPingSmoothed = -1;
 	for ( i = 0; i < MAX_GENTITIES; i++ ) {
 		cg_entities[i].demoDelagVisualCached = qfalse;
@@ -266,8 +276,46 @@ static qboolean demoDelagResolvePingMs( int *outPing ) {
 	return qtrue;
 }
 
-static void playerPoseFromBracket( int entityNum, int evalTime, const snapshot_t *sOld, const snapshot_t *sNew, float frac,
-		vec3_t outOrigin, vec3_t outAngles, qboolean *outOk ) {
+static int demoDelagAttackerSampleTime( int attackServerTime ) {
+	int ping;
+
+	if ( !demoDelagResolvePingMs( &ping ) ) {
+		return clampServerTimeToHistory( attackServerTime );
+	}
+	return clampServerTimeToHistory( attackServerTime - ping );
+}
+
+int CG_DemoHistory_LocalFireDelay( void ) {
+	int ping;
+	int frameMsec;
+
+	if ( !CG_DemoHistory_DemoDelagActive() ) {
+		return 0;
+	}
+	if ( !demoDelagResolvePingMs( &ping ) ) {
+		return 0;
+	}
+	if ( sv_fps.integer > 0 ) {
+		frameMsec = 1000 / sv_fps.integer;
+		if ( ping > frameMsec ) {
+			ping = frameMsec;
+		}
+	}
+	return ping;
+}
+
+static int demoDelagDisplayServerTime( void ) {
+	if ( cg.nextSnap ) {
+		int delta = cg.nextSnap->serverTime - cg.snap->serverTime;
+		if ( delta > 0 ) {
+			return cg.snap->serverTime + (int)( cg.frameInterpolation * (float)delta + 0.5f );
+		}
+	}
+	return cg.snap->serverTime;
+}
+
+static void entityPoseFromBracket( int entityNum, int evalTime, const snapshot_t *sOld, const snapshot_t *sNew, float frac,
+		vec3_t outOrigin, vec_t *outAnglesOpt, int *outSolidOpt, qboolean *outOk ) {
 	entityState_t esLo, esHi;
 	qboolean hasLo, hasHi;
 	vec3_t oLo, oHi;
@@ -283,10 +331,20 @@ static void playerPoseFromBracket( int entityNum, int evalTime, const snapshot_t
 	if ( hasLo && hasHi && sOld != sNew && sOld->serverTime < sNew->serverTime ) {
 		if ( frac <= 0.0f ) {
 			BG_EvaluateTrajectory( &esLo.pos, evalTime, outOrigin );
-			BG_EvaluateTrajectory( &esLo.apos, evalTime, outAngles );
+			if ( outAnglesOpt ) {
+				BG_EvaluateTrajectory( &esLo.apos, evalTime, outAnglesOpt );
+			}
+			if ( outSolidOpt ) {
+				*outSolidOpt = esLo.solid;
+			}
 		} else if ( frac >= 1.0f ) {
 			BG_EvaluateTrajectory( &esHi.pos, evalTime, outOrigin );
-			BG_EvaluateTrajectory( &esHi.apos, evalTime, outAngles );
+			if ( outAnglesOpt ) {
+				BG_EvaluateTrajectory( &esHi.apos, evalTime, outAnglesOpt );
+			}
+			if ( outSolidOpt ) {
+				*outSolidOpt = esHi.solid;
+			}
 		} else {
 			BG_EvaluateTrajectory( &esLo.pos, sOld->serverTime, oLo );
 			BG_EvaluateTrajectory( &esHi.pos, sNew->serverTime, oHi );
@@ -294,35 +352,54 @@ static void playerPoseFromBracket( int entityNum, int evalTime, const snapshot_t
 			outOrigin[1] = oLo[1] + frac * ( oHi[1] - oLo[1] );
 			outOrigin[2] = oLo[2] + frac * ( oHi[2] - oLo[2] );
 
-			BG_EvaluateTrajectory( &esLo.apos, sOld->serverTime, aLo );
-			BG_EvaluateTrajectory( &esHi.apos, sNew->serverTime, aHi );
-			outAngles[0] = LerpAngle( aLo[0], aHi[0], frac );
-			outAngles[1] = LerpAngle( aLo[1], aHi[1], frac );
-			outAngles[2] = LerpAngle( aLo[2], aHi[2], frac );
+			if ( outAnglesOpt ) {
+				BG_EvaluateTrajectory( &esLo.apos, sOld->serverTime, aLo );
+				BG_EvaluateTrajectory( &esHi.apos, sNew->serverTime, aHi );
+				outAnglesOpt[0] = LerpAngle( aLo[0], aHi[0], frac );
+				outAnglesOpt[1] = LerpAngle( aLo[1], aHi[1], frac );
+				outAnglesOpt[2] = LerpAngle( aLo[2], aHi[2], frac );
+			}
+			if ( outSolidOpt ) {
+				*outSolidOpt = esHi.solid;
+			}
 		}
 		*outOk = qtrue;
 		return;
 	}
-
 	if ( hasLo ) {
 		BG_EvaluateTrajectory( &esLo.pos, evalTime, outOrigin );
-		BG_EvaluateTrajectory( &esLo.apos, evalTime, outAngles );
+		if ( outAnglesOpt ) {
+			BG_EvaluateTrajectory( &esLo.apos, evalTime, outAnglesOpt );
+		}
+		if ( outSolidOpt ) {
+			*outSolidOpt = esLo.solid;
+		}
 		*outOk = qtrue;
 	} else if ( hasHi ) {
 		BG_EvaluateTrajectory( &esHi.pos, evalTime, outOrigin );
-		BG_EvaluateTrajectory( &esHi.apos, evalTime, outAngles );
+		if ( outAnglesOpt ) {
+			BG_EvaluateTrajectory( &esHi.apos, evalTime, outAnglesOpt );
+		}
+		if ( outSolidOpt ) {
+			*outSolidOpt = esHi.solid;
+		}
 		*outOk = qtrue;
 	}
 }
 
-static qboolean getPlayerPoseAtHistoryTime( int entityNum, int serverTime, vec3_t outOrigin, vec3_t outAngles ) {
+static qboolean getEntityPoseAtHistoryTime( int entityNum, int serverTime, vec3_t outOrigin, vec3_t outAngles ) {
 	const snapshot_t *sOld, *sNew;
 	float frac;
 	qboolean ok;
 
 	bracketServerTime( serverTime, &sOld, &sNew, &frac );
-	playerPoseFromBracket( entityNum, serverTime, sOld, sNew, frac, outOrigin, outAngles, &ok );
+	entityPoseFromBracket( entityNum, serverTime, sOld, sNew, frac, outOrigin, outAngles, NULL, &ok );
 	return ok;
+}
+
+static void computeRewoundPlayerState( int entityNum, int evalTime, const snapshot_t *sOld, const snapshot_t *sNew, float frac,
+		vec3_t outOrigin, int *outSolid, qboolean *outOk ) {
+	entityPoseFromBracket( entityNum, evalTime, sOld, sNew, frac, outOrigin, NULL, outSolid, outOk );
 }
 
 static qboolean demoDelagPoseFromActiveSnapWindow( const centity_t *cent, int tHist, vec3_t outOrigin, vec3_t outAngles ) {
@@ -441,6 +518,63 @@ static void demoDelagApplyPoseAndCache( centity_t *cent, const vec3_t origin, co
 	cent->demoDelagVisualCached = qtrue;
 }
 
+void CG_DemoHistory_BeginHitscanRewind( int rewindToServerTime, int skipEntityNum ) {
+	const snapshot_t *sOld, *sNew;
+	float frac;
+	int i;
+	int solid;
+	int tSample;
+	vec3_t origin;
+	qboolean ok;
+	centity_t *cent;
+
+	cg_demoRewindSaveCount = 0;
+	if ( !CG_DemoHistory_DemoDelagActive() ) {
+		return;
+	}
+
+	tSample = demoDelagAttackerSampleTime( rewindToServerTime );
+	bracketServerTime( tSample, &sOld, &sNew, &frac );
+	if ( !sOld || !sNew ) {
+		return;
+	}
+
+	for ( i = 0; i < MAX_CLIENTS; i++ ) {
+		if ( i == skipEntityNum ) {
+			continue;
+		}
+		cent = &cg_entities[i];
+		if ( !cent->currentValid || cent->currentState.eType != ET_PLAYER ) {
+			continue;
+		}
+		computeRewoundPlayerState( i, tSample, sOld, sNew, frac, origin, &solid, &ok );
+		if ( !ok ) {
+			continue;
+		}
+		if ( cg_demoRewindSaveCount >= MAX_CLIENTS ) {
+			break;
+		}
+		cg_demoRewindSaves[cg_demoRewindSaveCount].cent = cent;
+		VectorCopy( cent->lerpOrigin, cg_demoRewindSaves[cg_demoRewindSaveCount].savedLerp );
+		cg_demoRewindSaves[cg_demoRewindSaveCount].savedSolid = cent->currentState.solid;
+		cg_demoRewindSaveCount++;
+		VectorCopy( origin, cent->lerpOrigin );
+		cent->currentState.solid = solid;
+	}
+}
+
+void CG_DemoHistory_EndHitscanRewind( void ) {
+	int i;
+
+	for ( i = cg_demoRewindSaveCount - 1; i >= 0; i-- ) {
+		centity_t *cent = cg_demoRewindSaves[i].cent;
+
+		VectorCopy( cg_demoRewindSaves[i].savedLerp, cent->lerpOrigin );
+		cent->currentState.solid = cg_demoRewindSaves[i].savedSolid;
+	}
+	cg_demoRewindSaveCount = 0;
+}
+
 void CG_DemoHistory_AdjustPlayerLerpForDemoDelag( centity_t *cent ) {
 	int ping;
 	int tDisp;
@@ -464,19 +598,10 @@ void CG_DemoHistory_AdjustPlayerLerpForDemoDelag( centity_t *cent ) {
 		return;
 	}
 
-	if ( cg.nextSnap ) {
-		int delta = cg.nextSnap->serverTime - cg.snap->serverTime;
-		if ( delta > 0 ) {
-			tDisp = cg.snap->serverTime + (int)( cg.frameInterpolation * (float)delta + 0.5f );
-		} else {
-			tDisp = cg.snap->serverTime;
-		}
-	} else {
-		tDisp = cg.snap->serverTime;
-	}
+	tDisp = demoDelagDisplayServerTime();
 
 	tHist = clampServerTimeToHistory( tDisp - ping );
-	if ( getPlayerPoseAtHistoryTime( cent->currentState.number, tHist, origin, angles ) ) {
+	if ( getEntityPoseAtHistoryTime( cent->currentState.number, tHist, origin, angles ) ) {
 		demoDelagApplyPoseAndCache( cent, origin, angles );
 		return;
 	}
@@ -492,4 +617,36 @@ void CG_DemoHistory_AdjustPlayerLerpForDemoDelag( centity_t *cent ) {
 		VectorCopy( cent->demoDelagVisualOrigin, cent->lerpOrigin );
 		VectorCopy( cent->demoDelagVisualAngles, cent->lerpAngles );
 	}
+}
+
+qboolean CG_DemoHistory_AdjustMissileLerpForDemoDelag( centity_t *cent ) {
+	int ping;
+	int tDisp;
+	int tHist;
+	vec3_t origin;
+	vec3_t angles;
+
+	if ( !CG_DemoHistory_DemoDelagActive() || !cg.snap ) {
+		return qfalse;
+	}
+	if ( cent->currentState.eType != ET_MISSILE ) {
+		return qfalse;
+	}
+	if ( CG_IsOwnMissile( cent ) && cg_altPredictMissiles.integer > 0 && ( cgs.ratFlags & RAT_PREDICTMISSILES ) ) {
+		return qfalse;
+	}
+	if ( !demoDelagResolvePingMs( &ping ) ) {
+		return qfalse;
+	}
+
+	tDisp = demoDelagDisplayServerTime();
+
+	tHist = clampServerTimeToHistory( tDisp - ping );
+	if ( !getEntityPoseAtHistoryTime( cent->currentState.number, tHist, origin, angles ) ) {
+		return qfalse;
+	}
+
+	VectorCopy( origin, cent->lerpOrigin );
+	VectorCopy( angles, cent->lerpAngles );
+	return qtrue;
 }

--- a/ratoa_gamecode/code/cgame/cg_demo_history.c
+++ b/ratoa_gamecode/code/cgame/cg_demo_history.c
@@ -1,16 +1,15 @@
 /*
 ===========================================================================
-Demo playback snapshot history (ring buffer).
+Demo playback snapshot history.
 
-Deep-copies each authoritative snapshot_t when it becomes current during
-demo playback (initial snapshot and each transition). Inactive during
-live play; buffer is cleared when demo playback ends.
+Stores authoritative snapshots seen during demo playback and uses them to
+render remote players at the recording client's delayed view of the world.
 ===========================================================================
 */
 
 #include "cg_local.h"
 
-/* Match server unlagged window scale (~17 samples @ 20Hz); allow slack */
+/* Match server unlagged window scale (~17 samples @ 20Hz); allow slack. */
 #define CG_DEMO_HISTORY_CAPACITY 40
 
 static snapshot_t cg_demoHistoryBuf[CG_DEMO_HISTORY_CAPACITY];
@@ -18,11 +17,21 @@ static int cg_demoHistoryHead;
 static int cg_demoHistoryCount;
 static int cg_demoHistoryLastServerTime;
 static qboolean cg_demoHistoryPrevPlayback;
+static int cg_demoDelagPingSmoothed = -1;
+
+static int demoDelagPingRawAlongInterpolation( void );
+static qboolean demoDelagResolvePingMs( int *outPing );
 
 void CG_DemoHistory_Clear( void ) {
+	int i;
+
 	cg_demoHistoryHead = 0;
 	cg_demoHistoryCount = 0;
 	cg_demoHistoryLastServerTime = -1;
+	cg_demoDelagPingSmoothed = -1;
+	for ( i = 0; i < MAX_GENTITIES; i++ ) {
+		cg_entities[i].demoDelagVisualCached = qfalse;
+	}
 	Com_Memset( cg_demoHistoryBuf, 0, sizeof( cg_demoHistoryBuf ) );
 }
 
@@ -32,8 +41,25 @@ void CG_DemoHistory_Init( void ) {
 }
 
 void CG_DemoHistory_Frame( void ) {
+	int p;
+
 	if ( cg_demoHistoryPrevPlayback && !cg.demoPlayback ) {
 		CG_DemoHistory_Clear();
+	}
+	if ( cg.demoPlayback && cg_demoDelag.integer && cgs.delagHitscan && cg.snap ) {
+		p = demoDelagPingRawAlongInterpolation();
+		if ( p >= 1 && p < 900 ) {
+			if ( p > 400 ) {
+				p = 400;
+			}
+			if ( cg_demoDelagPingSmoothed < 0 ) {
+				cg_demoDelagPingSmoothed = p;
+			} else {
+				cg_demoDelagPingSmoothed += ( p - cg_demoDelagPingSmoothed + 4 ) / 8;
+			}
+		}
+	} else {
+		cg_demoDelagPingSmoothed = -1;
 	}
 	cg_demoHistoryPrevPlayback = cg.demoPlayback;
 }
@@ -87,4 +113,383 @@ const snapshot_t *CG_DemoHistory_GetByFramesAgo( int framesAgo ) {
 	}
 	idx = ( cg_demoHistoryHead + cg_demoHistoryCount - 1 - framesAgo ) % CG_DEMO_HISTORY_CAPACITY;
 	return &cg_demoHistoryBuf[idx];
+}
+
+qboolean CG_DemoHistory_DemoDelagActive( void ) {
+	return cg.demoPlayback && cg_demoDelag.integer && cgs.delagHitscan && CG_DemoHistory_GetCount() > 0;
+}
+
+static qboolean findEntityInSnapshot( const snapshot_t *snap, int entityNum, entityState_t *out ) {
+	int i;
+
+	if ( !snap ) {
+		return qfalse;
+	}
+	for ( i = 0; i < snap->numEntities; i++ ) {
+		if ( snap->entities[i].number == entityNum ) {
+			*out = snap->entities[i];
+			return qtrue;
+		}
+	}
+	return qfalse;
+}
+
+static void bracketServerTime( int serverTime, const snapshot_t **sOld, const snapshot_t **sNew, float *frac ) {
+	int c;
+	int i;
+	const snapshot_t *newest;
+	const snapshot_t *oldest;
+
+	*sOld = *sNew = NULL;
+	*frac = 0.0f;
+
+	c = CG_DemoHistory_GetCount();
+	if ( c <= 0 ) {
+		return;
+	}
+	if ( c == 1 ) {
+		*sOld = *sNew = CG_DemoHistory_GetByFramesAgo( 0 );
+		return;
+	}
+
+	newest = CG_DemoHistory_GetByFramesAgo( 0 );
+	oldest = CG_DemoHistory_GetByFramesAgo( c - 1 );
+	if ( serverTime >= newest->serverTime ) {
+		*sOld = *sNew = newest;
+		return;
+	}
+	if ( serverTime <= oldest->serverTime ) {
+		*sOld = *sNew = oldest;
+		return;
+	}
+
+	for ( i = 0; i < c - 1; i++ ) {
+		const snapshot_t *hi = CG_DemoHistory_GetByFramesAgo( i );
+		const snapshot_t *lo = CG_DemoHistory_GetByFramesAgo( i + 1 );
+
+		if ( lo->serverTime <= serverTime && serverTime <= hi->serverTime ) {
+			*sOld = lo;
+			*sNew = hi;
+			if ( hi->serverTime > lo->serverTime ) {
+				*frac = (float)( serverTime - lo->serverTime ) / (float)( hi->serverTime - lo->serverTime );
+			}
+			return;
+		}
+	}
+	*sOld = *sNew = newest;
+}
+
+static int clampServerTimeToHistory( int serverTime ) {
+	int c;
+	const snapshot_t *oldest;
+	const snapshot_t *newest;
+
+	c = CG_DemoHistory_GetCount();
+	if ( c < 1 ) {
+		return serverTime;
+	}
+	oldest = CG_DemoHistory_GetByFramesAgo( c - 1 );
+	newest = CG_DemoHistory_GetByFramesAgo( 0 );
+	if ( serverTime < oldest->serverTime ) {
+		return oldest->serverTime;
+	}
+	if ( serverTime > newest->serverTime ) {
+		return newest->serverTime;
+	}
+	return serverTime;
+}
+
+static int demoDelagPingRawAlongInterpolation( void ) {
+	snapshot_t *s;
+	snapshot_t *n;
+	int p0, p1, d, t;
+	float f;
+
+	s = cg.snap;
+	if ( !s ) {
+		return 999;
+	}
+	n = cg.nextSnap;
+	if ( !n || n->serverTime <= s->serverTime ) {
+		return CG_ReliablePingFromSnaps( s, n );
+	}
+	p0 = s->ping;
+	p1 = n->ping;
+	if ( p0 >= 999 || p1 >= 999 ) {
+		return CG_ReliablePingFromSnaps( s, n );
+	}
+	if ( p0 < 0 ) {
+		p0 = 0;
+	}
+	if ( p1 < 0 ) {
+		p1 = 0;
+	}
+	d = n->serverTime - s->serverTime;
+	f = (float)( cg.time - s->serverTime ) / (float)d;
+	if ( f < 0.0f ) {
+		f = 0.0f;
+	}
+	if ( f > 1.0f ) {
+		f = 1.0f;
+	}
+	t = (int)( (float)p0 + f * (float)( p1 - p0 ) + 0.5f );
+	if ( t < 0 ) {
+		t = 0;
+	}
+	if ( t > 999 ) {
+		t = 999;
+	}
+	return t;
+}
+
+static qboolean demoDelagResolvePingMs( int *outPing ) {
+	int raw;
+	int p;
+
+	if ( cg_demoDelagPingSmoothed >= 1 && cg_demoDelagPingSmoothed < 900 ) {
+		p = cg_demoDelagPingSmoothed;
+		if ( p > 400 ) {
+			p = 400;
+		}
+		*outPing = p;
+		return qtrue;
+	}
+
+	raw = demoDelagPingRawAlongInterpolation();
+	if ( raw < 1 || raw >= 900 ) {
+		return qfalse;
+	}
+	if ( raw > 400 ) {
+		raw = 400;
+	}
+	*outPing = raw;
+	return qtrue;
+}
+
+static void playerPoseFromBracket( int entityNum, int evalTime, const snapshot_t *sOld, const snapshot_t *sNew, float frac,
+		vec3_t outOrigin, vec3_t outAngles, qboolean *outOk ) {
+	entityState_t esLo, esHi;
+	qboolean hasLo, hasHi;
+	vec3_t oLo, oHi;
+	vec3_t aLo, aHi;
+
+	*outOk = qfalse;
+	if ( !sOld || !sNew ) {
+		return;
+	}
+	hasLo = findEntityInSnapshot( sOld, entityNum, &esLo );
+	hasHi = findEntityInSnapshot( sNew, entityNum, &esHi );
+
+	if ( hasLo && hasHi && sOld != sNew && sOld->serverTime < sNew->serverTime ) {
+		if ( frac <= 0.0f ) {
+			BG_EvaluateTrajectory( &esLo.pos, evalTime, outOrigin );
+			BG_EvaluateTrajectory( &esLo.apos, evalTime, outAngles );
+		} else if ( frac >= 1.0f ) {
+			BG_EvaluateTrajectory( &esHi.pos, evalTime, outOrigin );
+			BG_EvaluateTrajectory( &esHi.apos, evalTime, outAngles );
+		} else {
+			BG_EvaluateTrajectory( &esLo.pos, sOld->serverTime, oLo );
+			BG_EvaluateTrajectory( &esHi.pos, sNew->serverTime, oHi );
+			outOrigin[0] = oLo[0] + frac * ( oHi[0] - oLo[0] );
+			outOrigin[1] = oLo[1] + frac * ( oHi[1] - oLo[1] );
+			outOrigin[2] = oLo[2] + frac * ( oHi[2] - oLo[2] );
+
+			BG_EvaluateTrajectory( &esLo.apos, sOld->serverTime, aLo );
+			BG_EvaluateTrajectory( &esHi.apos, sNew->serverTime, aHi );
+			outAngles[0] = LerpAngle( aLo[0], aHi[0], frac );
+			outAngles[1] = LerpAngle( aLo[1], aHi[1], frac );
+			outAngles[2] = LerpAngle( aLo[2], aHi[2], frac );
+		}
+		*outOk = qtrue;
+		return;
+	}
+
+	if ( hasLo ) {
+		BG_EvaluateTrajectory( &esLo.pos, evalTime, outOrigin );
+		BG_EvaluateTrajectory( &esLo.apos, evalTime, outAngles );
+		*outOk = qtrue;
+	} else if ( hasHi ) {
+		BG_EvaluateTrajectory( &esHi.pos, evalTime, outOrigin );
+		BG_EvaluateTrajectory( &esHi.apos, evalTime, outAngles );
+		*outOk = qtrue;
+	}
+}
+
+static qboolean getPlayerPoseAtHistoryTime( int entityNum, int serverTime, vec3_t outOrigin, vec3_t outAngles ) {
+	const snapshot_t *sOld, *sNew;
+	float frac;
+	qboolean ok;
+
+	bracketServerTime( serverTime, &sOld, &sNew, &frac );
+	playerPoseFromBracket( entityNum, serverTime, sOld, sNew, frac, outOrigin, outAngles, &ok );
+	return ok;
+}
+
+static qboolean demoDelagPoseFromActiveSnapWindow( const centity_t *cent, int tHist, vec3_t outOrigin, vec3_t outAngles ) {
+	vec3_t curp, nxtp, cura, nxta;
+	float f;
+	int delta;
+
+	if ( !cg.snap || !cg.nextSnap ) {
+		return qfalse;
+	}
+	if ( tHist < cg.snap->serverTime || tHist > cg.nextSnap->serverTime ) {
+		return qfalse;
+	}
+	delta = cg.nextSnap->serverTime - cg.snap->serverTime;
+	if ( delta <= 0 ) {
+		return qfalse;
+	}
+	f = (float)( tHist - cg.snap->serverTime ) / (float)delta;
+	BG_EvaluateTrajectory( &cent->currentState.pos, cg.snap->serverTime, curp );
+	BG_EvaluateTrajectory( &cent->nextState.pos, cg.nextSnap->serverTime, nxtp );
+	outOrigin[0] = curp[0] + f * ( nxtp[0] - curp[0] );
+	outOrigin[1] = curp[1] + f * ( nxtp[1] - curp[1] );
+	outOrigin[2] = curp[2] + f * ( nxtp[2] - curp[2] );
+	BG_EvaluateTrajectory( &cent->currentState.apos, cg.snap->serverTime, cura );
+	BG_EvaluateTrajectory( &cent->nextState.apos, cg.nextSnap->serverTime, nxta );
+	outAngles[0] = LerpAngle( cura[0], nxta[0], f );
+	outAngles[1] = LerpAngle( cura[1], nxta[1], f );
+	outAngles[2] = LerpAngle( cura[2], nxta[2], f );
+	return qtrue;
+}
+
+static qboolean demoDelagPoseFromHistoryEnvelope( int entityNum, int tHist, vec3_t outOrigin, vec3_t outAngles ) {
+	int c;
+	int i;
+	const snapshot_t *snLo, *snHi;
+	entityState_t esLo, esHi;
+	qboolean hasLo, hasHi;
+	int tlo, thi;
+	float frac;
+	vec3_t oLo, oHi, aLo, aHi;
+
+	c = CG_DemoHistory_GetCount();
+	if ( c < 1 ) {
+		return qfalse;
+	}
+	snLo = snHi = NULL;
+	hasLo = hasHi = qfalse;
+
+	for ( i = 0; i < c; i++ ) {
+		const snapshot_t *sn = CG_DemoHistory_GetByFramesAgo( i );
+		if ( sn->serverTime > tHist ) {
+			continue;
+		}
+		if ( findEntityInSnapshot( sn, entityNum, &esLo ) ) {
+			snLo = sn;
+			hasLo = qtrue;
+			break;
+		}
+	}
+	for ( i = c - 1; i >= 0; i-- ) {
+		const snapshot_t *sn = CG_DemoHistory_GetByFramesAgo( i );
+		if ( sn->serverTime < tHist ) {
+			continue;
+		}
+		if ( findEntityInSnapshot( sn, entityNum, &esHi ) ) {
+			snHi = sn;
+			hasHi = qtrue;
+			break;
+		}
+	}
+
+	if ( hasLo && hasHi && snLo && snHi && snLo->serverTime < snHi->serverTime ) {
+		tlo = snLo->serverTime;
+		thi = snHi->serverTime;
+		if ( tHist <= tlo ) {
+			BG_EvaluateTrajectory( &esLo.pos, tHist, outOrigin );
+			BG_EvaluateTrajectory( &esLo.apos, tHist, outAngles );
+			return qtrue;
+		}
+		if ( tHist >= thi ) {
+			BG_EvaluateTrajectory( &esHi.pos, tHist, outOrigin );
+			BG_EvaluateTrajectory( &esHi.apos, tHist, outAngles );
+			return qtrue;
+		}
+		frac = (float)( tHist - tlo ) / (float)( thi - tlo );
+		BG_EvaluateTrajectory( &esLo.pos, tlo, oLo );
+		BG_EvaluateTrajectory( &esHi.pos, thi, oHi );
+		outOrigin[0] = oLo[0] + frac * ( oHi[0] - oLo[0] );
+		outOrigin[1] = oLo[1] + frac * ( oHi[1] - oLo[1] );
+		outOrigin[2] = oLo[2] + frac * ( oHi[2] - oLo[2] );
+		BG_EvaluateTrajectory( &esLo.apos, tlo, aLo );
+		BG_EvaluateTrajectory( &esHi.apos, thi, aHi );
+		outAngles[0] = LerpAngle( aLo[0], aHi[0], frac );
+		outAngles[1] = LerpAngle( aLo[1], aHi[1], frac );
+		outAngles[2] = LerpAngle( aLo[2], aHi[2], frac );
+		return qtrue;
+	}
+	if ( hasLo ) {
+		BG_EvaluateTrajectory( &esLo.pos, tHist, outOrigin );
+		BG_EvaluateTrajectory( &esLo.apos, tHist, outAngles );
+		return qtrue;
+	}
+	if ( hasHi ) {
+		BG_EvaluateTrajectory( &esHi.pos, tHist, outOrigin );
+		BG_EvaluateTrajectory( &esHi.apos, tHist, outAngles );
+		return qtrue;
+	}
+	return qfalse;
+}
+
+static void demoDelagApplyPoseAndCache( centity_t *cent, const vec3_t origin, const vec3_t angles ) {
+	VectorCopy( origin, cent->lerpOrigin );
+	VectorCopy( angles, cent->lerpAngles );
+	VectorCopy( origin, cent->demoDelagVisualOrigin );
+	VectorCopy( angles, cent->demoDelagVisualAngles );
+	cent->demoDelagVisualCached = qtrue;
+}
+
+void CG_DemoHistory_AdjustPlayerLerpForDemoDelag( centity_t *cent ) {
+	int ping;
+	int tDisp;
+	int tHist;
+	vec3_t origin;
+	vec3_t angles;
+
+	if ( !CG_DemoHistory_DemoDelagActive() || !cg.snap ) {
+		return;
+	}
+	if ( cent->currentState.eType != ET_PLAYER ) {
+		return;
+	}
+	if ( cent->currentState.number >= MAX_CLIENTS ) {
+		return;
+	}
+	if ( cent->currentState.number == cg.predictedPlayerState.clientNum ) {
+		return;
+	}
+	if ( !demoDelagResolvePingMs( &ping ) ) {
+		return;
+	}
+
+	if ( cg.nextSnap ) {
+		int delta = cg.nextSnap->serverTime - cg.snap->serverTime;
+		if ( delta > 0 ) {
+			tDisp = cg.snap->serverTime + (int)( cg.frameInterpolation * (float)delta + 0.5f );
+		} else {
+			tDisp = cg.snap->serverTime;
+		}
+	} else {
+		tDisp = cg.snap->serverTime;
+	}
+
+	tHist = clampServerTimeToHistory( tDisp - ping );
+	if ( getPlayerPoseAtHistoryTime( cent->currentState.number, tHist, origin, angles ) ) {
+		demoDelagApplyPoseAndCache( cent, origin, angles );
+		return;
+	}
+	if ( demoDelagPoseFromActiveSnapWindow( cent, tHist, origin, angles ) ) {
+		demoDelagApplyPoseAndCache( cent, origin, angles );
+		return;
+	}
+	if ( demoDelagPoseFromHistoryEnvelope( cent->currentState.number, tHist, origin, angles ) ) {
+		demoDelagApplyPoseAndCache( cent, origin, angles );
+		return;
+	}
+	if ( cent->demoDelagVisualCached ) {
+		VectorCopy( cent->demoDelagVisualOrigin, cent->lerpOrigin );
+		VectorCopy( cent->demoDelagVisualAngles, cent->lerpAngles );
+	}
 }

--- a/ratoa_gamecode/code/cgame/cg_demo_history.h
+++ b/ratoa_gamecode/code/cgame/cg_demo_history.h
@@ -8,7 +8,7 @@ Only populated while cg.demoPlayback is true.
 #ifndef CG_DEMO_HISTORY_H
 #define CG_DEMO_HISTORY_H
 
-#include "cg_public.h"
+/* snapshot_t is defined in cg_public.h — include cg_local.h (or cg_public.h) before this header */
 
 void CG_DemoHistory_Init( void );
 void CG_DemoHistory_Clear( void );

--- a/ratoa_gamecode/code/cgame/cg_demo_history.h
+++ b/ratoa_gamecode/code/cgame/cg_demo_history.h
@@ -22,6 +22,10 @@ const snapshot_t *CG_DemoHistory_GetNewest( void );
 const snapshot_t *CG_DemoHistory_GetByFramesAgo( int framesAgo );
 
 qboolean CG_DemoHistory_DemoDelagActive( void );
+void CG_DemoHistory_BeginHitscanRewind( int rewindToServerTime, int skipEntityNum );
+void CG_DemoHistory_EndHitscanRewind( void );
 void CG_DemoHistory_AdjustPlayerLerpForDemoDelag( struct centity_s *cent );
+qboolean CG_DemoHistory_AdjustMissileLerpForDemoDelag( struct centity_s *cent );
+int CG_DemoHistory_LocalFireDelay( void );
 
 #endif

--- a/ratoa_gamecode/code/cgame/cg_demo_history.h
+++ b/ratoa_gamecode/code/cgame/cg_demo_history.h
@@ -1,0 +1,22 @@
+/*
+===========================================================================
+Demo playback: ring buffer of past snapshots for pseudo delag (step 1).
+Only populated while cg.demoPlayback is true.
+===========================================================================
+*/
+
+#ifndef CG_DEMO_HISTORY_H
+#define CG_DEMO_HISTORY_H
+
+#include "cg_public.h"
+
+void CG_DemoHistory_Init( void );
+void CG_DemoHistory_Clear( void );
+void CG_DemoHistory_OnSnapshot( const snapshot_t *snap );
+void CG_DemoHistory_Frame( void );
+
+int CG_DemoHistory_GetCount( void );
+const snapshot_t *CG_DemoHistory_GetNewest( void );
+const snapshot_t *CG_DemoHistory_GetByFramesAgo( int framesAgo );
+
+#endif

--- a/ratoa_gamecode/code/cgame/cg_demo_history.h
+++ b/ratoa_gamecode/code/cgame/cg_demo_history.h
@@ -8,6 +8,8 @@ Only populated while cg.demoPlayback is true.
 #ifndef CG_DEMO_HISTORY_H
 #define CG_DEMO_HISTORY_H
 
+struct centity_s;
+
 /* snapshot_t is defined in cg_public.h — include cg_local.h (or cg_public.h) before this header */
 
 void CG_DemoHistory_Init( void );
@@ -18,5 +20,8 @@ void CG_DemoHistory_Frame( void );
 int CG_DemoHistory_GetCount( void );
 const snapshot_t *CG_DemoHistory_GetNewest( void );
 const snapshot_t *CG_DemoHistory_GetByFramesAgo( int framesAgo );
+
+qboolean CG_DemoHistory_DemoDelagActive( void );
+void CG_DemoHistory_AdjustPlayerLerpForDemoDelag( struct centity_s *cent );
 
 #endif

--- a/ratoa_gamecode/code/cgame/cg_ents.c
+++ b/ratoa_gamecode/code/cgame/cg_ents.c
@@ -1001,6 +1001,9 @@ static void CG_CalcEntityLerpPositions( centity_t *cent ) {
 	// if it's a missile but not a grappling hook
 	// if ( cent->currentState.eType == ET_MISSILE && cent->currentState.weapon != WP_GRAPPLING_HOOK ) {
 	if ( cent->currentState.eType == ET_MISSILE ) {
+		if ( CG_DemoHistory_AdjustMissileLerpForDemoDelag( cent ) ) {
+			return;
+		}
 		timeshift = CG_ProjectileNudgeTimeshift(cent);
 	}
 

--- a/ratoa_gamecode/code/cgame/cg_ents.c
+++ b/ratoa_gamecode/code/cgame/cg_ents.c
@@ -972,6 +972,7 @@ static void CG_CalcEntityLerpPositions( centity_t *cent ) {
 
 	if ( cent->interpolate && cent->currentState.pos.trType == TR_INTERPOLATE ) {
 		CG_InterpolateEntityPosition( cent );
+		CG_DemoHistory_AdjustPlayerLerpForDemoDelag( cent );
 		return;
 	}
 
@@ -980,6 +981,7 @@ static void CG_CalcEntityLerpPositions( centity_t *cent ) {
 	if ( cent->interpolate && cent->currentState.pos.trType == TR_LINEAR_STOP &&
 											cent->currentState.number < MAX_CLIENTS) {
 		CG_InterpolateEntityPosition( cent );
+		CG_DemoHistory_AdjustPlayerLerpForDemoDelag( cent );
 		return;
 	}
 
@@ -1042,6 +1044,8 @@ static void CG_CalcEntityLerpPositions( centity_t *cent ) {
 		CG_AdjustPositionForMover( cent->lerpOrigin, cent->currentState.groundEntityNum, 
 		cg.snap->serverTime, cg.time, cent->lerpOrigin );
 	}
+
+	CG_DemoHistory_AdjustPlayerLerpForDemoDelag( cent );
 }
 
 /*

--- a/ratoa_gamecode/code/cgame/cg_event.c
+++ b/ratoa_gamecode/code/cgame/cg_event.c
@@ -1138,6 +1138,16 @@ void CG_EntityEvent( centity_t *cent, vec3_t position ) {
 		} else if (es->weapon == WP_LIGHTNING && es->clientNum == cg.predictedPlayerState.clientNum &&
 				cgs.delagHitscan && (cg_delag.integer & 1 || cg_delag.integer & 8)) {
 			break;
+		} else if (es->weapon == WP_GAUNTLET && CG_DemoHistory_DemoDelagActive() &&
+				cgs.delagHitscan && (cg_delag.integer & 1)) {
+			vec3_t localToImpact;
+
+			VectorSubtract( position, cg.predictedPlayerState.origin, localToImpact );
+			if ( cg.predictedPlayerState.weapon == WP_GAUNTLET &&
+					cg.predictedPlayerState.weaponstate == WEAPON_FIRING &&
+					DotProduct( localToImpact, localToImpact ) < 96.0f * 96.0f ) {
+				break;
+			}
 		}
 		ByteToDir( es->eventParm, dir );
 		CG_MissileHitPlayer( es->weapon, position, dir, es->otherEntityNum,

--- a/ratoa_gamecode/code/cgame/cg_local.h
+++ b/ratoa_gamecode/code/cgame/cg_local.h
@@ -24,6 +24,7 @@ Foundation, Inc., 51 Franklin St, Fifth Floor, Boston, MA  02110-1301  USA
 #include "../renderer/tr_types.h"
 #include "../game/bg_public.h"
 #include "cg_public.h"
+#include "cg_demo_history.h"
 
 #include "../game/challenges.h"
 
@@ -2033,6 +2034,10 @@ void CG_SpurtBlood( vec3_t origin, vec3_t velocity, int hard );
 void CG_PingLocation( centity_t *cent );
 void CG_PingHudMarker ( vec3_t pingOrigin, float alpha, qhandle_t shader );
 void CG_HudBorderMarker ( vec3_t origin, float alpha, float radius, qhandle_t shader, int baseAngle );
+
+//
+// cg_demo_history.c (declarations in cg_demo_history.h)
+//
 
 //
 // cg_snapshot.c

--- a/ratoa_gamecode/code/cgame/cg_local.h
+++ b/ratoa_gamecode/code/cgame/cg_local.h
@@ -277,6 +277,10 @@ typedef struct centity_s {
 	vec3_t			lerpOrigin;
 	vec3_t			lerpAngles;
 
+	qboolean		demoDelagVisualCached;
+	vec3_t			demoDelagVisualOrigin;
+	vec3_t			demoDelagVisualAngles;
+
 	// for cg_projectileNudgeAuto
 	int			projectileNudge;
 

--- a/ratoa_gamecode/code/cgame/cg_local.h
+++ b/ratoa_gamecode/code/cgame/cg_local.h
@@ -1943,6 +1943,7 @@ void CG_RegisterWeapon( int weaponNum );
 void CG_RegisterItemVisuals( int itemNum );
 
 void CG_FireWeapon( centity_t *cent );
+void CG_ProcessDelayedWeaponFires( void );
 void CG_MissileHitWall( int weapon, int clientNum, vec3_t origin, vec3_t dir, impactSound_t soundType, predictedMissileStatus_t *missileStatus );
 void CG_MissileHitPlayer( int weapon, vec3_t origin, vec3_t dir, int entityNum, predictedMissileStatus_t *missileStatus );
 void CG_ShotgunFire( entityState_t *es );

--- a/ratoa_gamecode/code/cgame/cg_main.c
+++ b/ratoa_gamecode/code/cgame/cg_main.c
@@ -2566,6 +2566,8 @@ void CG_Init( int serverMessageNum, int serverCommandSequence, int clientNum ) {
 	memset( cg_weapons, 0, sizeof(cg_weapons) );
 	memset( cg_items, 0, sizeof(cg_items) );
 
+	CG_DemoHistory_Init();
+
 	cg.clientNum = clientNum;
 
 	cgs.processedSnapshotNum = serverMessageNum;
@@ -2693,6 +2695,7 @@ Called before every level change or subsystem restart
 void CG_Shutdown( void ) {
 	// some mods may need to do cleanup work here,
 	// like closing files or archiving session data
+	CG_DemoHistory_Clear();
 	challenges_save();
 }
 

--- a/ratoa_gamecode/code/cgame/cg_players.c
+++ b/ratoa_gamecode/code/cgame/cg_players.c
@@ -4122,6 +4122,7 @@ A player just came into view or teleported, so reset all animation info
 ===============
 */
 void CG_ResetPlayerEntity( centity_t *cent ) {
+	cent->demoDelagVisualCached = qfalse;
 	cent->errorTime = -99999;		// guarantee no error decay added
 	cent->extrapolated = qfalse;	
 
@@ -4130,6 +4131,8 @@ void CG_ResetPlayerEntity( centity_t *cent ) {
 
 	BG_EvaluateTrajectory( &cent->currentState.pos, cg.time, cent->lerpOrigin );
 	BG_EvaluateTrajectory( &cent->currentState.apos, cg.time, cent->lerpAngles );
+
+	CG_DemoHistory_AdjustPlayerLerpForDemoDelag( cent );
 
 	VectorCopy( cent->lerpOrigin, cent->rawOrigin );
 	VectorCopy( cent->lerpAngles, cent->rawAngles );

--- a/ratoa_gamecode/code/cgame/cg_snapshot.c
+++ b/ratoa_gamecode/code/cgame/cg_snapshot.c
@@ -35,6 +35,7 @@ CG_ResetEntity
 static void CG_ResetEntity( centity_t *cent ) {
 	// if the previous snapshot this entity was updated in is at least
 	// an event window back in time then we can reset the previous event
+	cent->demoDelagVisualCached = qfalse;
 	if ( cent->snapShotTime < cg.time - EVENT_VALID_MSEC ) {
 		cent->previousEvent = 0;
 	}

--- a/ratoa_gamecode/code/cgame/cg_snapshot.c
+++ b/ratoa_gamecode/code/cgame/cg_snapshot.c
@@ -145,6 +145,8 @@ void CG_SetInitialSnapshot( snapshot_t *snap ) {
 		// check for events
 		CG_CheckEvents( cent );
 	}
+
+	CG_DemoHistory_OnSnapshot( cg.snap );
 }
 
 
@@ -216,6 +218,8 @@ static void CG_TransitionSnapshot( void ) {
 			CG_TransitionPlayerState( ps, ops );
 		}
 	}
+
+	CG_DemoHistory_OnSnapshot( cg.snap );
 
 }
 

--- a/ratoa_gamecode/code/cgame/cg_unlagged.c
+++ b/ratoa_gamecode/code/cgame/cg_unlagged.c
@@ -37,6 +37,15 @@ void CG_PredictNailgunMissile( entityState_t *ent, vec3_t muzzlePoint, vec3_t fo
 #define MACHINEGUN_SPREAD	200
 #define CHAINGUN_SPREAD		600
 
+static int CG_DemoAttackTime( void ) {
+	int attackTime;
+
+	attackTime = ( cg.snap ? cg.snap->ps.commandTime : cg.predictedPlayerState.commandTime );
+	if ( attackTime <= 0 && cg.snap ) {
+		attackTime = cg.snap->serverTime;
+	}
+	return attackTime;
+}
 
 // similar to localentites
 predictedMissile_t	cg_predictedMissiles[MAX_PREDICTED_MISSILES];
@@ -448,12 +457,37 @@ void CG_PredictWeaponEffects( centity_t *cent ) {
 	AngleVectors( cg.predictedPlayerState.viewangles, forward, right, up );
 	VectorMA( muzzlePoint, 14, forward, muzzlePoint );
 
+	// was it a gauntlet attack?
+	if ( ent->weapon == WP_GAUNTLET ) {
+		if ( cg_delag.integer & 1 ) {
+			trace_t trace;
+			vec3_t endPoint;
+			qboolean demoRewind;
+			int attackTime;
+
+			VectorMA( muzzlePoint, 32, forward, endPoint );
+			demoRewind = CG_DemoHistory_DemoDelagActive();
+			attackTime = CG_DemoAttackTime();
+			if ( demoRewind ) {
+				CG_DemoHistory_BeginHitscanRewind( attackTime, cg.predictedPlayerState.clientNum );
+			}
+			CG_Trace( &trace, muzzlePoint, NULL, NULL, endPoint, cg.predictedPlayerState.clientNum, MASK_SHOT );
+			if ( demoRewind ) {
+				CG_DemoHistory_EndHitscanRewind();
+			}
+			if ( trace.fraction < 1.0f && trace.entityNum < MAX_CLIENTS && !( trace.surfaceFlags & SURF_NOIMPACT ) ) {
+				CG_MissileHitPlayer( WP_GAUNTLET, trace.endpos, trace.plane.normal, trace.entityNum, NULL );
+			}
+		}
+	}
 	// was it a rail attack?
-	if ( ent->weapon == WP_RAILGUN ) {
+	else if ( ent->weapon == WP_RAILGUN ) {
 		// do we have it on for the rail gun?
 		if ( cg_delag.integer & 1 || cg_delag.integer & 16 ) {
 			trace_t trace;
 			vec3_t endPoint;
+			qboolean demoRewind;
+			int attackTime;
 
 			// trace forward
 			VectorMA( muzzlePoint, 8192, forward, endPoint );
@@ -514,7 +548,15 @@ void CG_PredictWeaponEffects( centity_t *cent ) {
 			}*/
 
 			// find the rail's end point
-			CG_Trace( &trace, muzzlePoint, vec3_origin, vec3_origin, endPoint, cg.predictedPlayerState.clientNum, CONTENTS_SOLID );
+			demoRewind = CG_DemoHistory_DemoDelagActive();
+			attackTime = CG_DemoAttackTime();
+			if ( demoRewind ) {
+				CG_DemoHistory_BeginHitscanRewind( attackTime, cg.predictedPlayerState.clientNum );
+			}
+			CG_Trace( &trace, muzzlePoint, vec3_origin, vec3_origin, endPoint, cg.predictedPlayerState.clientNum, demoRewind ? MASK_SHOT : CONTENTS_SOLID );
+			if ( demoRewind ) {
+				CG_DemoHistory_EndHitscanRewind();
+			}
 
 			// do the magic-number adjustment
 			VectorMA( muzzlePoint, 4, right, muzzlePoint );
@@ -543,9 +585,19 @@ void CG_PredictWeaponEffects( centity_t *cent ) {
 			// This only predicts the impact sounds. The actual beam is drawn by CG_LightningBolt()
 			trace_t trace;
 			vec3_t endPoint;
+			qboolean demoRewind;
+			int attackTime;
 
 			VectorMA( muzzlePoint, LIGHTNING_RANGE, forward, endPoint );
+			demoRewind = CG_DemoHistory_DemoDelagActive();
+			attackTime = CG_DemoAttackTime();
+			if ( demoRewind ) {
+				CG_DemoHistory_BeginHitscanRewind( attackTime, cg.predictedPlayerState.clientNum );
+			}
 			CG_Trace( &trace, muzzlePoint, vec3_origin, vec3_origin, endPoint, cg.predictedPlayerState.clientNum, MASK_SHOT );
+			if ( demoRewind ) {
+				CG_DemoHistory_EndHitscanRewind();
+			}
 			if (trace.fraction < 1.0) {
 				if (trace.entityNum < MAX_CLIENTS) {
 					CG_MissileHitPlayer(WP_LIGHTNING, trace.endpos, trace.plane.normal, trace.entityNum, NULL);
@@ -560,7 +612,10 @@ void CG_PredictWeaponEffects( centity_t *cent ) {
 		// do we have it on for the shotgun?
 		if ( cg_delag.integer & 1 || cg_delag.integer & 4 ) {
 			int contents;
+			int seed;
+			int attackTime;
 			vec3_t endPoint, v;
+			qboolean demoRewind;
 
 			// do everything like the server does
 
@@ -586,7 +641,16 @@ void CG_PredictWeaponEffects( centity_t *cent ) {
 			}
 
 			// do the shotgun pellets
-			CG_ShotgunPattern( muzzlePoint, endPoint, cg.oldTime % 256, cg.predictedPlayerState.clientNum );
+			demoRewind = CG_DemoHistory_DemoDelagActive();
+			attackTime = CG_DemoAttackTime();
+			seed = demoRewind ? ( attackTime % 256 ) : ( cg.oldTime % 256 );
+			if ( demoRewind ) {
+				CG_DemoHistory_BeginHitscanRewind( attackTime, cg.predictedPlayerState.clientNum );
+			}
+			CG_ShotgunPattern( muzzlePoint, endPoint, seed, cg.predictedPlayerState.clientNum );
+			if ( demoRewind ) {
+				CG_DemoHistory_EndHitscanRewind();
+			}
 			//Com_Printf( "Predicted shotgun pattern\n" );
 		}
 	}
@@ -595,15 +659,20 @@ void CG_PredictWeaponEffects( centity_t *cent ) {
 		// do we have it on for the machinegun?
 		if ( cg_delag.integer & 1 || cg_delag.integer & 2 ) {
 			// the server will use this exact time (it'll be serverTime on that end)
-			int seed = cg.oldTime % 256;
+			int seed;
+			int attackTime;
 			float r, u;
 			trace_t tr;
 			qboolean flesh;
 			int fleshEntityNum = 0;
 			vec3_t endPoint;
+			qboolean demoRewind;
 
 			// do everything exactly like the server does
 
+			demoRewind = CG_DemoHistory_DemoDelagActive();
+			attackTime = CG_DemoAttackTime();
+			seed = demoRewind ? ( attackTime % 256 ) : ( cg.oldTime % 256 );
 			r = Q_random(&seed) * M_PI * 2.0f;
 			u = sin(r) * Q_crandom(&seed) * MACHINEGUN_SPREAD * 16;
 			r = cos(r) * Q_crandom(&seed) * MACHINEGUN_SPREAD * 16;
@@ -612,7 +681,13 @@ void CG_PredictWeaponEffects( centity_t *cent ) {
 			VectorMA( endPoint, r, right, endPoint );
 			VectorMA( endPoint, u, up, endPoint );
 
+			if ( demoRewind ) {
+				CG_DemoHistory_BeginHitscanRewind( attackTime, cg.predictedPlayerState.clientNum );
+			}
 			CG_Trace(&tr, muzzlePoint, NULL, NULL, endPoint, cg.predictedPlayerState.clientNum, MASK_SHOT );
+			if ( demoRewind ) {
+				CG_DemoHistory_EndHitscanRewind();
+			}
 
 			if ( tr.surfaceFlags & SURF_NOIMPACT ) {
 				return;
@@ -640,15 +715,20 @@ void CG_PredictWeaponEffects( centity_t *cent ) {
 		// do we have it on for the machinegun?
 		if ( cg_delag.integer & 1 || cg_delag.integer & 2 ) {
 			// the server will use this exact time (it'll be serverTime on that end)
-			int seed = cg.oldTime % 256;
+			int seed;
+			int attackTime;
 			float r, u;
 			trace_t tr;
 			qboolean flesh;
 			int fleshEntityNum = 0;
 			vec3_t endPoint;
+			qboolean demoRewind;
 
 			// do everything exactly like the server does
 
+			demoRewind = CG_DemoHistory_DemoDelagActive();
+			attackTime = CG_DemoAttackTime();
+			seed = demoRewind ? ( attackTime % 256 ) : ( cg.oldTime % 256 );
 			r = Q_random(&seed) * M_PI * 2.0f;
 			u = sin(r) * Q_crandom(&seed) * CHAINGUN_SPREAD * 16;
 			r = cos(r) * Q_crandom(&seed) * CHAINGUN_SPREAD * 16;
@@ -657,7 +737,13 @@ void CG_PredictWeaponEffects( centity_t *cent ) {
 			VectorMA( endPoint, r, right, endPoint );
 			VectorMA( endPoint, u, up, endPoint );
 
+			if ( demoRewind ) {
+				CG_DemoHistory_BeginHitscanRewind( attackTime, cg.predictedPlayerState.clientNum );
+			}
 			CG_Trace(&tr, muzzlePoint, NULL, NULL, endPoint, cg.predictedPlayerState.clientNum, MASK_SHOT );
+			if ( demoRewind ) {
+				CG_DemoHistory_EndHitscanRewind();
+			}
 
 			if ( tr.surfaceFlags & SURF_NOIMPACT ) {
 				return;

--- a/ratoa_gamecode/code/cgame/cg_view.c
+++ b/ratoa_gamecode/code/cgame/cg_view.c
@@ -1037,6 +1037,8 @@ void CG_DrawActiveFrame( int serverTime, stereoFrame_t stereoView, qboolean demo
 	// update cg.predictedPlayerState
 	CG_PredictPlayerState();
 
+	CG_ProcessDelayedWeaponFires();
+
 	// decide on third person view
 	cg.renderingThirdPerson = cg_thirdPerson.integer || (cg.snap->ps.stats[STAT_HEALTH] <= 0);
 

--- a/ratoa_gamecode/code/cgame/cg_view.c
+++ b/ratoa_gamecode/code/cgame/cg_view.c
@@ -999,6 +999,8 @@ void CG_DrawActiveFrame( int serverTime, stereoFrame_t stereoView, qboolean demo
 	cg.time = serverTime;
 	cg.demoPlayback = demoPlayback;
 
+	CG_DemoHistory_Frame();
+
 	// update cvars
 	CG_UpdateCvars();
 

--- a/ratoa_gamecode/code/cgame/cg_view.c
+++ b/ratoa_gamecode/code/cgame/cg_view.c
@@ -999,8 +999,6 @@ void CG_DrawActiveFrame( int serverTime, stereoFrame_t stereoView, qboolean demo
 	cg.time = serverTime;
 	cg.demoPlayback = demoPlayback;
 
-	CG_DemoHistory_Frame();
-
 	// update cvars
 	CG_UpdateCvars();
 
@@ -1027,6 +1025,8 @@ void CG_DrawActiveFrame( int serverTime, stereoFrame_t stereoView, qboolean demo
 		CG_DrawInformation();
 		return;
 	}
+
+	CG_DemoHistory_Frame();
 
 	// let the client system know what our weapon and zoom settings are
 	trap_SetUserCmdValue( cg.weaponSelect, cg.zoomSensitivity );

--- a/ratoa_gamecode/code/cgame/cg_weapons.c
+++ b/ratoa_gamecode/code/cgame/cg_weapons.c
@@ -1592,6 +1592,8 @@ static void CG_LightningBolt( centity_t *cent, vec3_t origin ) {
 	refEntity_t  beam;
 	vec3_t   forward;
 	vec3_t   muzzlePoint, endPoint;
+	qboolean demoRewind;
+	int attackTime;
 
 	if (cent->currentState.weapon != WP_LIGHTNING) {
 		return;
@@ -1671,8 +1673,24 @@ static void CG_LightningBolt( centity_t *cent, vec3_t origin ) {
 	VectorMA( muzzlePoint, LIGHTNING_RANGE, forward, endPoint );
 
 	// see if it hit a wall
+	demoRewind = ( cent->currentState.number == cg.predictedPlayerState.clientNum )
+		&& CG_DemoHistory_DemoDelagActive()
+		&& ( cg_delag.integer & 1 || cg_delag.integer & 8 );
+	attackTime = cg.predictedPlayerState.commandTime;
+	if ( attackTime <= 0 && cg.snap ) {
+		attackTime = cg.snap->ps.commandTime;
+	}
+	if ( attackTime <= 0 && cg.snap ) {
+		attackTime = cg.snap->serverTime;
+	}
+	if ( demoRewind ) {
+		CG_DemoHistory_BeginHitscanRewind( attackTime, cg.predictedPlayerState.clientNum );
+	}
 	CG_Trace( &trace, muzzlePoint, vec3_origin, vec3_origin, endPoint, 
 		cent->currentState.number, MASK_SHOT );
+	if ( demoRewind ) {
+		CG_DemoHistory_EndHitscanRewind();
+	}
 
 	// this is the endpoint
 	VectorCopy( trace.endpos, beam.oldorigin );
@@ -4135,6 +4153,108 @@ WEAPON EVENTS
 ===================================================================================================
 */
 
+#define MAX_DELAYED_WEAPON_FIRES 32
+
+typedef struct {
+	qboolean active;
+	int fireTime;
+	int centNum;
+	entityState_t state;
+} delayedWeaponFire_t;
+
+static delayedWeaponFire_t cg_delayedWeaponFires[MAX_DELAYED_WEAPON_FIRES];
+static qboolean cg_processingDelayedWeaponFire;
+
+static qboolean CG_IsDemoDelayedProjectileWeapon( int weapon ) {
+	switch ( weapon ) {
+	case WP_PLASMAGUN:
+	case WP_ROCKET_LAUNCHER:
+	case WP_GRENADE_LAUNCHER:
+	case WP_BFG:
+#ifdef MISSIONPACK
+	case WP_PROX_LAUNCHER:
+	case WP_NAILGUN:
+#endif
+		return qtrue;
+	default:
+		return qfalse;
+	}
+}
+
+static qboolean CG_QueueDelayedWeaponFire( centity_t *cent, int delay ) {
+	int i;
+	int best;
+	int bestTime;
+
+	if ( delay <= 0 ) {
+		return qfalse;
+	}
+	if ( !cent ) {
+		return qfalse;
+	}
+	if ( cent->currentState.number < 0 || cent->currentState.number >= MAX_GENTITIES ) {
+		return qfalse;
+	}
+
+	best = -1;
+	bestTime = 2147483647;
+	for ( i = 0; i < MAX_DELAYED_WEAPON_FIRES; i++ ) {
+		if ( !cg_delayedWeaponFires[i].active ) {
+			best = i;
+			break;
+		}
+		if ( cg_delayedWeaponFires[i].fireTime < bestTime ) {
+			bestTime = cg_delayedWeaponFires[i].fireTime;
+			best = i;
+		}
+	}
+	if ( best < 0 ) {
+		return qfalse;
+	}
+
+	cg_delayedWeaponFires[best].active = qtrue;
+	cg_delayedWeaponFires[best].fireTime = cg.time + delay;
+	cg_delayedWeaponFires[best].centNum = cent->currentState.number;
+	cg_delayedWeaponFires[best].state = cent->currentState;
+	return qtrue;
+}
+
+static void CG_FireWeaponNow( centity_t *cent );
+
+void CG_ProcessDelayedWeaponFires( void ) {
+	int i;
+
+	if ( !CG_DemoHistory_DemoDelagActive() ) {
+		Com_Memset( cg_delayedWeaponFires, 0, sizeof( cg_delayedWeaponFires ) );
+		return;
+	}
+
+	cg_processingDelayedWeaponFire = qtrue;
+	for ( i = 0; i < MAX_DELAYED_WEAPON_FIRES; i++ ) {
+		centity_t *cent;
+		entityState_t savedState;
+
+		if ( !cg_delayedWeaponFires[i].active ) {
+			continue;
+		}
+		if ( cg.time < cg_delayedWeaponFires[i].fireTime ) {
+			continue;
+		}
+		if ( cg_delayedWeaponFires[i].centNum < 0 || cg_delayedWeaponFires[i].centNum >= MAX_GENTITIES ) {
+			cg_delayedWeaponFires[i].active = qfalse;
+			continue;
+		}
+
+		cent = &cg_entities[cg_delayedWeaponFires[i].centNum];
+		savedState = cent->currentState;
+		cent->currentState = cg_delayedWeaponFires[i].state;
+		cg_delayedWeaponFires[i].active = qfalse;
+		CG_FireWeaponNow( cent );
+		cent->currentState = savedState;
+	}
+	cg_processingDelayedWeaponFire = qfalse;
+}
+
 /*
 ================
 CG_FireWeapon
@@ -4142,7 +4262,7 @@ CG_FireWeapon
 Caused by an EV_FIRE_WEAPON event
 ================
 */
-void CG_FireWeapon( centity_t *cent ) {
+static void CG_FireWeaponNow( centity_t *cent ) {
 	entityState_t *ent;
 	int				c;
 	weaponInfo_t	*weap;
@@ -4207,8 +4327,30 @@ void CG_FireWeapon( centity_t *cent ) {
 	}
 
 //unlagged - attack prediction #1
-	CG_PredictWeaponEffects( cent );
+	if ( !( cg_processingDelayedWeaponFire && CG_IsDemoDelayedProjectileWeapon( ent->weapon ) ) ) {
+		CG_PredictWeaponEffects( cent );
+	}
 //unlagged - attack prediction #1
+}
+
+void CG_FireWeapon( centity_t *cent ) {
+	entityState_t *ent;
+	int delay;
+
+	if ( !cent ) {
+		return;
+	}
+	ent = &cent->currentState;
+	delay = CG_DemoHistory_LocalFireDelay();
+	if ( !cg_processingDelayedWeaponFire
+			&& delay > 0
+			&& ent->number == cg.predictedPlayerState.clientNum
+			&& CG_IsDemoDelayedProjectileWeapon( ent->weapon )
+			&& CG_QueueDelayedWeaponFire( cent, delay ) ) {
+		return;
+	}
+
+	CG_FireWeaponNow( cent );
 }
 
 

--- a/ratoa_gamecode/windows_scripts/cgame.q3asm
+++ b/ratoa_gamecode/windows_scripts/cgame.q3asm
@@ -17,6 +17,7 @@ cg_predict
 cg_scoreboard
 cg_servercmds
 cg_snapshot
+cg_demo_history
 cg_unlagged
 cg_view
 cg_weapons

--- a/ratoa_gamecode/windows_scripts/cgame_mp.q3asm
+++ b/ratoa_gamecode/windows_scripts/cgame_mp.q3asm
@@ -18,6 +18,7 @@ cg_predict
 cg_scoreboard
 cg_servercmds
 cg_snapshot
+cg_demo_history
 cg_unlagged
 cg_view
 cg_weapons

--- a/ratoa_gamecode/windows_scripts/windows_compile_cgame.bat
+++ b/ratoa_gamecode/windows_scripts/windows_compile_cgame.bat
@@ -36,6 +36,7 @@ cd windows\build\cgame
 %cc%  ../../../code/cgame/cg_scoreboard.c
 %cc%  ../../../code/cgame/cg_servercmds.c
 %cc%  ../../../code/cgame/cg_snapshot.c
+%cc%  ../../../code/cgame/cg_demo_history.c
 %cc%  ../../../code/cgame/cg_unlagged.c
 %cc%  ../../../code/cgame/cg_view.c
 %cc%  ../../../code/cgame/cg_weapons.c

--- a/ratoa_gamecode/windows_scripts/windows_compile_cgame_missionpack.bat
+++ b/ratoa_gamecode/windows_scripts/windows_compile_cgame_missionpack.bat
@@ -36,6 +36,7 @@ cd windows\build\cgame
 %cc%  ../../../code/cgame/cg_scoreboard.c
 %cc%  ../../../code/cgame/cg_servercmds.c
 %cc%  ../../../code/cgame/cg_snapshot.c
+%cc%  ../../../code/cgame/cg_demo_history.c
 %cc%  ../../../code/cgame/cg_unlagged.c
 %cc%  ../../../code/cgame/cg_view.c
 %cc%  ../../../code/cgame/cg_weapons.c


### PR DESCRIPTION
This change should implement unlagged, or at least a lite version of it, for demo playback on localhost. Before this change, demo playback on Devo looked wack, particularly for high-ping players, because shots appeared to be aimed far behind their target's position while still hitting them.

Since we have no server running when playing back demos (only a stream of network data being replayed from the demo file), there's no inherent lag compensation, causing the visual problem we just described.

So we introduce a pseudo/lite version of the unlagged code that only runs when a demo is being played:
- Implement a ring buffer that retains the last 40 server snaps
- Read the latest ping value we have for the player
- Wind back enemy and projectile positions to the position they were in <ping> milliseconds before current time
- Wind back weapon firing effects (animation, sound) to the last server snapshot interval (it's approximately correct)
- Suppress the 'live' versions of events that would otherwise replay at the 'correct' times, ruining the illusion

The sum of these changes should loosely re-create what the recording player saw during live gameplay. It's controlled by a new cvar cg_demoDelag which is set to 1 by default.