### PR TITLE
Fix - Queue bots in Tourney

### DIFF
--- a/ratoa_gamecode/code/game/g_client.c
+++ b/ratoa_gamecode/code/game/g_client.c
@@ -2380,11 +2380,16 @@ void ClientUserinfoChanged( int clientNum ) {
 			// pick the team with the least number of players
 			team = PickTeam( clientNum );
 		}
-                client->sess.sessionTeam = team;
+        client->sess.sessionTeam = team;
 	} else if (g_gametype.integer != GT_TOURNAMENT && g_entities[clientNum].r.svFlags & SVF_BOT) {
 		// make sure bots can always join the game, even if it's locked
 		team = TEAM_FREE;
 		client->sess.sessionTeam = team;
+	} else if (g_gametype.integer == GT_TOURNAMENT && g_entities[clientNum].r.svFlags & SVF_BOT) {
+		//For tourney, we want bots to queue and not just sit in spec
+		team = TEAM_SPECTATOR;
+		client->sess.sessionTeam = team;
+		client->sess.spectatorGroup = SPECTATORGROUP_QUEUED;
 	}
 	else {
 		team = client->sess.sessionTeam;


### PR DESCRIPTION
Problem: Bots sit in the spectator list when gametype is changed to Tournament. They don't join the game unless you kick the current bot and allow a fresh one to connect.

Cause: When we introduced a second class of spectator, 'queued' to join the game, bots were still being assigned into the regular non-queued group of spectators. So they never join the game even when a slot opens up. there was no logic to ever promote them into the queue.

Solution: Assign them into the queued-to-play group when they join the game after map/gametype change.