### PR TITLE
Better scoreboard ping value during demo playback

### DIFF
--- a/ratoa_gamecode/code/cgame/cg_demo_history.c
+++ b/ratoa_gamecode/code/cgame/cg_demo_history.c
@@ -18,6 +18,8 @@ static int cg_demoHistoryCount;
 static int cg_demoHistoryLastServerTime;
 static qboolean cg_demoHistoryPrevPlayback;
 static int cg_demoDelagPingSmoothed = -1;
+static int cg_demoScoreboardPingLatchServerTime = -1;
+static int cg_demoScoreboardPingLatchMs = -1;
 
 typedef struct {
 	centity_t *cent;
@@ -39,6 +41,8 @@ void CG_DemoHistory_Clear( void ) {
 	cg_demoHistoryLastServerTime = -1;
 	cg_demoRewindSaveCount = 0;
 	cg_demoDelagPingSmoothed = -1;
+	cg_demoScoreboardPingLatchServerTime = -1;
+	cg_demoScoreboardPingLatchMs = -1;
 	for ( i = 0; i < MAX_GENTITIES; i++ ) {
 		cg_entities[i].demoDelagVisualCached = qfalse;
 	}
@@ -68,10 +72,40 @@ void CG_DemoHistory_Frame( void ) {
 				cg_demoDelagPingSmoothed += ( p - cg_demoDelagPingSmoothed + 4 ) / 8;
 			}
 		}
+		if ( cg.snap->serverTime != cg_demoScoreboardPingLatchServerTime ) {
+			int latched;
+
+			cg_demoScoreboardPingLatchServerTime = cg.snap->serverTime;
+			if ( demoDelagResolvePingMs( &latched ) ) {
+				if ( latched > 400 ) {
+					latched = 400;
+				}
+				cg_demoScoreboardPingLatchMs = latched;
+			} else {
+				cg_demoScoreboardPingLatchMs = -1;
+			}
+		}
 	} else {
 		cg_demoDelagPingSmoothed = -1;
+		cg_demoScoreboardPingLatchServerTime = -1;
+		cg_demoScoreboardPingLatchMs = -1;
 	}
 	cg_demoHistoryPrevPlayback = cg.demoPlayback;
+}
+
+/*
+=================
+CG_DemoHistory_GetScoreboardPingMs
+
+During demo playback with cg_demoDelag enabled, returns the delag ping latched
+once per snapshot serverTime (same basis as demo delag). Otherwise -1.
+=================
+ */
+int CG_DemoHistory_GetScoreboardPingMs( void ) {
+	if ( !cg.demoPlayback || !cg_demoDelag.integer || !cgs.delagHitscan ) {
+		return -1;
+	}
+	return cg_demoScoreboardPingLatchMs;
 }
 
 void CG_DemoHistory_OnSnapshot( const snapshot_t *snap ) {

--- a/ratoa_gamecode/code/cgame/cg_demo_history.h
+++ b/ratoa_gamecode/code/cgame/cg_demo_history.h
@@ -27,5 +27,6 @@ void CG_DemoHistory_EndHitscanRewind( void );
 void CG_DemoHistory_AdjustPlayerLerpForDemoDelag( struct centity_s *cent );
 qboolean CG_DemoHistory_AdjustMissileLerpForDemoDelag( struct centity_s *cent );
 int CG_DemoHistory_LocalFireDelay( void );
+int CG_DemoHistory_GetScoreboardPingMs( void );
 
 #endif

--- a/ratoa_gamecode/code/cgame/cg_scoreboard.c
+++ b/ratoa_gamecode/code/cgame/cg_scoreboard.c
@@ -914,7 +914,17 @@ void CG_BuildDemoScores( void ) {
 
 		if ( i == ps->clientNum ) {
 			s->score = ps->persistant[PERS_SCORE];
-			if ( cg.demoPlayback && cg.demoScoreboardPingValid ) {
+			if ( cg.demoPlayback && cg_demoDelag.integer && cgs.delagHitscan ) {
+				int delagPingSB = CG_DemoHistory_GetScoreboardPingMs();
+
+				if ( delagPingSB >= 0 ) {
+					s->ping = delagPingSB;
+				} else if ( cg.demoScoreboardPingValid ) {
+					s->ping = cg.demoScoreboardPing;
+				} else {
+					s->ping = ps->ping;
+				}
+			} else if ( cg.demoPlayback && cg.demoScoreboardPingValid ) {
 				s->ping = cg.demoScoreboardPing;
 			} else if ( cg.demoPlayback ) {
 				s->ping = ps->ping;


### PR DESCRIPTION
**Problem:** The first cut of fixing the scoreboard implemented a naive attempt to read the recording player's ping value from raw snap data. That wasn't returning correctly, usually ping would lock around a false value of 48-50 unless the `scores or ratscores servercmds` were invoked - Something that only happened if the servercmd **scores** ran at some point (player death, intermission, or opening the scoreboard). As a result, it was unreliable for our purposes.

**Solution:** With demo de-lag code merged on main, we have a better base to derive the recording player's live ping value. This change reads the ping value that the demo de-lagging applies (built from replay snaps and a bit of smoothing) to shift enemy players and projectiles backwards along their paths. It updates the scoreboard once per server tick, not client tick (so 20hz updates typically, not 125+).

**Testing:** If you open the scoreboard at the beginning of demo playback, you will now see a populated ping values for the recording client immediately. It should update frequently. That value is _also_ now a direct indication of how much de-lag is being applied to enemies and projectiles in the replay. To verify this for yourself, set up two key binds:
`\bind <key> toggle cg_demoDelag`
and
`\bind <key> toggle timescale`
You can use those keys to play/pause demo playback and toggle the delag system. When paused, you'll see enemies and projectiles jump back and forth, reflecting the lagged and de-lagged states. The de-lagged state isn't a perfect recreation of live, but it's a _lot_ closer than before.

(this is a long way of saying my previous scoreboard fix was poo-poo stinky no-good and this hopefully makes it work properly)