### PR TITLE
Added some new, optional, bot behaviors

### DIFF
--- a/docs/BOT-CVARS.md
+++ b/docs/BOT-CVARS.md
@@ -1,0 +1,40 @@
+# Bot CVARs
+
+Console variables that control bot AI, navigation, chat, and fill rules. Set them on the **server** (dedicated console, RCON, or `server.cfg`). Most apply as soon as they are changed; AAS-related settings usually matter when a map loads.
+
+**Origin:** *Vanilla* = Quake III Arena; *Devotion* = Devotion-only or Devotion-specific behavior.
+
+| Name | Origin | Default | Valid values | Description |
+|------|--------|---------|--------------|-------------|
+| `bot_aasoptimize` | Vanilla | `0` | 0 or 1 | When `1`, allows the bot navigation library to optimize the map’s AAS data when it is built or loaded. |
+| `bot_challenge` | Vanilla | `0` | 0 or 1 | Harder bots: steadier aim when locked on and more precise view tracking. Disables `bot_humanizeaim` while enabled. |
+| `bot_developer` | Vanilla | `0` | 0 or 1 | Extra bot-library debug output. Requires `sv_cheats 1`. |
+| `bot_enable` | Vanilla | `0` | 0 or 1 | Master switch: bots only load and play when `1`. Usually set in `server.cfg` (provided by the engine, not the game module). |
+| `bot_fastchat` | Vanilla | `0` | 0 or 1 | When `1`, bots are more likely to use chat lines (skips some random “stay quiet” rolls). |
+| `bot_forceclustering` | Vanilla | `0` | 0 or 1 | Forces the navigation system to rebuild area clusters for the current map (slow; map load / AAS build). |
+| `bot_forcereachability` | Vanilla | `0` | 0 or 1 | Forces reachability between areas to be recalculated (slow; map load / AAS build). |
+| `bot_forcewrite` | Vanilla | `0` | 0 or 1 | Forces the navigation `.aas` file to be written to disk when the map is processed. |
+| `bot_grapple` | Vanilla | `0` | 0 or 1 | When `1`, bots may use the off-hand grapple for movement where the mod supports it. |
+| `bot_humanizeaim` | Devotion | `0` | 0 or 1 | Smoother, more human-like bot aiming when `1` (`0` = classic snap aim). No effect while `bot_challenge` is `1`. Saved to config. |
+| `bot_interbreedbots` | Vanilla | `10` | integer ≥ 1 | Number of bots spawned when a bot “interbreeding” run starts. |
+| `bot_interbreedchar` | Vanilla | `` | bot name string | Bot character file to use for interbreeding; setting this starts a tournament-style breeding session. Cleared after spawn. |
+| `bot_interbreedcycle` | Vanilla | `20` | integer ≥ 1 | How many matches to run before the best bot’s AI is saved and a new generation is spawned. |
+| `bot_interbreedwrite` | Vanilla | `` | filename string | If set, writes the winning bot’s goal logic to this file at the end of a breeding cycle, then clears. |
+| `bot_memorydump` | Vanilla | `0` | 0 or 1 | One-shot: dumps bot-library memory stats, then resets to `0`. Requires `sv_cheats 1`. |
+| `bot_minplayers` | Vanilla | `0` | integer ≥ 0 | Target player count per team (or FFA slot fill): server adds or removes bots about every 10 seconds to match. `0` = off. Shown in server info. |
+| `bot_nochat` | Vanilla | `0` | integer ≥ 0 | `0` = normal chat; `1` = no bot taunts/greetings; `2` or higher also blocks team orders/voice and bots talking in global chat. |
+| `bot_pause` | Vanilla | `0` | 0 or 1 | Freezes bot movement (inputs zeroed each frame). Requires `sv_cheats 1`. |
+| `bot_predictobstacles` | Vanilla | `1` | 0 or 1 | When `1`, bots try to open doors and trigger movers on their route instead of ignoring them. |
+| `bot_reloadcharacters` | Vanilla | `0` | 0 or 1 | When `1`, reloads bot personality/weight files instead of using cached copies (used during interbreeding). |
+| `bot_report` | Vanilla | `0` | 0 or 1 | Updates internal bot status info shown in server config strings. Requires `sv_cheats 1`. |
+| `bot_rocketjump` | Vanilla | `1` | 0 or 1 | When `1`, bots may rocket-jump for vertical movement; `0` disables it. |
+| `bot_saveroutingcache` | Vanilla | `0` | 0 or 1 | One-shot: saves the routing cache for the current map, then resets to `0`. Requires `sv_cheats 1`. |
+| `bot_smartWeaponChoice` | Devotion | `0` | 0 or 1 | Smarter weapon picks by range and ammo when `1` (e.g. rail/MG at distance, rocket mid-range, shotgun up close). `0` = original picker. Saved to config. |
+| `bot_tacticalAI` | Devotion | `0` | 0 or 1 | Extra combat decisions when `1`: gauntlet rush/flee, react to third-party damage, finish wounded targets, prefer nearer threats. `0` = legacy behavior. Saved to config. |
+| `bot_testclusters` | Vanilla | `0` | 0 or 1 | Debug: print AAS area/cluster under the bot’s view. Requires `sv_cheats 1`. |
+| `bot_testichat` | Vanilla | `0` | 0 or 1 | Test mode: new bots fire their “enter game” chat line immediately. |
+| `bot_testrchat` | Vanilla | `0` | 0 or 1 | Test mode: triggers random chat handling in the bot library. |
+| `bot_testsolid` | Vanilla | `0` | 0 or 1 | Debug: report whether the bot’s view point is in solid AAS. Requires `sv_cheats 1`. |
+| `bot_thinktime` | Vanilla | `100` | integer (ms), max 200 | Milliseconds between bot AI updates; lower = more reactive bots, higher = less CPU. Capped at 200. |
+| `bot_visualizejumppads` | Vanilla | `0` | 0 or 1 | Debug: draw jump-pad reachability in the navigation mesh. |
+| `bot_wigglefactor` | Vanilla | `0.0` | 0.0–1.0 | How often bots change strafe direction in combat; higher = more side-to-side movement. |

--- a/docs/SERVER.md
+++ b/docs/SERVER.md
@@ -1,6 +1,6 @@
 # Server Commands
 
-For more detailed information, check out the [Server CVARs](SERVER-CVARS.md) and [Server Commands](SERVER-COMMANDS.md) tables.
+For more detailed information, check out the [Server CVARs](SERVER-CVARS.md), [Bot CVARs](BOT-CVARS.md), and [Server Commands](SERVER-COMMANDS.md) tables.
 
 ## Dedicated Server launch Example
 

--- a/ratoa_gamecode/Makefile
+++ b/ratoa_gamecode/Makefile
@@ -1781,6 +1781,7 @@ Q3GOBJ_ = \
   $(B)/baseq3/game/ai_dmq3.o \
   $(B)/baseq3/game/ai_aim_harness.o \
   $(B)/baseq3/game/ai_weapon_select.o \
+  $(B)/baseq3/game/ai_bot_tactics.o \
   $(B)/baseq3/game/ai_main.o \
   $(B)/baseq3/game/ai_team.o \
   $(B)/baseq3/game/ai_vcmd.o \
@@ -1843,6 +1844,7 @@ MPGOBJ_ = \
   $(B)/missionpack/game/ai_dmq3.o \
   $(B)/missionpack/game/ai_aim_harness.o \
   $(B)/missionpack/game/ai_weapon_select.o \
+  $(B)/missionpack/game/ai_bot_tactics.o \
   $(B)/missionpack/game/ai_main.o \
   $(B)/missionpack/game/ai_team.o \
   $(B)/missionpack/game/ai_vcmd.o \

--- a/ratoa_gamecode/Makefile
+++ b/ratoa_gamecode/Makefile
@@ -1780,6 +1780,7 @@ Q3GOBJ_ = \
   $(B)/baseq3/game/ai_dmnet.o \
   $(B)/baseq3/game/ai_dmq3.o \
   $(B)/baseq3/game/ai_aim_harness.o \
+  $(B)/baseq3/game/ai_weapon_select.o \
   $(B)/baseq3/game/ai_main.o \
   $(B)/baseq3/game/ai_team.o \
   $(B)/baseq3/game/ai_vcmd.o \
@@ -1841,6 +1842,7 @@ MPGOBJ_ = \
   $(B)/missionpack/game/ai_dmnet.o \
   $(B)/missionpack/game/ai_dmq3.o \
   $(B)/missionpack/game/ai_aim_harness.o \
+  $(B)/missionpack/game/ai_weapon_select.o \
   $(B)/missionpack/game/ai_main.o \
   $(B)/missionpack/game/ai_team.o \
   $(B)/missionpack/game/ai_vcmd.o \

--- a/ratoa_gamecode/Makefile
+++ b/ratoa_gamecode/Makefile
@@ -1779,6 +1779,7 @@ Q3GOBJ_ = \
   $(B)/baseq3/game/ai_cmd.o \
   $(B)/baseq3/game/ai_dmnet.o \
   $(B)/baseq3/game/ai_dmq3.o \
+  $(B)/baseq3/game/ai_aim_harness.o \
   $(B)/baseq3/game/ai_main.o \
   $(B)/baseq3/game/ai_team.o \
   $(B)/baseq3/game/ai_vcmd.o \
@@ -1839,6 +1840,7 @@ MPGOBJ_ = \
   $(B)/missionpack/game/ai_cmd.o \
   $(B)/missionpack/game/ai_dmnet.o \
   $(B)/missionpack/game/ai_dmq3.o \
+  $(B)/missionpack/game/ai_aim_harness.o \
   $(B)/missionpack/game/ai_main.o \
   $(B)/missionpack/game/ai_team.o \
   $(B)/missionpack/game/ai_vcmd.o \

--- a/ratoa_gamecode/code/game/ai_aim_harness.c
+++ b/ratoa_gamecode/code/game/ai_aim_harness.c
@@ -1,0 +1,197 @@
+/*
+===========================================================================
+BOT AIM HARNESS (v1) — see ai_aim_harness.h
+===========================================================================
+*/
+
+#include "g_local.h"
+#include "../botlib/botlib.h"
+#include "../botlib/be_aas.h"
+#include "../botlib/be_ea.h"
+#include "../botlib/be_ai_char.h"
+#include "../botlib/be_ai_goal.h"
+#include "../botlib/be_ai_move.h"
+#include "../botlib/be_ai_weap.h"
+#include "ai_main.h"
+#include "chars.h"
+#include "ai_aim_harness.h"
+
+vmCvar_t bot_humanizeaim;
+
+extern vmCvar_t bot_challenge;
+
+#define AIMH_FLICK_ANGLE		22.0f
+#define AIMH_STIFFNESS_TRACK	200.0f
+#define AIMH_STIFFNESS_FLICK	360.0f
+#define AIMH_DAMPING_TRACK		32.0f
+#define AIMH_DAMPING_FLICK		16.0f
+#define AIMH_ROAM_STIFFNESS		80.0f
+#define AIMH_ROAM_DAMPING		40.0f
+
+static float BotAimHarness_AngleDiff(float ang1, float ang2) {
+	float diff;
+
+	diff = ang1 - ang2;
+	if (ang1 > ang2) {
+		if (diff > 180.0f) {
+			diff -= 360.0f;
+		}
+	} else {
+		if (diff < -180.0f) {
+			diff += 360.0f;
+		}
+	}
+	return diff;
+}
+
+void BotAimHarness_RegisterCvars(void) {
+	trap_Cvar_Register(&bot_humanizeaim, "bot_humanizeaim", "0", CVAR_ARCHIVE);
+}
+
+int BotAimHarness_IsActive(void) {
+	if (!bot_humanizeaim.integer) {
+		return 0;
+	}
+	if (bot_challenge.integer) {
+		return 0;
+	}
+	return 1;
+}
+
+void BotAimHarness_Reset(bot_state_t *bs) {
+	VectorCopy(bs->viewangles, bs->aimh_goal);
+	bs->aimh_vel[PITCH] = 0.0f;
+	bs->aimh_vel[YAW] = 0.0f;
+	bs->aimh_motor_inaccuracy = 0.0f;
+	bs->aimh_combat_aim = qfalse;
+}
+
+void BotAimHarness_SetCombatGoal(bot_state_t *bs, const vec3_t idealAngles,
+	float aimAccuracy, float weaponVSpread, float weaponHSpread) {
+	float inaccuracy;
+
+	VectorCopy(idealAngles, bs->aimh_goal);
+
+	inaccuracy = 1.0f - aimAccuracy;
+	if (inaccuracy < 0.0f) {
+		inaccuracy = 0.0f;
+	}
+	if (inaccuracy > 1.0f) {
+		inaccuracy = 1.0f;
+	}
+	bs->aimh_motor_inaccuracy = inaccuracy;
+
+	bs->aimh_goal[PITCH] += 6.0f * weaponVSpread * crandom() * inaccuracy;
+	bs->aimh_goal[PITCH] = AngleMod(bs->aimh_goal[PITCH]);
+	bs->aimh_goal[YAW] += 6.0f * weaponHSpread * crandom() * inaccuracy;
+	bs->aimh_goal[YAW] = AngleMod(bs->aimh_goal[YAW]);
+
+	bs->aimh_combat_aim = qtrue;
+	VectorCopy(bs->aimh_goal, bs->ideal_viewangles);
+}
+
+static void BotAimHarness_UpdateAxis(bot_state_t *bs, int axis, float goalAngle,
+	float dt, float stiffness, float damping, float maxSpeed, float motorNoise) {
+	float err, accel;
+
+	err = BotAimHarness_AngleDiff(bs->viewangles[axis], goalAngle);
+	accel = stiffness * err - damping * bs->aimh_vel[axis];
+	bs->aimh_vel[axis] += accel * dt;
+
+	if (bs->aimh_vel[axis] > maxSpeed) {
+		bs->aimh_vel[axis] = maxSpeed;
+	} else if (bs->aimh_vel[axis] < -maxSpeed) {
+		bs->aimh_vel[axis] = -maxSpeed;
+	}
+
+	bs->viewangles[axis] = AngleMod(bs->viewangles[axis] + bs->aimh_vel[axis] * dt);
+
+	if (motorNoise > 0.01f && fabs(err) < 10.0f) {
+		bs->viewangles[axis] = AngleMod(bs->viewangles[axis] +
+			crandom() * 3.0f * motorNoise * dt * 60.0f);
+	}
+}
+
+/*
+ * Returns 1 if viewangles were updated (caller should skip legacy motor).
+ */
+int BotAimHarness_ChangeViewAngles(bot_state_t *bs, float thinktime) {
+	vec3_t goal;
+	float skill, maxChange, maxTrack, maxFlick;
+	float stiffness, damping, maxSpeed, motorNoise;
+	float magErr;
+	int i;
+
+	if (!BotAimHarness_IsActive()) {
+		return 0;
+	}
+
+	if (thinktime <= 0.0f) {
+		thinktime = 0.001f;
+	}
+
+	if (bs->enemy < 0) {
+		bs->aimh_combat_aim = qfalse;
+		bs->aimh_motor_inaccuracy = 0.0f;
+	}
+
+	if (bs->aimh_combat_aim) {
+		VectorCopy(bs->aimh_goal, goal);
+		motorNoise = bs->aimh_motor_inaccuracy;
+		skill = trap_Characteristic_BFloat(bs->character, CHARACTERISTIC_VIEW_FACTOR, 0.01f, 1.0f);
+		maxChange = trap_Characteristic_BFloat(bs->character, CHARACTERISTIC_VIEW_MAXCHANGE, 1.0f, 1800.0f);
+		if (maxChange < 240.0f) {
+			maxChange = 240.0f;
+		}
+		maxTrack = maxChange * skill;
+		maxFlick = maxChange * 1.35f * skill;
+	} else {
+		VectorCopy(bs->ideal_viewangles, goal);
+		motorNoise = 0.0f;
+		skill = 0.05f;
+		maxTrack = 360.0f;
+		maxFlick = 360.0f;
+	}
+
+	if (goal[PITCH] > 180.0f) {
+		goal[PITCH] -= 360.0f;
+	}
+
+	{
+		float pitchErr, yawErr;
+
+		pitchErr = BotAimHarness_AngleDiff(bs->viewangles[PITCH], goal[PITCH]);
+		yawErr = BotAimHarness_AngleDiff(bs->viewangles[YAW], goal[YAW]);
+		magErr = sqrt(pitchErr * pitchErr + yawErr * yawErr);
+	}
+
+	if (bs->aimh_combat_aim && magErr > AIMH_FLICK_ANGLE) {
+		stiffness = AIMH_STIFFNESS_FLICK;
+		damping = AIMH_DAMPING_FLICK;
+		maxSpeed = maxFlick * thinktime;
+	} else if (bs->aimh_combat_aim) {
+		stiffness = AIMH_STIFFNESS_TRACK;
+		damping = AIMH_DAMPING_TRACK;
+		maxSpeed = maxTrack * thinktime;
+	} else {
+		stiffness = AIMH_ROAM_STIFFNESS;
+		damping = AIMH_ROAM_DAMPING;
+		maxSpeed = maxFlick * thinktime;
+	}
+
+	if (maxSpeed < 1.0f) {
+		maxSpeed = 1.0f;
+	}
+
+	for (i = 0; i < 2; i++) {
+		BotAimHarness_UpdateAxis(bs, i, goal[i], thinktime,
+			stiffness, damping, maxSpeed, motorNoise);
+	}
+
+	if (bs->viewangles[PITCH] > 180.0f) {
+		bs->viewangles[PITCH] -= 360.0f;
+	}
+
+	trap_EA_View(bs->client, bs->viewangles);
+	return 1;
+}

--- a/ratoa_gamecode/code/game/ai_aim_harness.c
+++ b/ratoa_gamecode/code/game/ai_aim_harness.c
@@ -19,6 +19,7 @@ BOT AIM HARNESS (v1) — see ai_aim_harness.h
 vmCvar_t bot_humanizeaim;
 
 extern vmCvar_t bot_challenge;
+extern vmCvar_t bot_thinktime;
 extern bot_state_t *botstates[MAX_CLIENTS];
 
 #define AIMH_FLICK_ANGLE		28.0f
@@ -31,6 +32,9 @@ extern bot_state_t *botstates[MAX_CLIENTS];
 /* Combat turn rate multiplier on top of CHARACTERISTIC_VIEW_* (legacy parity target ~2x) */
 #define AIMH_COMBAT_VEL_SCALE	1.85f
 #define AIMH_MOTOR_NOISE_SCALE	2.0f
+/* Extra lead on hitscan goals to offset bot-think + spring motor lag (seconds). */
+#define AIMH_HITSCAN_LEAD_EXTRA	0.025f
+#define AIMH_HITSCAN_LEAD_SCALE	0.9f
 
 static int bot_humanizeaim_last = -1;
 
@@ -169,11 +173,14 @@ void BotAimHarness_SetCombatGoal(bot_state_t *bs, const vec3_t idealAngles,
 }
 
 /*
- * Re-aim at the live enemy each harness tick (bot think is ~100ms; strafe needs faster goals).
+ * Re-aim at the live enemy each harness tick with velocity lead (aimtarget is only
+ * refreshed on bot think ~100ms and reads behind on hitscan).
  */
 static void BotAimHarness_GetCombatGoal(bot_state_t *bs, vec3_t goal) {
 	aas_entityinfo_t entinfo;
-	vec3_t dir, target;
+	weaponinfo_t wi;
+	vec3_t dir, target, vel;
+	float leadTime, dist, flightTime;
 
 	if (bs->enemy < 0 || bs->enemy >= MAX_CLIENTS) {
 		VectorCopy(bs->aimh_goal, goal);
@@ -186,12 +193,44 @@ static void BotAimHarness_GetCombatGoal(bot_state_t *bs, vec3_t goal) {
 		return;
 	}
 
-	if (!VectorCompare(bs->aimtarget, vec3_origin)) {
-		VectorCopy(bs->aimtarget, target);
+	VectorSubtract(entinfo.origin, entinfo.lastvisorigin, vel);
+	if (entinfo.update_time > 0.001f) {
+		VectorScale(vel, 1.0f / entinfo.update_time, vel);
 	} else {
+		VectorClear(vel);
+	}
+
+	trap_BotGetWeaponInfo(bs->ws, bs->weaponnum, &wi);
+
+	if (wi.speed > 0.0f) {
+		/* Projectile: BotAimAtEnemy aimtarget already includes prediction. */
+		if (!VectorCompare(bs->aimtarget, vec3_origin)) {
+			VectorCopy(bs->aimtarget, target);
+		} else {
+			VectorCopy(entinfo.origin, target);
+			target[2] += 8.0f;
+			VectorSubtract(target, bs->eye, dir);
+			dist = VectorLength(dir);
+			flightTime = dist / wi.speed;
+			if (flightTime > 2.0f) {
+				flightTime = 2.0f;
+			}
+			VectorMA(target, flightTime, vel, target);
+		}
+		leadTime = AIMH_HITSCAN_LEAD_EXTRA;
+	} else {
+		/* Hitscan: live origin + lead for think interval and view motor lag. */
 		VectorCopy(entinfo.origin, target);
 		target[2] += 8.0f;
+		trap_Cvar_Update(&bot_thinktime);
+		leadTime = (bot_thinktime.integer / 1000.0f) * AIMH_HITSCAN_LEAD_SCALE;
+		leadTime += AIMH_HITSCAN_LEAD_EXTRA;
+		if (leadTime > 0.2f) {
+			leadTime = 0.2f;
+		}
 	}
+
+	VectorMA(target, leadTime, vel, target);
 
 	VectorSubtract(target, bs->eye, dir);
 	vectoangles(dir, goal);

--- a/ratoa_gamecode/code/game/ai_aim_harness.c
+++ b/ratoa_gamecode/code/game/ai_aim_harness.c
@@ -18,6 +18,10 @@ BOT AIM HARNESS (v1) — see ai_aim_harness.h
 
 vmCvar_t bot_humanizeaim;
 
+/* Forward — defined in ai_dmq3.c */
+float BotEntityVisible(int viewer, vec3_t eye, vec3_t viewangles, float fov, int ent);
+qboolean BotIsDead(bot_state_t *bs);
+
 extern vmCvar_t bot_challenge;
 extern vmCvar_t bot_thinktime;
 extern bot_state_t *botstates[MAX_CLIENTS];
@@ -29,12 +33,29 @@ extern bot_state_t *botstates[MAX_CLIENTS];
 #define AIMH_DAMPING_FLICK		22.0f
 #define AIMH_ROAM_STIFFNESS		80.0f
 #define AIMH_ROAM_DAMPING		40.0f
-/* Combat turn rate multiplier on top of CHARACTERISTIC_VIEW_* (legacy parity target ~2x) */
 #define AIMH_COMBAT_VEL_SCALE	1.85f
 #define AIMH_MOTOR_NOISE_SCALE	2.0f
-/* Extra lead on hitscan goals to offset bot-think + spring motor lag (seconds). */
 #define AIMH_HITSCAN_LEAD_EXTRA	0.025f
 #define AIMH_HITSCAN_LEAD_SCALE	0.9f
+#define AIMH_AIM_HEIGHT			32.0f
+#define AIMH_MAX_VERT_LEAD_VEL	480.0f
+#define AIMH_VERT_LEAD_SCALE	0.2f
+#define AIMH_ENEMY_Z_SPIKE		72.0f
+#define AIMH_PITCH_RESET_ERR	14.0f
+#define AIMH_PITCH_CATCHUP_ERR	10.0f
+#define AIMH_PITCH_CATCHUP_RATE	7.0f
+#define AIMH_PITCH_VEL_MIN		220.0f
+#define AIMH_SANITY_INTERVAL		0.14f
+#define AIMH_SANITY_COOLDOWN_SWITCH	0.35f
+#define AIMH_SANITY_PITCH_SOFT	11.0f
+#define AIMH_SANITY_PITCH_HARD	18.0f
+#define AIMH_SANITY_SUSTAIN_ERR	20.0f
+#define AIMH_SANITY_SUSTAIN_TIME	0.22f
+#define AIMH_SANITY_MISS_STREAK_HARD	3
+#define AIMH_RECOVER_DURATION		0.28f
+#define AIMH_RECOVER_CATCHUP_MULT	1.45f
+#define AIMH_ACQUIRE_DURATION		0.4f
+#define AIMH_ACQUIRE_FLICK_ANGLE	44.0f
 
 static int bot_humanizeaim_last = -1;
 
@@ -54,9 +75,6 @@ static float BotAimHarness_AngleDiff(float ang1, float ang2) {
 	return diff;
 }
 
-/*
- * Pitch is linear in [-89, 89] for view — never use yaw-style AngleMod wrapping.
- */
 float BotAimHarness_ClampPitchAngle(float pitch) {
 	if (pitch > 180.0f) {
 		pitch -= 360.0f;
@@ -81,9 +99,187 @@ static float BotAimHarness_PitchDiff(float pitch, float goal) {
 	return BotAimHarness_ClampPitch(goal) - BotAimHarness_ClampPitch(pitch);
 }
 
-/* Shortest-path goal - view (same sign convention as pitch). */
 static float BotAimHarness_YawDiff(float yaw, float goal) {
 	return BotAimHarness_AngleDiff(goal, yaw);
+}
+
+static void BotAimHarness_RefreshEye(bot_state_t *bs) {
+	VectorCopy(bs->cur_ps.origin, bs->origin);
+	VectorCopy(bs->cur_ps.origin, bs->eye);
+	bs->eye[2] += bs->cur_ps.viewheight;
+}
+
+static int BotAimHarness_AimTargetValid(bot_state_t *bs) {
+	if (VectorCompare(bs->aimtarget, vec3_origin)) {
+		return 0;
+	}
+	if (VectorLengthSquared(bs->aimtarget) < 1.0f) {
+		return 0;
+	}
+	return 1;
+}
+
+static void BotAimHarness_ClearRecoveryState(bot_state_t *bs) {
+	bs->aimh_bad_aim_since = 0.0f;
+	bs->aimh_recover_until = 0.0f;
+	bs->aimh_sanity_miss_streak = 0;
+}
+
+static void BotAimHarness_ClampVerticalLeadVel(float *vel) {
+	if (vel[2] > AIMH_MAX_VERT_LEAD_VEL) {
+		vel[2] = AIMH_MAX_VERT_LEAD_VEL;
+	} else if (vel[2] < -AIMH_MAX_VERT_LEAD_VEL) {
+		vel[2] = -AIMH_MAX_VERT_LEAD_VEL;
+	}
+}
+
+static void BotAimHarness_ApplyLead(vec3_t target, const vec3_t vel, float leadTime,
+	qboolean reducedVertical) {
+	vec3_t leadVel;
+	float vertScale;
+
+	VectorCopy(vel, leadVel);
+	BotAimHarness_ClampVerticalLeadVel(leadVel);
+
+	vertScale = reducedVertical ? AIMH_VERT_LEAD_SCALE : 1.0f;
+	target[0] += leadVel[0] * leadTime;
+	target[1] += leadVel[1] * leadTime;
+	target[2] += leadVel[2] * leadTime * vertScale;
+}
+
+/*
+ * Same reference BotCheckAttack uses for "in field of view" (aimtarget, not live torso).
+ */
+static void BotAimHarness_GetAttackAimAngles(bot_state_t *bs, vec3_t angles) {
+	vec3_t dir;
+
+	if (BotAimHarness_AimTargetValid(bs)) {
+		VectorSubtract(bs->aimtarget, bs->eye, dir);
+	} else if (bs->enemy >= 0 && bs->enemy < MAX_CLIENTS) {
+		aas_entityinfo_t entinfo;
+
+		BotEntityInfo(bs->enemy, &entinfo);
+		if (!entinfo.valid) {
+			VectorCopy(bs->aimh_goal, angles);
+			return;
+		}
+		VectorSubtract(entinfo.origin, bs->eye, dir);
+		dir[2] += AIMH_AIM_HEIGHT;
+	} else {
+		VectorCopy(bs->aimh_goal, angles);
+		return;
+	}
+	vectoangles(dir, angles);
+	angles[PITCH] = BotAimHarness_ClampPitch(angles[PITCH]);
+	angles[YAW] = AngleMod(angles[YAW]);
+}
+
+/*
+ * 0 = ok, 1 = soft (motor boost only), 2 = hard (also damp motor).
+ */
+static int BotAimHarness_EvaluateAimQuality(bot_state_t *bs, const vec3_t goal,
+	float pitchErr, float yawErr) {
+	vec3_t attackAngles;
+	float attackPitchErr, attackYawErr;
+
+	if (bs->enemy < 0 || bs->enemy >= MAX_CLIENTS) {
+		return 0;
+	}
+	if (BotEntityVisible(bs->entitynum, bs->eye, bs->viewangles, 360, bs->enemy) < 0.2f) {
+		bs->aimh_bad_aim_since = 0.0f;
+		bs->aimh_sanity_miss_streak = 0;
+		return 0;
+	}
+
+	BotAimHarness_GetAttackAimAngles(bs, attackAngles);
+	attackPitchErr = BotAimHarness_PitchDiff(bs->viewangles[PITCH], attackAngles[PITCH]);
+	attackYawErr = BotAimHarness_YawDiff(bs->viewangles[YAW], attackAngles[YAW]);
+
+	if (fabs(attackPitchErr) <= AIMH_SANITY_PITCH_SOFT &&
+			fabs(attackYawErr) <= AIMH_SANITY_PITCH_SOFT + 3.0f) {
+		bs->aimh_bad_aim_since = 0.0f;
+		bs->aimh_sanity_miss_streak = 0;
+		return 0;
+	}
+
+	if (fabs(attackPitchErr) > AIMH_SANITY_PITCH_HARD ||
+			fabs(attackYawErr) > AIMH_SANITY_PITCH_HARD + 4.0f) {
+		bs->aimh_sanity_miss_streak++;
+		if (bs->aimh_sanity_miss_streak >= AIMH_SANITY_MISS_STREAK_HARD) {
+			return 2;
+		}
+		return 1;
+	}
+
+	if (fabs(pitchErr) > AIMH_SANITY_SUSTAIN_ERR) {
+		if (bs->aimh_bad_aim_since <= 0.0f) {
+			bs->aimh_bad_aim_since = FloatTime();
+		} else if (FloatTime() - bs->aimh_bad_aim_since > AIMH_SANITY_SUSTAIN_TIME) {
+			bs->aimh_sanity_miss_streak++;
+			if (bs->aimh_sanity_miss_streak >= AIMH_SANITY_MISS_STREAK_HARD) {
+				return 2;
+			}
+			return 1;
+		}
+	} else {
+		bs->aimh_bad_aim_since = 0.0f;
+	}
+
+	bs->aimh_sanity_miss_streak++;
+	if (bs->aimh_sanity_miss_streak >= AIMH_SANITY_MISS_STREAK_HARD) {
+		return 2;
+	}
+	(void)goal;
+	(void)yawErr;
+	return 1;
+}
+
+static void BotAimHarness_BeginRecovery(bot_state_t *bs, int severity) {
+	if (bs->aimh_recover_until > FloatTime()) {
+		return;
+	}
+	if (severity >= 2) {
+		bs->aimh_vel[PITCH] = 0.0f;
+		bs->aimh_vel[YAW] *= 0.5f;
+	}
+	bs->aimh_recover_until = FloatTime() + AIMH_RECOVER_DURATION;
+}
+
+static void BotAimHarness_RunSanityCheck(bot_state_t *bs, const vec3_t goal) {
+	int quality;
+	float pitchErr, yawErr;
+
+	if (!bs->aimh_combat_aim || bs->enemy < 0 || bs->enemy >= MAX_CLIENTS) {
+		return;
+	}
+	if (FloatTime() < bs->aimh_next_sanity_time) {
+		return;
+	}
+	if (FloatTime() < bs->aimh_acquire_until) {
+		return;
+	}
+	bs->aimh_next_sanity_time = FloatTime() + AIMH_SANITY_INTERVAL;
+
+	pitchErr = BotAimHarness_PitchDiff(bs->viewangles[PITCH], goal[PITCH]);
+	yawErr = BotAimHarness_YawDiff(bs->viewangles[YAW], goal[YAW]);
+	quality = BotAimHarness_EvaluateAimQuality(bs, goal, pitchErr, yawErr);
+	if (quality <= 0) {
+		return;
+	}
+	BotAimHarness_BeginRecovery(bs, quality);
+}
+
+static void BotAimHarness_OnEnemyChange(bot_state_t *bs) {
+	if (bs->enemy == bs->aimh_last_sanity_enemy) {
+		return;
+	}
+	bs->aimh_last_sanity_enemy = bs->enemy;
+	bs->aimh_last_enemy_z = 0.0f;
+	BotAimHarness_ClearRecoveryState(bs);
+	bs->aimh_next_sanity_time = FloatTime() + AIMH_SANITY_COOLDOWN_SWITCH;
+	bs->aimh_acquire_until = FloatTime() + AIMH_ACQUIRE_DURATION;
+	bs->aimh_vel[PITCH] *= 0.4f;
+	bs->aimh_vel[YAW] *= 0.4f;
 }
 
 void BotAimHarness_RegisterCvars(void) {
@@ -145,6 +341,13 @@ void BotAimHarness_Reset(bot_state_t *bs) {
 	bs->aimh_vel[YAW] = 0.0f;
 	bs->aimh_motor_inaccuracy = 0.0f;
 	bs->aimh_combat_aim = qfalse;
+	bs->aimh_last_enemy_z = 0.0f;
+	bs->aimh_next_sanity_time = 0.0f;
+	bs->aimh_bad_aim_since = 0.0f;
+	bs->aimh_recover_until = 0.0f;
+	bs->aimh_acquire_until = 0.0f;
+	bs->aimh_last_sanity_enemy = -1;
+	bs->aimh_sanity_miss_streak = 0;
 }
 
 void BotAimHarness_SetCombatGoal(bot_state_t *bs, const vec3_t idealAngles,
@@ -165,17 +368,12 @@ void BotAimHarness_SetCombatGoal(bot_state_t *bs, const vec3_t idealAngles,
 	if (inaccuracy > 1.0f) {
 		inaccuracy = 1.0f;
 	}
-	/* Continuous jitter via motor noise — not per-think goal hops. */
 	bs->aimh_motor_inaccuracy = inaccuracy * 0.7f;
 
 	bs->aimh_combat_aim = qtrue;
 	VectorCopy(bs->aimh_goal, bs->ideal_viewangles);
 }
 
-/*
- * Re-aim at the live enemy each harness tick with velocity lead (aimtarget is only
- * refreshed on bot think ~100ms and reads behind on hitscan).
- */
 static void BotAimHarness_GetCombatGoal(bot_state_t *bs, vec3_t goal) {
 	aas_entityinfo_t entinfo;
 	weaponinfo_t wi;
@@ -193,44 +391,51 @@ static void BotAimHarness_GetCombatGoal(bot_state_t *bs, vec3_t goal) {
 		return;
 	}
 
+	if (bs->aimh_last_enemy_z != 0.0f &&
+			fabs(entinfo.origin[2] - bs->aimh_last_enemy_z) > AIMH_ENEMY_Z_SPIKE) {
+		bs->aimh_vel[PITCH] = 0.0f;
+	}
+	bs->aimh_last_enemy_z = entinfo.origin[2];
+
 	VectorSubtract(entinfo.origin, entinfo.lastvisorigin, vel);
 	if (entinfo.update_time > 0.001f) {
 		VectorScale(vel, 1.0f / entinfo.update_time, vel);
 	} else {
 		VectorClear(vel);
 	}
+	BotAimHarness_ClampVerticalLeadVel(vel);
 
 	trap_BotGetWeaponInfo(bs->ws, bs->weaponnum, &wi);
 
 	if (wi.speed > 0.0f) {
-		/* Projectile: BotAimAtEnemy aimtarget already includes prediction. */
-		if (!VectorCompare(bs->aimtarget, vec3_origin)) {
+		if (BotAimHarness_AimTargetValid(bs)) {
 			VectorCopy(bs->aimtarget, target);
 		} else {
 			VectorCopy(entinfo.origin, target);
-			target[2] += 8.0f;
+			target[2] += AIMH_AIM_HEIGHT;
 			VectorSubtract(target, bs->eye, dir);
 			dist = VectorLength(dir);
 			flightTime = dist / wi.speed;
 			if (flightTime > 2.0f) {
 				flightTime = 2.0f;
 			}
-			VectorMA(target, flightTime, vel, target);
+			BotAimHarness_ApplyLead(target, vel, flightTime, qtrue);
 		}
-		leadTime = AIMH_HITSCAN_LEAD_EXTRA;
 	} else {
-		/* Hitscan: live origin + lead for think interval and view motor lag. */
-		VectorCopy(entinfo.origin, target);
-		target[2] += 8.0f;
+		if (BotAimHarness_AimTargetValid(bs)) {
+			VectorCopy(bs->aimtarget, target);
+		} else {
+			VectorCopy(entinfo.origin, target);
+			target[2] += AIMH_AIM_HEIGHT;
+		}
 		trap_Cvar_Update(&bot_thinktime);
 		leadTime = (bot_thinktime.integer / 1000.0f) * AIMH_HITSCAN_LEAD_SCALE;
 		leadTime += AIMH_HITSCAN_LEAD_EXTRA;
 		if (leadTime > 0.2f) {
 			leadTime = 0.2f;
 		}
+		BotAimHarness_ApplyLead(target, vel, leadTime, qtrue);
 	}
-
-	VectorMA(target, leadTime, vel, target);
 
 	VectorSubtract(target, bs->eye, dir);
 	vectoangles(dir, goal);
@@ -252,7 +457,6 @@ static void BotAimHarness_UpdateAxis(bot_state_t *bs, int axis, float goalAngle,
 	accel = stiffness * err - damping * bs->aimh_vel[axis];
 	bs->aimh_vel[axis] += accel * dt;
 
-	/* maxVel is degrees/sec (legacy maxchange before its single * thinktime) */
 	if (bs->aimh_vel[axis] > maxVel) {
 		bs->aimh_vel[axis] = maxVel;
 	} else if (bs->aimh_vel[axis] < -maxVel) {
@@ -275,15 +479,12 @@ static void BotAimHarness_UpdateAxis(bot_state_t *bs, int axis, float goalAngle,
 	}
 }
 
-/*
- * Returns 1 if viewangles were updated (caller should skip legacy motor).
- */
 int BotAimHarness_ChangeViewAngles(bot_state_t *bs, float thinktime) {
 	vec3_t goal;
-	float skill, maxChange, maxTrack, maxFlick;
+	float skill, maxChange, maxTrack, maxFlick, maxVelPitch;
 	float stiffness, damping, maxVel, motorNoise;
-	float magErr;
-	int i;
+	float magErr, pitchErr, yawErr, catchup, catchupRate;
+	float flickAngle;
 
 	if (!BotAimHarness_IsActive()) {
 		return 0;
@@ -293,9 +494,27 @@ int BotAimHarness_ChangeViewAngles(bot_state_t *bs, float thinktime) {
 		thinktime = 0.001f;
 	}
 
+	BotAimHarness_RefreshEye(bs);
+
+	if (BotIsDead(bs)) {
+		bs->aimh_combat_aim = qfalse;
+		BotAimHarness_ClearRecoveryState(bs);
+		bs->aimh_last_enemy_z = 0.0f;
+		bs->aimh_last_sanity_enemy = -1;
+		bs->aimh_acquire_until = 0.0f;
+		trap_EA_View(bs->client, bs->viewangles);
+		return 1;
+	}
+
 	if (bs->enemy < 0) {
 		bs->aimh_combat_aim = qfalse;
 		bs->aimh_motor_inaccuracy = 0.0f;
+		bs->aimh_last_enemy_z = 0.0f;
+		bs->aimh_last_sanity_enemy = -1;
+		BotAimHarness_ClearRecoveryState(bs);
+		bs->aimh_acquire_until = 0.0f;
+	} else {
+		BotAimHarness_OnEnemyChange(bs);
 	}
 
 	if (bs->aimh_combat_aim) {
@@ -319,15 +538,22 @@ int BotAimHarness_ChangeViewAngles(bot_state_t *bs, float thinktime) {
 	goal[PITCH] = BotAimHarness_ClampPitch(goal[PITCH]);
 	bs->viewangles[PITCH] = BotAimHarness_ClampPitch(bs->viewangles[PITCH]);
 
-	{
-		float pitchErr, yawErr;
+	pitchErr = BotAimHarness_PitchDiff(bs->viewangles[PITCH], goal[PITCH]);
+	yawErr = BotAimHarness_YawDiff(bs->viewangles[YAW], goal[YAW]);
+	magErr = sqrt(pitchErr * pitchErr + yawErr * yawErr);
 
-		pitchErr = BotAimHarness_PitchDiff(bs->viewangles[PITCH], goal[PITCH]);
-		yawErr = BotAimHarness_YawDiff(bs->viewangles[YAW], goal[YAW]);
-		magErr = sqrt(pitchErr * pitchErr + yawErr * yawErr);
+	if (bs->aimh_combat_aim && bs->aimh_acquire_until <= FloatTime() &&
+			fabs(pitchErr) > AIMH_PITCH_RESET_ERR) {
+		bs->aimh_vel[PITCH] = 0.0f;
 	}
 
-	if (bs->aimh_combat_aim && magErr > AIMH_FLICK_ANGLE) {
+	flickAngle = AIMH_FLICK_ANGLE;
+	if (bs->aimh_acquire_until > FloatTime()) {
+		flickAngle = AIMH_ACQUIRE_FLICK_ANGLE;
+		maxTrack *= 0.82f;
+		maxFlick *= 0.82f;
+	}
+	if (bs->aimh_combat_aim && magErr > flickAngle) {
 		stiffness = AIMH_STIFFNESS_FLICK;
 		damping = AIMH_DAMPING_FLICK;
 		maxVel = maxFlick;
@@ -347,9 +573,36 @@ int BotAimHarness_ChangeViewAngles(bot_state_t *bs, float thinktime) {
 		maxVel = 90.0f;
 	}
 
-	for (i = 0; i < 2; i++) {
-		BotAimHarness_UpdateAxis(bs, i, goal[i], thinktime,
-			stiffness, damping, maxVel, motorNoise);
+	maxVelPitch = maxVel * 1.55f;
+	if (bs->aimh_combat_aim && maxVelPitch < AIMH_PITCH_VEL_MIN) {
+		maxVelPitch = AIMH_PITCH_VEL_MIN;
+	}
+	if (bs->aimh_recover_until > FloatTime() && bs->aimh_acquire_until <= FloatTime()) {
+		maxVelPitch *= 1.12f;
+	}
+
+	BotAimHarness_UpdateAxis(bs, PITCH, goal[PITCH], thinktime,
+		stiffness, damping, maxVelPitch, motorNoise);
+	BotAimHarness_UpdateAxis(bs, YAW, goal[YAW], thinktime,
+		stiffness, damping, maxVel, motorNoise);
+
+	catchupRate = AIMH_PITCH_CATCHUP_RATE;
+	if (bs->aimh_recover_until > FloatTime() && bs->aimh_acquire_until <= FloatTime()) {
+		catchupRate *= AIMH_RECOVER_CATCHUP_MULT;
+	}
+	if (bs->aimh_combat_aim && bs->aimh_acquire_until <= FloatTime() &&
+			fabs(pitchErr) > AIMH_PITCH_CATCHUP_ERR) {
+		catchup = pitchErr * thinktime * catchupRate;
+		if (catchup > pitchErr) {
+			catchup = pitchErr;
+		} else if (catchup < -pitchErr) {
+			catchup = -pitchErr;
+		}
+		bs->viewangles[PITCH] = BotAimHarness_ClampPitch(bs->viewangles[PITCH] + catchup);
+	}
+
+	if (bs->aimh_combat_aim && bs->enemy >= 0) {
+		BotAimHarness_RunSanityCheck(bs, goal);
 	}
 
 	bs->viewangles[PITCH] = BotAimHarness_ClampPitch(bs->viewangles[PITCH]);

--- a/ratoa_gamecode/code/game/ai_aim_harness.c
+++ b/ratoa_gamecode/code/game/ai_aim_harness.c
@@ -19,14 +19,20 @@ BOT AIM HARNESS (v1) — see ai_aim_harness.h
 vmCvar_t bot_humanizeaim;
 
 extern vmCvar_t bot_challenge;
+extern bot_state_t *botstates[MAX_CLIENTS];
 
-#define AIMH_FLICK_ANGLE		22.0f
-#define AIMH_STIFFNESS_TRACK	200.0f
-#define AIMH_STIFFNESS_FLICK	360.0f
-#define AIMH_DAMPING_TRACK		32.0f
-#define AIMH_DAMPING_FLICK		16.0f
+#define AIMH_FLICK_ANGLE		28.0f
+#define AIMH_STIFFNESS_TRACK	320.0f
+#define AIMH_STIFFNESS_FLICK	500.0f
+#define AIMH_DAMPING_TRACK		36.0f
+#define AIMH_DAMPING_FLICK		22.0f
 #define AIMH_ROAM_STIFFNESS		80.0f
 #define AIMH_ROAM_DAMPING		40.0f
+/* Combat turn rate multiplier on top of CHARACTERISTIC_VIEW_* (legacy parity target ~2x) */
+#define AIMH_COMBAT_VEL_SCALE	1.85f
+#define AIMH_MOTOR_NOISE_SCALE	2.0f
+
+static int bot_humanizeaim_last = -1;
 
 static float BotAimHarness_AngleDiff(float ang1, float ang2) {
 	float diff;
@@ -44,11 +50,69 @@ static float BotAimHarness_AngleDiff(float ang1, float ang2) {
 	return diff;
 }
 
+/*
+ * Pitch is linear in [-89, 89] for view — never use yaw-style AngleMod wrapping.
+ */
+float BotAimHarness_ClampPitchAngle(float pitch) {
+	if (pitch > 180.0f) {
+		pitch -= 360.0f;
+	}
+	if (pitch < -180.0f) {
+		pitch += 360.0f;
+	}
+	if (pitch > 89.0f) {
+		pitch = 89.0f;
+	}
+	if (pitch < -89.0f) {
+		pitch = -89.0f;
+	}
+	return pitch;
+}
+
+static float BotAimHarness_ClampPitch(float pitch) {
+	return BotAimHarness_ClampPitchAngle(pitch);
+}
+
+static float BotAimHarness_PitchDiff(float pitch, float goal) {
+	return BotAimHarness_ClampPitch(goal) - BotAimHarness_ClampPitch(pitch);
+}
+
+/* Shortest-path goal - view (same sign convention as pitch). */
+static float BotAimHarness_YawDiff(float yaw, float goal) {
+	return BotAimHarness_AngleDiff(goal, yaw);
+}
+
 void BotAimHarness_RegisterCvars(void) {
 	trap_Cvar_Register(&bot_humanizeaim, "bot_humanizeaim", "0", CVAR_ARCHIVE);
+	trap_Cvar_Update(&bot_humanizeaim);
+}
+
+void BotAimHarness_ResetCvarLatch(void) {
+	bot_humanizeaim_last = -1;
+}
+
+void BotAimHarness_UpdateCvar(void) {
+	int i;
+
+	trap_Cvar_Update(&bot_humanizeaim);
+	if (bot_humanizeaim_last == bot_humanizeaim.integer) {
+		return;
+	}
+	bot_humanizeaim_last = bot_humanizeaim.integer;
+
+	for (i = 0; i < MAX_CLIENTS; i++) {
+		if (botstates[i] && botstates[i]->inuse) {
+			BotAimHarness_Reset(botstates[i]);
+			if (!bot_humanizeaim.integer) {
+				botstates[i]->viewanglespeed[0] = 0;
+				botstates[i]->viewanglespeed[1] = 0;
+			}
+		}
+	}
 }
 
 int BotAimHarness_IsActive(void) {
+	trap_Cvar_Update(&bot_humanizeaim);
 	if (!bot_humanizeaim.integer) {
 		return 0;
 	}
@@ -58,8 +122,21 @@ int BotAimHarness_IsActive(void) {
 	return 1;
 }
 
+static void BotAimHarness_SyncViewAngles(bot_state_t *bs) {
+	entityState_t es;
+
+	if (!BotAI_GetEntityState(bs->entitynum, &es)) {
+		return;
+	}
+	bs->viewangles[PITCH] = BotAimHarness_ClampPitch(es.angles[PITCH]);
+	bs->viewangles[YAW] = AngleMod(es.angles[YAW]);
+	bs->viewangles[ROLL] = 0;
+}
+
 void BotAimHarness_Reset(bot_state_t *bs) {
+	BotAimHarness_SyncViewAngles(bs);
 	VectorCopy(bs->viewangles, bs->aimh_goal);
+	VectorCopy(bs->viewangles, bs->ideal_viewangles);
 	bs->aimh_vel[PITCH] = 0.0f;
 	bs->aimh_vel[YAW] = 0.0f;
 	bs->aimh_motor_inaccuracy = 0.0f;
@@ -70,7 +147,12 @@ void BotAimHarness_SetCombatGoal(bot_state_t *bs, const vec3_t idealAngles,
 	float aimAccuracy, float weaponVSpread, float weaponHSpread) {
 	float inaccuracy;
 
+	(void)weaponVSpread;
+	(void)weaponHSpread;
+
 	VectorCopy(idealAngles, bs->aimh_goal);
+	bs->aimh_goal[PITCH] = BotAimHarness_ClampPitch(bs->aimh_goal[PITCH]);
+	bs->aimh_goal[YAW] = AngleMod(bs->aimh_goal[YAW]);
 
 	inaccuracy = 1.0f - aimAccuracy;
 	if (inaccuracy < 0.0f) {
@@ -79,36 +161,78 @@ void BotAimHarness_SetCombatGoal(bot_state_t *bs, const vec3_t idealAngles,
 	if (inaccuracy > 1.0f) {
 		inaccuracy = 1.0f;
 	}
-	bs->aimh_motor_inaccuracy = inaccuracy;
-
-	bs->aimh_goal[PITCH] += 6.0f * weaponVSpread * crandom() * inaccuracy;
-	bs->aimh_goal[PITCH] = AngleMod(bs->aimh_goal[PITCH]);
-	bs->aimh_goal[YAW] += 6.0f * weaponHSpread * crandom() * inaccuracy;
-	bs->aimh_goal[YAW] = AngleMod(bs->aimh_goal[YAW]);
+	/* Continuous jitter via motor noise — not per-think goal hops. */
+	bs->aimh_motor_inaccuracy = inaccuracy * 0.7f;
 
 	bs->aimh_combat_aim = qtrue;
 	VectorCopy(bs->aimh_goal, bs->ideal_viewangles);
 }
 
-static void BotAimHarness_UpdateAxis(bot_state_t *bs, int axis, float goalAngle,
-	float dt, float stiffness, float damping, float maxSpeed, float motorNoise) {
-	float err, accel;
+/*
+ * Re-aim at the live enemy each harness tick (bot think is ~100ms; strafe needs faster goals).
+ */
+static void BotAimHarness_GetCombatGoal(bot_state_t *bs, vec3_t goal) {
+	aas_entityinfo_t entinfo;
+	vec3_t dir, target;
 
-	err = BotAimHarness_AngleDiff(bs->viewangles[axis], goalAngle);
+	if (bs->enemy < 0 || bs->enemy >= MAX_CLIENTS) {
+		VectorCopy(bs->aimh_goal, goal);
+		return;
+	}
+
+	BotEntityInfo(bs->enemy, &entinfo);
+	if (!entinfo.valid) {
+		VectorCopy(bs->aimh_goal, goal);
+		return;
+	}
+
+	if (!VectorCompare(bs->aimtarget, vec3_origin)) {
+		VectorCopy(bs->aimtarget, target);
+	} else {
+		VectorCopy(entinfo.origin, target);
+		target[2] += 8.0f;
+	}
+
+	VectorSubtract(target, bs->eye, dir);
+	vectoangles(dir, goal);
+	goal[PITCH] = BotAimHarness_ClampPitch(goal[PITCH]);
+	goal[YAW] = AngleMod(goal[YAW]);
+}
+
+static void BotAimHarness_UpdateAxis(bot_state_t *bs, int axis, float goalAngle,
+	float dt, float stiffness, float damping, float maxVel, float motorNoise) {
+	float err, accel, delta;
+
+	if (axis == PITCH) {
+		goalAngle = BotAimHarness_ClampPitch(goalAngle);
+		err = BotAimHarness_PitchDiff(bs->viewangles[PITCH], goalAngle);
+	} else {
+		err = BotAimHarness_YawDiff(bs->viewangles[YAW], goalAngle);
+	}
+
 	accel = stiffness * err - damping * bs->aimh_vel[axis];
 	bs->aimh_vel[axis] += accel * dt;
 
-	if (bs->aimh_vel[axis] > maxSpeed) {
-		bs->aimh_vel[axis] = maxSpeed;
-	} else if (bs->aimh_vel[axis] < -maxSpeed) {
-		bs->aimh_vel[axis] = -maxSpeed;
+	/* maxVel is degrees/sec (legacy maxchange before its single * thinktime) */
+	if (bs->aimh_vel[axis] > maxVel) {
+		bs->aimh_vel[axis] = maxVel;
+	} else if (bs->aimh_vel[axis] < -maxVel) {
+		bs->aimh_vel[axis] = -maxVel;
 	}
 
-	bs->viewangles[axis] = AngleMod(bs->viewangles[axis] + bs->aimh_vel[axis] * dt);
-
-	if (motorNoise > 0.01f && fabs(err) < 10.0f) {
-		bs->viewangles[axis] = AngleMod(bs->viewangles[axis] +
-			crandom() * 3.0f * motorNoise * dt * 60.0f);
+	delta = bs->aimh_vel[axis] * dt;
+	if (axis == PITCH) {
+		bs->viewangles[PITCH] = BotAimHarness_ClampPitch(bs->viewangles[PITCH] + delta);
+		if (motorNoise > 0.01f && fabs(err) < 12.0f) {
+			bs->viewangles[PITCH] = BotAimHarness_ClampPitch(bs->viewangles[PITCH] +
+				crandom() * AIMH_MOTOR_NOISE_SCALE * motorNoise * dt * 60.0f * 0.5f);
+		}
+	} else {
+		bs->viewangles[axis] = AngleMod(bs->viewangles[axis] + delta);
+		if (motorNoise > 0.01f && fabs(err) < 12.0f) {
+			bs->viewangles[axis] = AngleMod(bs->viewangles[axis] +
+				crandom() * AIMH_MOTOR_NOISE_SCALE * motorNoise * dt * 60.0f);
+		}
 	}
 }
 
@@ -118,7 +242,7 @@ static void BotAimHarness_UpdateAxis(bot_state_t *bs, int axis, float goalAngle,
 int BotAimHarness_ChangeViewAngles(bot_state_t *bs, float thinktime) {
 	vec3_t goal;
 	float skill, maxChange, maxTrack, maxFlick;
-	float stiffness, damping, maxSpeed, motorNoise;
+	float stiffness, damping, maxVel, motorNoise;
 	float magErr;
 	int i;
 
@@ -136,15 +260,15 @@ int BotAimHarness_ChangeViewAngles(bot_state_t *bs, float thinktime) {
 	}
 
 	if (bs->aimh_combat_aim) {
-		VectorCopy(bs->aimh_goal, goal);
+		BotAimHarness_GetCombatGoal(bs, goal);
 		motorNoise = bs->aimh_motor_inaccuracy;
 		skill = trap_Characteristic_BFloat(bs->character, CHARACTERISTIC_VIEW_FACTOR, 0.01f, 1.0f);
 		maxChange = trap_Characteristic_BFloat(bs->character, CHARACTERISTIC_VIEW_MAXCHANGE, 1.0f, 1800.0f);
 		if (maxChange < 240.0f) {
 			maxChange = 240.0f;
 		}
-		maxTrack = maxChange * skill;
-		maxFlick = maxChange * 1.35f * skill;
+		maxTrack = maxChange * skill * AIMH_COMBAT_VEL_SCALE;
+		maxFlick = maxChange * 1.35f * skill * AIMH_COMBAT_VEL_SCALE;
 	} else {
 		VectorCopy(bs->ideal_viewangles, goal);
 		motorNoise = 0.0f;
@@ -153,44 +277,43 @@ int BotAimHarness_ChangeViewAngles(bot_state_t *bs, float thinktime) {
 		maxFlick = 360.0f;
 	}
 
-	if (goal[PITCH] > 180.0f) {
-		goal[PITCH] -= 360.0f;
-	}
+	goal[PITCH] = BotAimHarness_ClampPitch(goal[PITCH]);
+	bs->viewangles[PITCH] = BotAimHarness_ClampPitch(bs->viewangles[PITCH]);
 
 	{
 		float pitchErr, yawErr;
 
-		pitchErr = BotAimHarness_AngleDiff(bs->viewangles[PITCH], goal[PITCH]);
-		yawErr = BotAimHarness_AngleDiff(bs->viewangles[YAW], goal[YAW]);
+		pitchErr = BotAimHarness_PitchDiff(bs->viewangles[PITCH], goal[PITCH]);
+		yawErr = BotAimHarness_YawDiff(bs->viewangles[YAW], goal[YAW]);
 		magErr = sqrt(pitchErr * pitchErr + yawErr * yawErr);
 	}
 
 	if (bs->aimh_combat_aim && magErr > AIMH_FLICK_ANGLE) {
 		stiffness = AIMH_STIFFNESS_FLICK;
 		damping = AIMH_DAMPING_FLICK;
-		maxSpeed = maxFlick * thinktime;
+		maxVel = maxFlick;
 	} else if (bs->aimh_combat_aim) {
 		stiffness = AIMH_STIFFNESS_TRACK;
 		damping = AIMH_DAMPING_TRACK;
-		maxSpeed = maxTrack * thinktime;
+		maxVel = maxTrack;
 	} else {
 		stiffness = AIMH_ROAM_STIFFNESS;
 		damping = AIMH_ROAM_DAMPING;
-		maxSpeed = maxFlick * thinktime;
+		maxVel = maxFlick;
 	}
 
-	if (maxSpeed < 1.0f) {
-		maxSpeed = 1.0f;
+	if (bs->aimh_combat_aim && maxVel < 140.0f) {
+		maxVel = 140.0f;
+	} else if (maxVel < 90.0f) {
+		maxVel = 90.0f;
 	}
 
 	for (i = 0; i < 2; i++) {
 		BotAimHarness_UpdateAxis(bs, i, goal[i], thinktime,
-			stiffness, damping, maxSpeed, motorNoise);
+			stiffness, damping, maxVel, motorNoise);
 	}
 
-	if (bs->viewangles[PITCH] > 180.0f) {
-		bs->viewangles[PITCH] -= 360.0f;
-	}
+	bs->viewangles[PITCH] = BotAimHarness_ClampPitch(bs->viewangles[PITCH]);
 
 	trap_EA_View(bs->client, bs->viewangles);
 	return 1;

--- a/ratoa_gamecode/code/game/ai_aim_harness.h
+++ b/ratoa_gamecode/code/game/ai_aim_harness.h
@@ -18,7 +18,10 @@ Include after g_local.h and ai_main.h in .c files (ai_main.h has no guards).
 struct bot_state_s;
 
 void BotAimHarness_RegisterCvars(void);
+void BotAimHarness_ResetCvarLatch(void);
+void BotAimHarness_UpdateCvar(void);
 int BotAimHarness_IsActive(void);
+float BotAimHarness_ClampPitchAngle(float pitch);
 
 void BotAimHarness_Reset(struct bot_state_s *bs);
 void BotAimHarness_SetCombatGoal(struct bot_state_s *bs, const float idealAngles[3],

--- a/ratoa_gamecode/code/game/ai_aim_harness.h
+++ b/ratoa_gamecode/code/game/ai_aim_harness.h
@@ -1,0 +1,28 @@
+/*
+===========================================================================
+BOT AIM HARNESS (v1) — humanized view actuation for bots.
+
+Ringfenced module: all harness logic lives in ai_aim_harness.c / this header.
+To remove: delete these files, drop from Makefile/q3asm, revert marked hooks in
+ai_main.h, ai_main.c, and ai_dmq3.c, and unset bot_humanizeaim.
+
+Toggle at runtime: bot_humanizeaim 1 (default 0 = legacy aim motor)
+
+Include after g_local.h and ai_main.h in .c files (ai_main.h has no guards).
+===========================================================================
+*/
+
+#ifndef AI_AIM_HARNESS_H
+#define AI_AIM_HARNESS_H
+
+struct bot_state_s;
+
+void BotAimHarness_RegisterCvars(void);
+int BotAimHarness_IsActive(void);
+
+void BotAimHarness_Reset(struct bot_state_s *bs);
+void BotAimHarness_SetCombatGoal(struct bot_state_s *bs, const float idealAngles[3],
+	float aimAccuracy, float weaponVSpread, float weaponHSpread);
+int BotAimHarness_ChangeViewAngles(struct bot_state_s *bs, float thinktime);
+
+#endif /* AI_AIM_HARNESS_H */

--- a/ratoa_gamecode/code/game/ai_bot_tactics.c
+++ b/ratoa_gamecode/code/game/ai_bot_tactics.c
@@ -1,6 +1,6 @@
 /*
 ===========================================================================
-BOT TACTICAL AI (v1) — see ai_bot_tactics.h
+BOT TACTICAL AI — see ai_bot_tactics.h
 ===========================================================================
 */
 
@@ -18,6 +18,8 @@ BOT TACTICAL AI (v1) — see ai_bot_tactics.h
 #include "ai_bot_tactics.h"
 
 void AIEnter_Battle_Retreat(bot_state_t *bs, char *s);
+void AIEnter_Battle_Fight(bot_state_t *bs, char *s);
+int AINode_Battle_Fight(bot_state_t *bs);
 
 qboolean EntityCarriesFlag(aas_entityinfo_t *entinfo);
 
@@ -27,6 +29,17 @@ vmCvar_t bot_tacticalAI;
 #define BOT_TACTICS_FAR_ENGAGE_DIST		512
 #define BOT_TACTICS_CLOSER_MARGIN		128
 #define BOT_TACTICS_FINISH_HEALTH		40
+#define BOT_TACTICS_HURT_MIN_DAMAGE		8
+#define BOT_TACTICS_FLEE_HEALTH			50
+#define BOT_TACTICS_BIG_DAMAGE			45
+#define BOT_TACTICS_HURT_DEBOUNCE		0.35f
+#define BOT_TACTICS_THREAT_SWITCH_RATIO	1.25f
+
+typedef enum {
+	TACT_ACT_CONTINUE = 0,
+	TACT_ACT_SWITCH,
+	TACT_ACT_FLEE
+} tact_action_t;
 
 static int BotTactics_IsActive(void) {
 	trap_Cvar_Update(&bot_tacticalAI);
@@ -57,6 +70,242 @@ static int BotTactics_IsGauntletOnly(bot_state_t *bs) {
 	return !BotTactics_HasUsableNonGauntletWeapon(bs);
 }
 
+static void BotTactics_AssignEnemy(bot_state_t *bs, int newenemy) {
+	bs->enemy = newenemy;
+	bs->enemysight_time = FloatTime() - 2;
+	bs->enemysuicide = qfalse;
+	bs->enemydeath_time = 0;
+	bs->enemyvisible_time = FloatTime();
+}
+
+static int BotTactics_IsValidEnemyClient(bot_state_t *bs, int clientnum) {
+	aas_entityinfo_t entinfo;
+
+	if (clientnum < 0 || clientnum >= MAX_CLIENTS) {
+		return 0;
+	}
+	if (clientnum == bs->client) {
+		return 0;
+	}
+	if (BotSameTeam(bs, clientnum)) {
+		return 0;
+	}
+	if (EntityClientIsDead(clientnum)) {
+		return 0;
+	}
+	BotEntityInfo(clientnum, &entinfo);
+	if (!entinfo.valid) {
+		return 0;
+	}
+	if (g_entities[clientnum].flags & FL_NOTARGET) {
+		return 0;
+	}
+	return 1;
+}
+
+static int BotTactics_HorizontalDist(bot_state_t *bs, int clientnum) {
+	vec3_t dir;
+	aas_entityinfo_t entinfo;
+
+	BotEntityInfo(clientnum, &entinfo);
+	VectorSubtract(entinfo.origin, bs->origin, dir);
+	dir[2] = 0;
+	return (int)VectorLength(dir);
+}
+
+static float BotTactics_ModThreatBonus(int mod) {
+	switch (mod) {
+	case MOD_RAILGUN:
+		return 90.0f;
+	case MOD_ROCKET:
+	case MOD_ROCKET_SPLASH:
+		return 55.0f;
+	case MOD_PLASMA:
+	case MOD_PLASMA_SPLASH:
+		return 45.0f;
+	case MOD_LIGHTNING:
+		return 50.0f;
+	case MOD_SHOTGUN:
+		return 35.0f;
+	case MOD_MACHINEGUN:
+		return 25.0f;
+	case MOD_BFG:
+	case MOD_BFG_SPLASH:
+		return 60.0f;
+	default:
+		return 10.0f;
+	}
+}
+
+static float BotTactics_ThreatScore(bot_state_t *bs, int clientnum, int damage, int mod) {
+	float score, vis;
+	aas_entityinfo_t entinfo;
+
+	if (!BotTactics_IsValidEnemyClient(bs, clientnum)) {
+		return -1e9f;
+	}
+	BotEntityInfo(clientnum, &entinfo);
+	score = 900.0f - (float)BotTactics_HorizontalDist(bs, clientnum);
+	if (damage > 0) {
+		score += (float)damage * 2.5f;
+	}
+	score += BotTactics_ModThreatBonus(mod);
+	vis = BotEntityVisible(bs->entitynum, bs->eye, bs->viewangles, 360, clientnum);
+	if (vis > 0) {
+		score += 40.0f * vis;
+	}
+	if (EntityIsShooting(&entinfo)) {
+		score += 35.0f;
+	}
+	if (EntityCarriesFlag(&entinfo)) {
+		score += 80.0f;
+	}
+	return score;
+}
+
+static void BotTactics_QueueEvent(bot_state_t *bs, int evt, int attacker, int damage, int mod) {
+	bs->tact_pending |= evt;
+	bs->tact_evt_attacker = attacker;
+	bs->tact_evt_damage = damage;
+	bs->tact_evt_mod = mod;
+}
+
+static void BotTactics_ScanEvents(bot_state_t *bs) {
+	int damage, attacker, mod;
+	gclient_t *cl;
+
+	if (!BotTactics_IsActive()) {
+		bs->tact_pending = 0;
+		return;
+	}
+	if (!bs->inuse || BotIsDead(bs) || BotIsObserver(bs)) {
+		return;
+	}
+
+	damage = bs->lastframe_health - bs->inventory[INVENTORY_HEALTH];
+	if (damage < BOT_TACTICS_HURT_MIN_DAMAGE) {
+		return;
+	}
+	if (FloatTime() - bs->tact_last_hurt_time < BOT_TACTICS_HURT_DEBOUNCE) {
+		return;
+	}
+
+	cl = g_entities[bs->client].client;
+	if (!cl) {
+		return;
+	}
+	attacker = cl->lasthurt_client;
+	mod = cl->lasthurt_mod;
+	if (!BotTactics_IsValidEnemyClient(bs, attacker)) {
+		return;
+	}
+	if (attacker == bs->enemy) {
+		return;
+	}
+
+	bs->tact_last_hurt_time = FloatTime();
+	BotTactics_QueueEvent(bs, BOT_TACT_EVT_HURT_BY_OTHER, attacker, damage, mod);
+}
+
+static tact_action_t BotTactics_DecideHurtByOther(bot_state_t *bs, int attacker, int damage, int mod) {
+	int curenemy;
+	float attackerThreat, currentThreat;
+	aas_entityinfo_t cureinfo;
+
+	if (!BotTactics_IsValidEnemyClient(bs, attacker)) {
+		return TACT_ACT_CONTINUE;
+	}
+
+	curenemy = bs->enemy;
+	attackerThreat = BotTactics_ThreatScore(bs, attacker, damage, mod);
+
+	if (curenemy < 0 || curenemy >= MAX_CLIENTS) {
+		if (attackerThreat > 0) {
+			return TACT_ACT_SWITCH;
+		}
+		return TACT_ACT_CONTINUE;
+	}
+
+	if (!BotTactics_IsValidEnemyClient(bs, curenemy)) {
+		return TACT_ACT_SWITCH;
+	}
+
+	if (g_entities[curenemy].health > 0 &&
+			g_entities[curenemy].health <= BOT_TACTICS_FINISH_HEALTH) {
+		return TACT_ACT_CONTINUE;
+	}
+	BotEntityInfo(curenemy, &cureinfo);
+	if (EntityCarriesFlag(&cureinfo)) {
+		return TACT_ACT_CONTINUE;
+	}
+
+	currentThreat = BotTactics_ThreatScore(bs, curenemy, 0, MOD_UNKNOWN);
+
+	if (bs->inventory[INVENTORY_HEALTH] <= BOT_TACTICS_FLEE_HEALTH &&
+			(damage >= BOT_TACTICS_BIG_DAMAGE ||
+			 mod == MOD_RAILGUN || mod == MOD_ROCKET || mod == MOD_ROCKET_SPLASH)) {
+		if (attackerThreat >= currentThreat) {
+			return TACT_ACT_FLEE;
+		}
+	}
+
+	if (BotTactics_HorizontalDist(bs, attacker) + 96 <
+			BotTactics_HorizontalDist(bs, curenemy)) {
+		if (attackerThreat > currentThreat * 0.85f) {
+			return TACT_ACT_SWITCH;
+		}
+	}
+
+	if (attackerThreat > currentThreat * BOT_TACTICS_THREAT_SWITCH_RATIO) {
+		return TACT_ACT_SWITCH;
+	}
+
+	return TACT_ACT_CONTINUE;
+}
+
+static void BotTactics_ApplyHurtByOther(bot_state_t *bs) {
+	int attacker, damage, mod;
+	tact_action_t action;
+
+	attacker = bs->tact_evt_attacker;
+	damage = bs->tact_evt_damage;
+	mod = bs->tact_evt_mod;
+
+	action = BotTactics_DecideHurtByOther(bs, attacker, damage, mod);
+
+	switch (action) {
+	case TACT_ACT_SWITCH:
+		BotTactics_AssignEnemy(bs, attacker);
+		BotUpdateBattleInventory(bs, attacker);
+		if (bs->ainode != AINode_Battle_Fight) {
+			AIEnter_Battle_Fight(bs, "tactics: switch to aggressor");
+		}
+		break;
+	case TACT_ACT_FLEE:
+		bs->flags |= BFL_TACTICS_SURVIVAL_FLEE;
+		AIEnter_Battle_Retreat(bs, "tactics: flee aggressor");
+		break;
+	default:
+		break;
+	}
+}
+
+static void BotTactics_ProcessPending(bot_state_t *bs) {
+	int pending;
+
+	if (!BotTactics_IsActive()) {
+		bs->tact_pending = 0;
+		return;
+	}
+
+	pending = bs->tact_pending;
+	bs->tact_pending = 0;
+
+	if (pending & BOT_TACT_EVT_HURT_BY_OTHER) {
+		BotTactics_ApplyHurtByOther(bs);
+	}
+}
+
 void BotTactics_RegisterCvars(void) {
 	trap_Cvar_Register(&bot_tacticalAI, "bot_tacticalAI", "0", CVAR_ARCHIVE);
 	trap_Cvar_Update(&bot_tacticalAI);
@@ -67,6 +316,20 @@ void BotTactics_Reset(bot_state_t *bs) {
 		return;
 	}
 	bs->flags &= ~BFL_TACTICS_SURVIVAL_FLEE;
+	bs->tact_pending = 0;
+	bs->tact_evt_attacker = -1;
+	bs->tact_evt_damage = 0;
+	bs->tact_evt_mod = MOD_UNKNOWN;
+	bs->tact_last_hurt_time = -999999.0f;
+}
+
+void BotTactics_OnThink(bot_state_t *bs) {
+	if (!BotTactics_IsActive()) {
+		bs->tact_pending = 0;
+		return;
+	}
+	BotTactics_ScanEvents(bs);
+	BotTactics_ProcessPending(bs);
 }
 
 int BotTactics_BattleFightTryFlee(bot_state_t *bs) {
@@ -135,14 +398,6 @@ int BotTactics_SkipAimAtEnemy(bot_state_t *bs) {
 		return qfalse;
 	}
 	return qtrue;
-}
-
-static void BotTactics_AssignEnemy(bot_state_t *bs, int newenemy) {
-	bs->enemy = newenemy;
-	bs->enemysight_time = FloatTime() - 2;
-	bs->enemysuicide = qfalse;
-	bs->enemydeath_time = 0;
-	bs->enemyvisible_time = FloatTime();
 }
 
 void BotTactics_PreferCloserEnemy(bot_state_t *bs) {

--- a/ratoa_gamecode/code/game/ai_bot_tactics.c
+++ b/ratoa_gamecode/code/game/ai_bot_tactics.c
@@ -1,0 +1,132 @@
+/*
+===========================================================================
+BOT TACTICAL AI (v1) — see ai_bot_tactics.h
+===========================================================================
+*/
+
+#include "g_local.h"
+#include "../botlib/botlib.h"
+#include "../botlib/be_aas.h"
+#include "../botlib/be_ea.h"
+#include "../botlib/be_ai_char.h"
+#include "../botlib/be_ai_goal.h"
+#include "../botlib/be_ai_move.h"
+#include "../botlib/be_ai_weap.h"
+#include "ai_main.h"
+#include "inv.h"
+#include "ai_bot_tactics.h"
+
+void AIEnter_Battle_Retreat(bot_state_t *bs, char *s);
+
+vmCvar_t bot_tacticalAI;
+
+#define BOT_TACTICS_GAUNTLET_RUSH_DIST	192
+
+static int BotTactics_IsActive(void) {
+	trap_Cvar_Update(&bot_tacticalAI);
+	return bot_tacticalAI.integer != 0;
+}
+
+static int BotTactics_HasUsableNonGauntletWeapon(bot_state_t *bs) {
+	int mask;
+	int wp;
+
+	mask = bs->cur_ps.stats[STAT_WEAPONS];
+	for (wp = WP_MACHINEGUN; wp < WP_NUM_WEAPONS; wp++) {
+		if (!(mask & (1 << wp))) {
+			continue;
+		}
+		if (bs->cur_ps.ammo[wp] <= 0) {
+			continue;
+		}
+		return 1;
+	}
+	return 0;
+}
+
+static int BotTactics_IsGauntletOnly(bot_state_t *bs) {
+	if (!(bs->cur_ps.stats[STAT_WEAPONS] & (1 << WP_GAUNTLET))) {
+		return 0;
+	}
+	return !BotTactics_HasUsableNonGauntletWeapon(bs);
+}
+
+void BotTactics_RegisterCvars(void) {
+	trap_Cvar_Register(&bot_tacticalAI, "bot_tacticalAI", "0", CVAR_ARCHIVE);
+	trap_Cvar_Update(&bot_tacticalAI);
+}
+
+void BotTactics_Reset(bot_state_t *bs) {
+	if (!bs) {
+		return;
+	}
+	bs->flags &= ~BFL_TACTICS_SURVIVAL_FLEE;
+}
+
+int BotTactics_BattleFightTryFlee(bot_state_t *bs) {
+	if (!BotTactics_IsActive()) {
+		bs->flags &= ~BFL_TACTICS_SURVIVAL_FLEE;
+		return qfalse;
+	}
+	if (!BotTactics_IsGauntletOnly(bs)) {
+		bs->flags &= ~BFL_TACTICS_SURVIVAL_FLEE;
+		return qfalse;
+	}
+	if (bs->enemy < 0) {
+		return qfalse;
+	}
+	if (bs->inventory[ENEMY_HORIZONTAL_DIST] <= BOT_TACTICS_GAUNTLET_RUSH_DIST) {
+		bs->flags &= ~BFL_TACTICS_SURVIVAL_FLEE;
+		return qfalse;
+	}
+	bs->flags |= BFL_TACTICS_SURVIVAL_FLEE;
+	AIEnter_Battle_Retreat(bs, "tactics: gauntlet survival flee");
+	return qtrue;
+}
+
+int BotTactics_BattleFightSuppressRetreat(bot_state_t *bs) {
+	if (!BotTactics_IsActive()) {
+		return qfalse;
+	}
+	if (!BotTactics_IsGauntletOnly(bs)) {
+		return qfalse;
+	}
+	if (bs->enemy < 0) {
+		return qfalse;
+	}
+	if (bs->inventory[ENEMY_HORIZONTAL_DIST] <= BOT_TACTICS_GAUNTLET_RUSH_DIST) {
+		return qtrue;
+	}
+	return qfalse;
+}
+
+void BotTactics_RetreatAfterInventory(bot_state_t *bs) {
+	if (!BotTactics_IsActive()) {
+		bs->flags &= ~BFL_TACTICS_SURVIVAL_FLEE;
+		return;
+	}
+	if (!BotTactics_IsGauntletOnly(bs)) {
+		bs->flags &= ~BFL_TACTICS_SURVIVAL_FLEE;
+		return;
+	}
+	if (bs->enemy < 0) {
+		bs->flags &= ~BFL_TACTICS_SURVIVAL_FLEE;
+		return;
+	}
+	if (bs->inventory[ENEMY_HORIZONTAL_DIST] > BOT_TACTICS_GAUNTLET_RUSH_DIST) {
+		bs->flags |= BFL_TACTICS_SURVIVAL_FLEE;
+	}
+}
+
+int BotTactics_SkipAimAtEnemy(bot_state_t *bs) {
+	if (!BotTactics_IsActive()) {
+		return qfalse;
+	}
+	if (!(bs->flags & BFL_TACTICS_SURVIVAL_FLEE)) {
+		return qfalse;
+	}
+	if (bs->enemy < 0 || bs->enemy >= MAX_CLIENTS) {
+		return qfalse;
+	}
+	return qtrue;
+}

--- a/ratoa_gamecode/code/game/ai_bot_tactics.c
+++ b/ratoa_gamecode/code/game/ai_bot_tactics.c
@@ -14,13 +14,19 @@ BOT TACTICAL AI (v1) — see ai_bot_tactics.h
 #include "../botlib/be_ai_weap.h"
 #include "ai_main.h"
 #include "inv.h"
+#include "ai_dmq3.h"
 #include "ai_bot_tactics.h"
 
 void AIEnter_Battle_Retreat(bot_state_t *bs, char *s);
 
+qboolean EntityCarriesFlag(aas_entityinfo_t *entinfo);
+
 vmCvar_t bot_tacticalAI;
 
 #define BOT_TACTICS_GAUNTLET_RUSH_DIST	192
+#define BOT_TACTICS_FAR_ENGAGE_DIST		512
+#define BOT_TACTICS_CLOSER_MARGIN		128
+#define BOT_TACTICS_FINISH_HEALTH		40
 
 static int BotTactics_IsActive(void) {
 	trap_Cvar_Update(&bot_tacticalAI);
@@ -129,4 +135,89 @@ int BotTactics_SkipAimAtEnemy(bot_state_t *bs) {
 		return qfalse;
 	}
 	return qtrue;
+}
+
+static void BotTactics_AssignEnemy(bot_state_t *bs, int newenemy) {
+	bs->enemy = newenemy;
+	bs->enemysight_time = FloatTime() - 2;
+	bs->enemysuicide = qfalse;
+	bs->enemydeath_time = 0;
+	bs->enemyvisible_time = FloatTime();
+}
+
+void BotTactics_PreferCloserEnemy(bot_state_t *bs) {
+	int i, curenemy, bestenemy, curhoriz, candhoriz, besthoriz;
+	float vis;
+	vec3_t dir;
+	aas_entityinfo_t entinfo, cureinfo;
+
+	if (!BotTactics_IsActive()) {
+		return;
+	}
+	curenemy = bs->enemy;
+	if (curenemy < 0 || curenemy >= MAX_CLIENTS) {
+		return;
+	}
+	if (EntityClientIsDead(curenemy)) {
+		return;
+	}
+	curhoriz = bs->inventory[ENEMY_HORIZONTAL_DIST];
+	if (curhoriz <= BOT_TACTICS_FAR_ENGAGE_DIST) {
+		return;
+	}
+	if (g_entities[curenemy].health > 0 &&
+			g_entities[curenemy].health <= BOT_TACTICS_FINISH_HEALTH) {
+		return;
+	}
+	BotEntityInfo(curenemy, &cureinfo);
+	if (EntityCarriesFlag(&cureinfo)) {
+		return;
+	}
+
+	bestenemy = -1;
+	besthoriz = 999999;
+	for (i = 0; i < maxclients && i < MAX_CLIENTS; i++) {
+		if (i == bs->client || i == curenemy) {
+			continue;
+		}
+		BotEntityInfo(i, &entinfo);
+		if (!entinfo.valid) {
+			continue;
+		}
+		if (EntityClientIsDead(i) || entinfo.number == bs->entitynum) {
+			continue;
+		}
+		if (EntityIsInvisible(&entinfo) && !EntityIsShooting(&entinfo)) {
+			continue;
+		}
+		if (g_entities[i].flags & FL_NOTARGET) {
+			continue;
+		}
+		if (BotSameTeam(bs, i)) {
+			continue;
+		}
+		VectorSubtract(entinfo.origin, bs->origin, dir);
+		dir[2] = 0;
+		candhoriz = (int)VectorLength(dir);
+		if (candhoriz + BOT_TACTICS_CLOSER_MARGIN >= curhoriz) {
+			continue;
+		}
+		vis = BotEntityVisible(bs->entitynum, bs->eye, bs->viewangles, 360, i);
+		if (vis <= 0) {
+			continue;
+		}
+		if (bestenemy < 0 || candhoriz < besthoriz) {
+			bestenemy = i;
+			besthoriz = candhoriz;
+		}
+	}
+
+	if (bestenemy < 0) {
+		return;
+	}
+	if (bestenemy == curenemy) {
+		return;
+	}
+	BotTactics_AssignEnemy(bs, bestenemy);
+	BotUpdateBattleInventory(bs, bestenemy);
 }

--- a/ratoa_gamecode/code/game/ai_bot_tactics.h
+++ b/ratoa_gamecode/code/game/ai_bot_tactics.h
@@ -23,4 +23,7 @@ int BotTactics_BattleFightSuppressRetreat(struct bot_state_s *bs);
 void BotTactics_RetreatAfterInventory(struct bot_state_s *bs);
 int BotTactics_SkipAimAtEnemy(struct bot_state_s *bs);
 
+/* Prefer a nearer visible threat while engaging someone far away (finish weak targets). */
+void BotTactics_PreferCloserEnemy(struct bot_state_s *bs);
+
 #endif

--- a/ratoa_gamecode/code/game/ai_bot_tactics.h
+++ b/ratoa_gamecode/code/game/ai_bot_tactics.h
@@ -1,11 +1,11 @@
 /*
 ===========================================================================
-BOT TACTICAL AI (v1) — decision hooks, gated by bot_tacticalAI.
+BOT TACTICAL AI — decision hooks + minimal events, gated by bot_tacticalAI.
 
 Ringfenced: logic in ai_bot_tactics.c. Toggle with bot_tacticalAI (0/1).
 
 Remove: delete ai_bot_tactics.c/h, Makefile/q3asm/bat entries, revert hooks in
-ai_main.h, ai_main.c, ai_dmnet.c, ai_dmq3.c.
+ai_main.h, ai_main.c, ai_dmq3.c, ai_dmnet.c.
 ===========================================================================
 */
 
@@ -14,16 +14,22 @@ ai_main.h, ai_main.c, ai_dmnet.c, ai_dmq3.c.
 
 struct bot_state_s;
 
+/* Pending event bits (set by scan/notify, cleared in Process). */
+#define BOT_TACT_EVT_HURT_BY_OTHER	1
+
 void BotTactics_RegisterCvars(void);
 void BotTactics_Reset(struct bot_state_s *bs);
 
-/* Gauntlet-only survival (bot_tacticalAI): flee to items when far, rush when close. */
+/* Once per think after inventory: edge-detect damage, dispatch pending events. */
+void BotTactics_OnThink(struct bot_state_s *bs);
+
+/* Gauntlet-only survival */
 int BotTactics_BattleFightTryFlee(struct bot_state_s *bs);
 int BotTactics_BattleFightSuppressRetreat(struct bot_state_s *bs);
 void BotTactics_RetreatAfterInventory(struct bot_state_s *bs);
 int BotTactics_SkipAimAtEnemy(struct bot_state_s *bs);
 
-/* Prefer a nearer visible threat while engaging someone far away (finish weak targets). */
+/* Prefer a nearer visible threat while engaging someone far away */
 void BotTactics_PreferCloserEnemy(struct bot_state_s *bs);
 
 #endif

--- a/ratoa_gamecode/code/game/ai_bot_tactics.h
+++ b/ratoa_gamecode/code/game/ai_bot_tactics.h
@@ -1,0 +1,26 @@
+/*
+===========================================================================
+BOT TACTICAL AI (v1) — decision hooks, gated by bot_tacticalAI.
+
+Ringfenced: logic in ai_bot_tactics.c. Toggle with bot_tacticalAI (0/1).
+
+Remove: delete ai_bot_tactics.c/h, Makefile/q3asm/bat entries, revert hooks in
+ai_main.h, ai_main.c, ai_dmnet.c, ai_dmq3.c.
+===========================================================================
+*/
+
+#ifndef AI_BOT_TACTICS_H
+#define AI_BOT_TACTICS_H
+
+struct bot_state_s;
+
+void BotTactics_RegisterCvars(void);
+void BotTactics_Reset(struct bot_state_s *bs);
+
+/* Gauntlet-only survival (bot_tacticalAI): flee to items when far, rush when close. */
+int BotTactics_BattleFightTryFlee(struct bot_state_s *bs);
+int BotTactics_BattleFightSuppressRetreat(struct bot_state_s *bs);
+void BotTactics_RetreatAfterInventory(struct bot_state_s *bs);
+int BotTactics_SkipAimAtEnemy(struct bot_state_s *bs);
+
+#endif

--- a/ratoa_gamecode/code/game/ai_dmnet.c
+++ b/ratoa_gamecode/code/game/ai_dmnet.c
@@ -2132,7 +2132,7 @@ int AINode_Battle_Fight(bot_state_t *bs) {
 		}
 	}
 	else {
-		if (EntityIsDead(&entinfo)) {
+		if (EntityClientIsDead(bs->enemy)) {
 			bs->enemydeath_time = FloatTime();
 		}
 	}
@@ -2276,7 +2276,12 @@ int AINode_Battle_Chase(bot_state_t *bs)
 	}
 	//if the enemy is visible
 	if (BotEntityVisible(bs->entitynum, bs->eye, bs->viewangles, 360, bs->enemy)) {
-		AIEnter_Battle_Fight(bs, "battle chase");
+		if (!EntityClientIsDead(bs->enemy)) {
+			AIEnter_Battle_Fight(bs, "battle chase");
+			return qfalse;
+		}
+		bs->enemy = -1;
+		AIEnter_Seek_LTG(bs, "battle chase: enemy dead");
 		return qfalse;
 	}
 	//if there is another enemy
@@ -2415,11 +2420,11 @@ int AINode_Battle_Retreat(bot_state_t *bs) {
 		return qfalse;
 	}
 	//
-	BotEntityInfo(bs->enemy, &entinfo);
-	if (EntityIsDead(&entinfo)) {
+	if (EntityClientIsDead(bs->enemy)) {
 		AIEnter_Seek_LTG(bs, "battle retreat: enemy dead");
 		return qfalse;
 	}
+	BotEntityInfo(bs->enemy, &entinfo);
 	//if there is another better enemy
 	if (BotFindEnemy(bs, bs->enemy)) {
 #ifdef DEBUG
@@ -2602,11 +2607,11 @@ int AINode_Battle_NBG(bot_state_t *bs) {
 		return qfalse;
 	}
 	//
-	BotEntityInfo(bs->enemy, &entinfo);
-	if (EntityIsDead(&entinfo)) {
+	if (EntityClientIsDead(bs->enemy)) {
 		AIEnter_Seek_NBG(bs, "battle nbg: enemy dead");
 		return qfalse;
 	}
+	BotEntityInfo(bs->enemy, &entinfo);
 	//
 	bs->tfl = TFL_DEFAULT;
 	if (bot_grapple.integer) bs->tfl |= TFL_GRAPPLEHOOK;

--- a/ratoa_gamecode/code/game/ai_dmnet.c
+++ b/ratoa_gamecode/code/game/ai_dmnet.c
@@ -42,6 +42,7 @@ Foundation, Inc., 51 Franklin St, Fifth Floor, Boston, MA  02110-1301  USA
 #include "../botlib/be_ai_weap.h"
 //
 #include "ai_main.h"
+#include "ai_bot_tactics.h"
 #include "ai_dmq3.h"
 #include "ai_chat.h"
 #include "ai_cmd.h"
@@ -2161,6 +2162,9 @@ int AINode_Battle_Fight(bot_state_t *bs) {
 	}
 	//update the attack inventory values
 	BotUpdateBattleInventory(bs, bs->enemy);
+	if (BotTactics_BattleFightTryFlee(bs)) {
+		return qfalse;
+	}
 	//if the bot's health decreased
 	if (bs->lastframe_health > bs->inventory[INVENTORY_HEALTH]) {
 		if (BotChat_HitNoDeath(bs)) {
@@ -2224,7 +2228,7 @@ int AINode_Battle_Fight(bot_state_t *bs) {
 	BotCheckAttack(bs);
 	//if the bot wants to retreat
 	if (!(bs->flags & BFL_FIGHTSUICIDAL)) {
-		if (BotWantsToRetreat(bs)) {
+		if (!BotTactics_BattleFightSuppressRetreat(bs) && BotWantsToRetreat(bs)) {
 			AIEnter_Battle_Retreat(bs, "battle fight: wants to retreat");
 			return qtrue;
 		}
@@ -2440,6 +2444,7 @@ int AINode_Battle_Retreat(bot_state_t *bs) {
 	BotMapScripts(bs);
 	//update the attack inventory values
 	BotUpdateBattleInventory(bs, bs->enemy);
+	BotTactics_RetreatAfterInventory(bs);
 	//if the bot doesn't want to retreat anymore... probably picked up some nice items
 	if (BotWantsToChase(bs)) {
 		//empty the goal stack, when chasing, only the enemy is the goal

--- a/ratoa_gamecode/code/game/ai_dmnet.c
+++ b/ratoa_gamecode/code/game/ai_dmnet.c
@@ -2162,6 +2162,7 @@ int AINode_Battle_Fight(bot_state_t *bs) {
 	}
 	//update the attack inventory values
 	BotUpdateBattleInventory(bs, bs->enemy);
+	BotTactics_PreferCloserEnemy(bs);
 	if (BotTactics_BattleFightTryFlee(bs)) {
 		return qfalse;
 	}
@@ -2337,6 +2338,7 @@ int AINode_Battle_Chase(bot_state_t *bs)
 	}
 	//
 	BotUpdateBattleInventory(bs, bs->enemy);
+	BotTactics_PreferCloserEnemy(bs);
 	//initialize the movement state
 	BotSetupForMovement(bs);
 	//move towards the goal

--- a/ratoa_gamecode/code/game/ai_dmq3.c
+++ b/ratoa_gamecode/code/game/ai_dmq3.c
@@ -45,6 +45,7 @@ Foundation, Inc., 51 Franklin St, Fifth Floor, Boston, MA  02110-1301  USA
 #include "ai_main.h"
 #include "ai_dmq3.h"
 #include "ai_aim_harness.h"
+#include "ai_weapon_select.h"
 #include "ai_chat.h"
 #include "ai_cmd.h"
 #include "ai_dmnet.h"
@@ -1720,7 +1721,9 @@ BotChooseWeapon
 */
 void BotChooseWeapon(bot_state_t *bs) {
 	int newweaponnum;
+	int prevweaponnum;
 
+	prevweaponnum = bs->weaponnum;
 	if (bs->cur_ps.weaponstate == WEAPON_RAISING ||
 			bs->cur_ps.weaponstate == WEAPON_DROPPING) {
 		trap_EA_SelectWeapon(bs->client, bs->weaponnum);
@@ -1730,10 +1733,15 @@ void BotChooseWeapon(bot_state_t *bs) {
                     newweaponnum = WP_RAILGUN;
                 else if(g_rockets.integer)
                     newweaponnum = WP_ROCKET_LAUNCHER;
-                else
-                    newweaponnum = trap_BotChooseBestFightWeapon(bs->ws, bs->inventory);
+                else {
+			newweaponnum = BotWpnSelect_Choose(bs);
+			if (newweaponnum < 0 || newweaponnum >= WP_NUM_WEAPONS) {
+				newweaponnum = trap_BotChooseBestFightWeapon(bs->ws, bs->inventory);
+			}
+		}
 		if (bs->weaponnum != newweaponnum) bs->weaponchange_time = FloatTime();
 		bs->weaponnum = newweaponnum;
+		BotWpnSelect_NotifyWeaponCommitted(bs, prevweaponnum, newweaponnum);
 		//BotAI_Print(PRT_MESSAGE, "bs->weaponnum = %d\n", bs->weaponnum);
 		trap_EA_SelectWeapon(bs->client, bs->weaponnum);
 	}

--- a/ratoa_gamecode/code/game/ai_dmq3.c
+++ b/ratoa_gamecode/code/game/ai_dmq3.c
@@ -44,6 +44,7 @@ Foundation, Inc., 51 Franklin St, Fifth Floor, Boston, MA  02110-1301  USA
 //
 #include "ai_main.h"
 #include "ai_dmq3.h"
+#include "ai_aim_harness.h"
 #include "ai_chat.h"
 #include "ai_cmd.h"
 #include "ai_dmnet.h"
@@ -3610,9 +3611,11 @@ void BotAimAtEnemy(bot_state_t *bs) {
 				}
 			}
 		}
-		bestorigin[0] += 20 * crandom() * (1 - aim_accuracy);
-		bestorigin[1] += 20 * crandom() * (1 - aim_accuracy);
-		bestorigin[2] += 10 * crandom() * (1 - aim_accuracy);
+		if (!BotAimHarness_IsActive()) {
+			bestorigin[0] += 20 * crandom() * (1 - aim_accuracy);
+			bestorigin[1] += 20 * crandom() * (1 - aim_accuracy);
+			bestorigin[2] += 10 * crandom() * (1 - aim_accuracy);
+		}
 	}
 	else {
 		//
@@ -3663,18 +3666,22 @@ void BotAimAtEnemy(bot_state_t *bs) {
 		f = 0.6 + dist / 150 * 0.4;
 		aim_accuracy *= f;
 	}
-	//add some random stuff to the aim direction depending on the aim accuracy
-	if (aim_accuracy < 0.8) {
-		VectorNormalize(dir);
-		for (i = 0; i < 3; i++) dir[i] += 0.3 * crandom() * (1 - aim_accuracy);
+	if (!BotAimHarness_IsActive()) {
+		if (aim_accuracy < 0.8) {
+			VectorNormalize(dir);
+			for (i = 0; i < 3; i++) dir[i] += 0.3 * crandom() * (1 - aim_accuracy);
+		}
 	}
-	//set the ideal view angles
 	vectoangles(dir, bs->ideal_viewangles);
-	//take the weapon spread into account for lower skilled bots
-	bs->ideal_viewangles[PITCH] += 6 * wi.vspread * crandom() * (1 - aim_accuracy);
-	bs->ideal_viewangles[PITCH] = AngleMod(bs->ideal_viewangles[PITCH]);
-	bs->ideal_viewangles[YAW] += 6 * wi.hspread * crandom() * (1 - aim_accuracy);
-	bs->ideal_viewangles[YAW] = AngleMod(bs->ideal_viewangles[YAW]);
+	if (!BotAimHarness_IsActive()) {
+		bs->ideal_viewangles[PITCH] += 6 * wi.vspread * crandom() * (1 - aim_accuracy);
+		bs->ideal_viewangles[PITCH] = AngleMod(bs->ideal_viewangles[PITCH]);
+		bs->ideal_viewangles[YAW] += 6 * wi.hspread * crandom() * (1 - aim_accuracy);
+		bs->ideal_viewangles[YAW] = AngleMod(bs->ideal_viewangles[YAW]);
+	} else {
+		BotAimHarness_SetCombatGoal(bs, bs->ideal_viewangles, aim_accuracy,
+			wi.vspread, wi.hspread);
+	}
 	//if the bots should be really challenging
 	if (bot_challenge.integer) {
 		//if the bot is really accurate and has the enemy in view for some time

--- a/ratoa_gamecode/code/game/ai_dmq3.c
+++ b/ratoa_gamecode/code/game/ai_dmq3.c
@@ -234,15 +234,43 @@ bot_goal_t *BotTeamFlag(bot_state_t *bs) {
 EntityIsDead
 ==================
 */
-qboolean EntityIsDead(aas_entityinfo_t *entinfo) {
+qboolean EntityClientIsDead(int clientNum) {
 	playerState_t ps;
 
-	if (entinfo->number >= 0 && entinfo->number < MAX_CLIENTS) {
-		//retrieve the current client state
-		BotAI_GetClientState( entinfo->number, &ps );
-		if (ps.pm_type != PM_NORMAL) return qtrue;
+	if (clientNum < 0 || clientNum >= MAX_CLIENTS) {
+		return qfalse;
+	}
+	if (!BotAI_GetClientState(clientNum, &ps)) {
+		return qtrue;
+	}
+	if (ps.pm_type != PM_NORMAL) {
+		return qtrue;
+	}
+	if (ps.stats[STAT_HEALTH] <= 0) {
+		return qtrue;
 	}
 	return qfalse;
+}
+
+/*
+==================
+EntityIsDead
+==================
+*/
+qboolean EntityIsDead(aas_entityinfo_t *entinfo) {
+	return EntityClientIsDead(entinfo->number);
+}
+
+/*
+==================
+BotTargetPlayerIsDead
+==================
+*/
+qboolean BotTargetPlayerIsDead(bot_state_t *bs) {
+	if (bs->enemy < 0 || bs->enemy >= MAX_CLIENTS) {
+		return qfalse;
+	}
+	return EntityClientIsDead(bs->enemy);
 }
 
 /*
@@ -3079,6 +3107,10 @@ int BotFindEnemy(bot_state_t *bs, int curenemy) {
 	//remember the current health value
 	bs->lasthealth = bs->inventory[INVENTORY_HEALTH];
 	//
+	if (curenemy >= 0 && curenemy < MAX_CLIENTS && EntityClientIsDead(curenemy)) {
+		bs->enemy = -1;
+		curenemy = -1;
+	}
 	if (curenemy >= 0) {
 		BotEntityInfo(curenemy, &curenemyinfo);
 		if (EntityCarriesFlag(&curenemyinfo)) return qfalse;
@@ -3126,7 +3158,7 @@ int BotFindEnemy(bot_state_t *bs, int curenemy) {
 		//
 		if (!entinfo.valid) continue;
 		//if the enemy isn't dead and the enemy isn't the bot self
-		if (EntityIsDead(&entinfo) || entinfo.number == bs->entitynum) continue;
+		if (EntityClientIsDead(i) || entinfo.number == bs->entitynum) continue;
 		//if the enemy is invisible and not shooting
 		if (EntityIsInvisible(&entinfo) && !EntityIsShooting(&entinfo)) {
 			continue;
@@ -3271,6 +3303,8 @@ int BotEnemyFlagCarrierVisible(bot_state_t *bs) {
 		//if this player is active
 		if (!entinfo.valid)
 			continue;
+		if (EntityIsDead(&entinfo))
+			continue;
 		//if this player is carrying a flag
 		if (!EntityCarriesFlag(&entinfo))
 			continue;
@@ -3414,6 +3448,9 @@ void BotAimAtEnemy(bot_state_t *bs) {
 
 	//if the bot has no enemy
 	if (bs->enemy < 0) {
+		return;
+	}
+	if (BotTargetPlayerIsDead(bs)) {
 		return;
 	}
 	//get the enemy entity information
@@ -3710,6 +3747,12 @@ void BotCheckAttack(bot_state_t *bs) {
 	aas_entityinfo_t entinfo;
 	vec3_t mins = {-8, -8, -8}, maxs = {8, 8, 8};
 
+	if (bs->enemy < 0) {
+		return;
+	}
+	if (BotTargetPlayerIsDead(bs)) {
+		return;
+	}
 	attackentity = bs->enemy;
 	//
 	BotEntityInfo(attackentity, &entinfo);

--- a/ratoa_gamecode/code/game/ai_dmq3.c
+++ b/ratoa_gamecode/code/game/ai_dmq3.c
@@ -46,6 +46,7 @@ Foundation, Inc., 51 Franklin St, Fifth Floor, Boston, MA  02110-1301  USA
 #include "ai_dmq3.h"
 #include "ai_aim_harness.h"
 #include "ai_weapon_select.h"
+#include "ai_bot_tactics.h"
 #include "ai_chat.h"
 #include "ai_cmd.h"
 #include "ai_dmnet.h"
@@ -3477,6 +3478,9 @@ void BotAimAtEnemy(bot_state_t *bs) {
 		vectoangles(dir, bs->ideal_viewangles);
 		//set the aim target before trying to attack
 		VectorCopy(target, bs->aimtarget);
+		return;
+	}
+	if (BotTactics_SkipAimAtEnemy(bs)) {
 		return;
 	}
 	//

--- a/ratoa_gamecode/code/game/ai_dmq3.c
+++ b/ratoa_gamecode/code/game/ai_dmq3.c
@@ -5449,6 +5449,7 @@ void BotDeathmatchAI(bot_state_t *bs, float thinktime) {
 		BotSetTeleportTime(bs);
 		//update some inventory values
 		BotUpdateInventory(bs);
+		BotTactics_OnThink(bs);
 		//check out the snapshot
 		BotCheckSnapshot(bs);
 		//check for air

--- a/ratoa_gamecode/code/game/ai_dmq3.h
+++ b/ratoa_gamecode/code/game/ai_dmq3.h
@@ -56,8 +56,12 @@ qboolean BotIsObserver(bot_state_t *bs);
 qboolean BotIntermission(bot_state_t *bs);
 //returns true if the bot is in lava or slime
 qboolean BotInLavaOrSlime(bot_state_t *bs);
+//returns true if the client is dead (use clientNum, not entinfo fields alone)
+qboolean EntityClientIsDead(int clientNum);
 //returns true if the entity is dead
 qboolean EntityIsDead(aas_entityinfo_t *entinfo);
+//returns true if bs->enemy is a dead player
+qboolean BotTargetPlayerIsDead(bot_state_t *bs);
 //returns true if the entity is invisible
 qboolean EntityIsInvisible(aas_entityinfo_t *entinfo);
 //returns true if the entity is shooting

--- a/ratoa_gamecode/code/game/ai_main.c
+++ b/ratoa_gamecode/code/game/ai_main.c
@@ -944,7 +944,12 @@ void BotUpdateInput(bot_state_t *bs, int time, int elapsed_time) {
 
 	//add the delta angles to the bot's current view angles
 	for (j = 0; j < 3; j++) {
-		bs->viewangles[j] = AngleMod(bs->viewangles[j] + SHORT2ANGLE(bs->cur_ps.delta_angles[j]));
+		if (j == PITCH && BotAimHarness_IsActive()) {
+			bs->viewangles[PITCH] = BotAimHarness_ClampPitchAngle(bs->viewangles[PITCH] +
+				SHORT2ANGLE(bs->cur_ps.delta_angles[PITCH]));
+		} else {
+			bs->viewangles[j] = AngleMod(bs->viewangles[j] + SHORT2ANGLE(bs->cur_ps.delta_angles[j]));
+		}
 	}
 	//change the bot view angles
 	BotChangeViewAngles(bs, (float) elapsed_time / 1000);
@@ -958,7 +963,12 @@ void BotUpdateInput(bot_state_t *bs, int time, int elapsed_time) {
 	BotInputToUserCommand(&bi, &bs->lastucmd, bs->cur_ps.delta_angles, time);
 	//subtract the delta angles
 	for (j = 0; j < 3; j++) {
-		bs->viewangles[j] = AngleMod(bs->viewangles[j] - SHORT2ANGLE(bs->cur_ps.delta_angles[j]));
+		if (j == PITCH && BotAimHarness_IsActive()) {
+			bs->viewangles[PITCH] = BotAimHarness_ClampPitchAngle(bs->viewangles[PITCH] -
+				SHORT2ANGLE(bs->cur_ps.delta_angles[PITCH]));
+		} else {
+			bs->viewangles[j] = AngleMod(bs->viewangles[j] - SHORT2ANGLE(bs->cur_ps.delta_angles[j]));
+		}
 	}
 }
 
@@ -1066,7 +1076,12 @@ int BotAI(int client, float thinktime) {
 	}
 	//add the delta angles to the bot's current view angles
 	for (j = 0; j < 3; j++) {
-		bs->viewangles[j] = AngleMod(bs->viewangles[j] + SHORT2ANGLE(bs->cur_ps.delta_angles[j]));
+		if (j == PITCH && BotAimHarness_IsActive()) {
+			bs->viewangles[PITCH] = BotAimHarness_ClampPitchAngle(bs->viewangles[PITCH] +
+				SHORT2ANGLE(bs->cur_ps.delta_angles[j]));
+		} else {
+			bs->viewangles[j] = AngleMod(bs->viewangles[j] + SHORT2ANGLE(bs->cur_ps.delta_angles[j]));
+		}
 	}
 	//increase the local time of the bot
 	bs->ltime += thinktime;
@@ -1085,7 +1100,12 @@ int BotAI(int client, float thinktime) {
 	trap_EA_SelectWeapon(bs->client, bs->weaponnum);
 	//subtract the delta angles
 	for (j = 0; j < 3; j++) {
-		bs->viewangles[j] = AngleMod(bs->viewangles[j] - SHORT2ANGLE(bs->cur_ps.delta_angles[j]));
+		if (j == PITCH && BotAimHarness_IsActive()) {
+			bs->viewangles[PITCH] = BotAimHarness_ClampPitchAngle(bs->viewangles[PITCH] -
+				SHORT2ANGLE(bs->cur_ps.delta_angles[j]));
+		} else {
+			bs->viewangles[j] = AngleMod(bs->viewangles[j] - SHORT2ANGLE(bs->cur_ps.delta_angles[j]));
+		}
 	}
 	//everything was ok
 	return qtrue;
@@ -1414,6 +1434,7 @@ int BotAILoadMap( int restart ) {
 	}
 
 	BotSetupDeathmatchAI();
+	BotAimHarness_ResetCvarLatch();
 
 	return qtrue;
 }
@@ -1446,6 +1467,7 @@ int BotAIStartFrame(int time) {
 	trap_Cvar_Update(&bot_saveroutingcache);
 	trap_Cvar_Update(&bot_pause);
 	trap_Cvar_Update(&bot_report);
+	BotAimHarness_UpdateCvar();
 
 	if (bot_report.integer) {
 //		BotTeamplayReport();
@@ -1722,6 +1744,7 @@ int BotAISetup( int restart ) {
 
 	errnum = BotInitLibrary();
 	if (errnum != BLERR_NOERROR) return qfalse;
+	BotAimHarness_ResetCvarLatch();
 	return qtrue;
 }
 

--- a/ratoa_gamecode/code/game/ai_main.c
+++ b/ratoa_gamecode/code/game/ai_main.c
@@ -51,6 +51,7 @@ Foundation, Inc., 51 Franklin St, Fifth Floor, Boston, MA  02110-1301  USA
 #include "ai_vcmd.h"
 #include "ai_aim_harness.h"
 #include "ai_weapon_select.h"
+#include "ai_bot_tactics.h"
 
 //
 #include "chars.h"
@@ -1309,6 +1310,7 @@ int BotAISetupClient(int client, struct bot_settings_s *settings, qboolean resta
 	}
 	BotAimHarness_Reset(bs);
 	BotWpnSelect_Reset(bs);
+	BotTactics_Reset(bs);
 	//bot has been setup succesfully
 	return qtrue;
 }
@@ -1413,6 +1415,7 @@ void BotResetState(bot_state_t *bs) {
 	if (bs->ms) trap_BotResetAvoidReach(bs->ms);
 	BotAimHarness_Reset(bs);
 	BotWpnSelect_Reset(bs);
+	BotTactics_Reset(bs);
 }
 
 /*
@@ -1737,6 +1740,7 @@ int BotAISetup( int restart ) {
 	trap_Cvar_Register(&bot_interbreedwrite, "bot_interbreedwrite", "", 0);
 	BotAimHarness_RegisterCvars();
 	BotWpnSelect_RegisterCvars();
+	BotTactics_RegisterCvars();
 
 	//if the game is restarted for a tournament
 	if (restart) {

--- a/ratoa_gamecode/code/game/ai_main.c
+++ b/ratoa_gamecode/code/game/ai_main.c
@@ -49,6 +49,7 @@ Foundation, Inc., 51 Franklin St, Fifth Floor, Boston, MA  02110-1301  USA
 #include "ai_cmd.h"
 #include "ai_dmnet.h"
 #include "ai_vcmd.h"
+#include "ai_aim_harness.h"
 
 //
 #include "chars.h"
@@ -783,6 +784,11 @@ void BotChangeViewAngles(bot_state_t *bs, float thinktime) {
 	float diff, factor, maxchange, anglespeed, disired_speed;
 	int i;
 
+	/* BOT AIM HARNESS (v1): optional humanized view motor */
+	if (BotAimHarness_ChangeViewAngles(bs, thinktime)) {
+		return;
+	}
+
 	if (bs->ideal_viewangles[PITCH] > 180) bs->ideal_viewangles[PITCH] -= 360;
 	//
 	if (bs->enemy >= 0) {
@@ -1280,6 +1286,7 @@ int BotAISetupClient(int client, struct bot_settings_s *settings, qboolean resta
 	if (restart) {
 		BotReadSessionData(bs);
 	}
+	BotAimHarness_Reset(bs);
 	//bot has been setup succesfully
 	return qtrue;
 }
@@ -1382,6 +1389,7 @@ void BotResetState(bot_state_t *bs) {
 	if (bs->ws) trap_BotResetWeaponState(bs->ws);
 	if (bs->gs) trap_BotResetAvoidGoals(bs->gs);
 	if (bs->ms) trap_BotResetAvoidReach(bs->ms);
+	BotAimHarness_Reset(bs);
 }
 
 /*
@@ -1702,6 +1710,7 @@ int BotAISetup( int restart ) {
 	trap_Cvar_Register(&bot_interbreedbots, "bot_interbreedbots", "10", 0);
 	trap_Cvar_Register(&bot_interbreedcycle, "bot_interbreedcycle", "20", 0);
 	trap_Cvar_Register(&bot_interbreedwrite, "bot_interbreedwrite", "", 0);
+	BotAimHarness_RegisterCvars();
 
 	//if the game is restarted for a tournament
 	if (restart) {

--- a/ratoa_gamecode/code/game/ai_main.c
+++ b/ratoa_gamecode/code/game/ai_main.c
@@ -50,6 +50,7 @@ Foundation, Inc., 51 Franklin St, Fifth Floor, Boston, MA  02110-1301  USA
 #include "ai_dmnet.h"
 #include "ai_vcmd.h"
 #include "ai_aim_harness.h"
+#include "ai_weapon_select.h"
 
 //
 #include "chars.h"
@@ -1307,6 +1308,7 @@ int BotAISetupClient(int client, struct bot_settings_s *settings, qboolean resta
 		BotReadSessionData(bs);
 	}
 	BotAimHarness_Reset(bs);
+	BotWpnSelect_Reset(bs);
 	//bot has been setup succesfully
 	return qtrue;
 }
@@ -1410,6 +1412,7 @@ void BotResetState(bot_state_t *bs) {
 	if (bs->gs) trap_BotResetAvoidGoals(bs->gs);
 	if (bs->ms) trap_BotResetAvoidReach(bs->ms);
 	BotAimHarness_Reset(bs);
+	BotWpnSelect_Reset(bs);
 }
 
 /*
@@ -1733,6 +1736,7 @@ int BotAISetup( int restart ) {
 	trap_Cvar_Register(&bot_interbreedcycle, "bot_interbreedcycle", "20", 0);
 	trap_Cvar_Register(&bot_interbreedwrite, "bot_interbreedwrite", "", 0);
 	BotAimHarness_RegisterCvars();
+	BotWpnSelect_RegisterCvars();
 
 	//if the game is restarted for a tournament
 	if (restart) {

--- a/ratoa_gamecode/code/game/ai_main.h
+++ b/ratoa_gamecode/code/game/ai_main.h
@@ -286,6 +286,13 @@ typedef struct bot_state_s
 	bot_waypoint_t *patrolpoints;					//patrol points
 	bot_waypoint_t *curpatrolpoint;					//current patrol point the bot is going for
 	int patrolflags;								//patrol flags
+
+	/* ---- BOT AIM HARNESS (v1): ai_aim_harness.c — remove this block to revert ---- */
+	vec3_t		aimh_goal;
+	float		aimh_vel[2];
+	float		aimh_motor_inaccuracy;
+	qboolean	aimh_combat_aim;
+	/* ---- end BOT AIM HARNESS ---- */
 } bot_state_t;
 
 //resets the whole bot state

--- a/ratoa_gamecode/code/game/ai_main.h
+++ b/ratoa_gamecode/code/game/ai_main.h
@@ -293,6 +293,14 @@ typedef struct bot_state_s
 	float		aimh_motor_inaccuracy;
 	qboolean	aimh_combat_aim;
 	/* ---- end BOT AIM HARNESS ---- */
+
+	/* ---- BOT SMART WEAPON SELECT (v1): ai_weapon_select.c — remove to revert ---- */
+	float		wps_next_eval_time;
+	float		wps_last_switch_time;
+	int			wps_last_chosen_weapon;
+	int			wps_desired_weapon;
+	float		wps_desire_strength;
+	/* ---- end BOT SMART WEAPON SELECT ---- */
 } bot_state_t;
 
 //resets the whole bot state

--- a/ratoa_gamecode/code/game/ai_main.h
+++ b/ratoa_gamecode/code/game/ai_main.h
@@ -42,6 +42,7 @@ Foundation, Inc., 51 Franklin St, Fifth Floor, Boston, MA  02110-1301  USA
 #define BFL_AVOIDRIGHT				16	//avoid obstacles by going to the right
 #define BFL_IDEALVIEWSET			32	//bot has ideal view angles set
 #define BFL_FIGHTSUICIDAL			64	//bot is in a suicidal fight
+#define BFL_TACTICS_SURVIVAL_FLEE		128	//ai_bot_tactics: gauntlet flee, skip aim-at-enemy
 //long term goal types
 #define LTG_TEAMHELP				1	//help a team mate
 #define LTG_TEAMACCOMPANY			2	//accompany a team mate

--- a/ratoa_gamecode/code/game/ai_main.h
+++ b/ratoa_gamecode/code/game/ai_main.h
@@ -293,6 +293,13 @@ typedef struct bot_state_s
 	float		aimh_vel[2];
 	float		aimh_motor_inaccuracy;
 	qboolean	aimh_combat_aim;
+	float		aimh_last_enemy_z;
+	float		aimh_next_sanity_time;
+	float		aimh_bad_aim_since;
+	float		aimh_recover_until;
+	float		aimh_acquire_until;
+	int			aimh_last_sanity_enemy;
+	int			aimh_sanity_miss_streak;
 	/* ---- end BOT AIM HARNESS ---- */
 
 	/* ---- BOT SMART WEAPON SELECT (v1): ai_weapon_select.c — remove to revert ---- */

--- a/ratoa_gamecode/code/game/ai_main.h
+++ b/ratoa_gamecode/code/game/ai_main.h
@@ -302,6 +302,14 @@ typedef struct bot_state_s
 	int			wps_desired_weapon;
 	float		wps_desire_strength;
 	/* ---- end BOT SMART WEAPON SELECT ---- */
+
+	/* ---- BOT TACTICAL AI: ai_bot_tactics.c — remove this block to revert ---- */
+	int			tact_pending;
+	int			tact_evt_attacker;
+	int			tact_evt_damage;
+	int			tact_evt_mod;
+	float		tact_last_hurt_time;
+	/* ---- end BOT TACTICAL AI ---- */
 } bot_state_t;
 
 //resets the whole bot state

--- a/ratoa_gamecode/code/game/ai_weapon_select.c
+++ b/ratoa_gamecode/code/game/ai_weapon_select.c
@@ -1,0 +1,413 @@
+/*
+===========================================================================
+BOT SMART WEAPON SELECT (v1) — see ai_weapon_select.h
+===========================================================================
+*/
+
+#include "g_local.h"
+#include "../botlib/botlib.h"
+#include "../botlib/be_aas.h"
+#include "../botlib/be_ea.h"
+#include "../botlib/be_ai_char.h"
+#include "../botlib/be_ai_goal.h"
+#include "../botlib/be_ai_move.h"
+#include "../botlib/be_ai_weap.h"
+#include "ai_main.h"
+#include "chars.h"
+#include "inv.h"
+#include "ai_weapon_select.h"
+
+vmCvar_t bot_smartWeaponChoice;
+
+/* Forward — defined in ai_dmq3.c */
+float BotEntityVisible(int viewer, vec3_t eye, vec3_t viewangles, float fov, int ent);
+
+#define WPNSEL_LEGACY_BIAS		28.0f
+#define WPNSEL_HYSTERESIS_BASE	12.0f
+#define WPNSEL_HYSTERESIS_SKILL	22.0f
+#define WPNSEL_NOISE_MAX		42.0f
+#define WPNSEL_EVAL_MIN			0.06f
+#define WPNSEL_EVAL_MAX			0.28f
+#define WPNSEL_FATIGUE_WINDOW	0.55f
+#define WPNSEL_FATIGUE_MAX		55.0f
+#define WPNSEL_SWITCH_COST_SCALE	18.0f
+#define WPNSEL_SPLASH_NEAR_MULT	2.2f
+#define WPNSEL_SPLASH_PENALTY	48.0f
+
+static int BotWpnSel_HasWeaponAndAmmo(bot_state_t *bs, int wp) {
+	if (wp <= WP_NONE || wp >= WP_NUM_WEAPONS) {
+		return 0;
+	}
+	if (!(bs->cur_ps.stats[STAT_WEAPONS] & (1 << wp))) {
+		return 0;
+	}
+	if (wp == WP_GAUNTLET) {
+		return 1;
+	}
+	if (bs->cur_ps.ammo[wp] <= 0) {
+		return 0;
+	}
+	return 1;
+}
+
+static float BotWpnSel_EnemyDistance(bot_state_t *bs) {
+	aas_entityinfo_t entinfo;
+	vec3_t d;
+
+	if (bs->enemy < 0 || bs->enemy >= MAX_CLIENTS) {
+		return 9999.0f;
+	}
+	BotEntityInfo(bs->enemy, &entinfo);
+	if (!entinfo.valid) {
+		return 9999.0f;
+	}
+	VectorSubtract(entinfo.origin, bs->origin, d);
+	return VectorLength(d);
+}
+
+/*
+ * Situational base score 0..~100 by range bands (tunable).
+ */
+static float BotWpnSel_RangeScore(int wp, float dist) {
+	float d;
+
+	d = dist;
+	switch (wp) {
+	case WP_SHOTGUN:
+		if (d < 128.0f) return 95.0f;
+		if (d < 256.0f) return 70.0f;
+		if (d < 400.0f) return 40.0f;
+		return 15.0f;
+	case WP_MACHINEGUN:
+		if (d < 200.0f) return 88.0f;
+		if (d < 700.0f) return 75.0f;
+		if (d < 1400.0f) return 55.0f;
+		return 35.0f;
+	case WP_LIGHTNING:
+		if (d < 320.0f) return 92.0f;
+		if (d < 600.0f) return 55.0f;
+		return 25.0f;
+	case WP_RAILGUN:
+		if (d < 200.0f) return 35.0f;
+		if (d < 500.0f) return 70.0f;
+		if (d < 2500.0f) return 90.0f;
+		return 65.0f;
+	case WP_ROCKET_LAUNCHER:
+	case WP_GRENADE_LAUNCHER:
+		if (d < 120.0f) return 40.0f;
+		if (d < 900.0f) return 82.0f;
+		if (d < 1600.0f) return 55.0f;
+		return 30.0f;
+	case WP_PLASMAGUN:
+		if (d < 200.0f) return 75.0f;
+		if (d < 1000.0f) return 78.0f;
+		return 45.0f;
+	case WP_BFG:
+		if (d < 400.0f) return 50.0f;
+		if (d < 2000.0f) return 72.0f;
+		return 40.0f;
+	case WP_GAUNTLET:
+		if (d < 64.0f) return 100.0f;
+		if (d < 128.0f) return 55.0f;
+		return 10.0f;
+#ifdef MISSIONPACK
+	case WP_NAILGUN:
+		if (d < 900.0f) return 70.0f;
+		return 40.0f;
+	case WP_PROX_LAUNCHER:
+		if (d < 350.0f) return 65.0f;
+		return 35.0f;
+	case WP_CHAINGUN:
+		if (d < 800.0f) return 72.0f;
+		return 48.0f;
+#endif
+	default:
+		return 40.0f;
+	}
+}
+
+static float BotWpnSel_AmmoPressure(bot_state_t *bs, int wp) {
+	int ammo;
+
+	if (wp == WP_GAUNTLET) {
+		return 0.0f;
+	}
+	ammo = bs->cur_ps.ammo[wp];
+	switch (wp) {
+	case WP_ROCKET_LAUNCHER:
+		if (ammo < 2) return 80.0f;
+		if (ammo < 5) return 35.0f;
+		if (ammo < 10) return 12.0f;
+		return 0.0f;
+	case WP_RAILGUN:
+		if (ammo < 2) return 70.0f;
+		if (ammo < 5) return 25.0f;
+		return 0.0f;
+	case WP_SHOTGUN:
+		if (ammo < 3) return 45.0f;
+		if (ammo < 8) return 15.0f;
+		return 0.0f;
+	case WP_GRENADE_LAUNCHER:
+		if (ammo < 3) return 40.0f;
+		return 0.0f;
+	case WP_LIGHTNING:
+	case WP_MACHINEGUN:
+		if (ammo < 25) return 18.0f;
+		return 0.0f;
+	case WP_PLASMAGUN:
+		if (ammo < 20) return 20.0f;
+		return 0.0f;
+	case WP_BFG:
+		if (ammo < 15) return 25.0f;
+		return 0.0f;
+	default:
+		if (ammo < 10) return 15.0f;
+		return 0.0f;
+	}
+}
+
+static float BotWpnSel_SplashPenalty(bot_state_t *bs, int wp, float dist,
+	const weaponinfo_t *wi) {
+	(void)bs;
+	if (!(wi->proj.damagetype & DAMAGETYPE_RADIAL)) {
+		return 0.0f;
+	}
+	if (wi->proj.radius <= 0) {
+		return 0.0f;
+	}
+	if (dist < (float)wi->proj.radius * WPNSEL_SPLASH_NEAR_MULT) {
+		return WPNSEL_SPLASH_PENALTY;
+	}
+	if (dist < (float)wi->proj.radius * 4.0f) {
+		return WPNSEL_SPLASH_PENALTY * 0.35f;
+	}
+	return 0.0f;
+}
+
+/*
+ * Seconds of "pain" for leaving current weapon and bringing candidate up.
+ */
+static float BotWpnSel_SwitchOutCost(bot_state_t *bs, int from_wp) {
+	float t;
+
+	t = 0.0f;
+	if (bs->cur_ps.weaponstate != WEAPON_READY) {
+		t += 0.35f;
+	}
+	if (bs->cur_ps.weaponTime > 0) {
+		t += bs->cur_ps.weaponTime * 0.001f;
+	}
+	if (from_wp == WP_BFG && bs->cur_ps.weaponTime > 0) {
+		t += 0.45f;
+	}
+	return t;
+}
+
+static float BotWpnSel_SwitchInCost(const weaponinfo_t *wi) {
+	float t;
+
+	t = wi->activate * 0.001f;
+	t += wi->reload * 0.001f;
+	t += wi->spinup * 0.001f;
+	if (t < 0.05f) {
+		t = 0.05f;
+	}
+	if (t > 1.1f) {
+		t = 1.1f;
+	}
+	return t;
+}
+
+static float BotWpnSel_SwitchFatigue(bot_state_t *bs, float skillCombat) {
+	float dt, u, cool;
+
+	if (bs->wps_last_switch_time <= 0.0f) {
+		return 0.0f;
+	}
+	dt = FloatTime() - bs->wps_last_switch_time;
+	cool = WPNSEL_FATIGUE_WINDOW * (0.55f + 0.45f * skillCombat);
+	if (dt >= cool) {
+		return 0.0f;
+	}
+	u = 1.0f - (dt / cool);
+	return u * WPNSEL_FATIGUE_MAX * (0.55f + 0.45f * (1.0f - skillCombat));
+}
+
+void BotWpnSelect_RegisterCvars(void) {
+	trap_Cvar_Register(&bot_smartWeaponChoice, "bot_smartWeaponChoice", "0",
+		CVAR_ARCHIVE);
+	trap_Cvar_Update(&bot_smartWeaponChoice);
+}
+
+int BotWpnSelect_IsActive(void) {
+	trap_Cvar_Update(&bot_smartWeaponChoice);
+	if (!bot_smartWeaponChoice.integer) {
+		return 0;
+	}
+	return 1;
+}
+
+void BotWpnSelect_Reset(bot_state_t *bs) {
+	bs->wps_next_eval_time = 0.0f;
+	bs->wps_last_switch_time = -999999.0f;
+	bs->wps_last_chosen_weapon = 0;
+	bs->wps_desired_weapon = BOTWPN_DESIRE_NONE;
+	bs->wps_desire_strength = 0.0f;
+}
+
+void BotWpnSelect_NotifyWeaponCommitted(bot_state_t *bs, int prev_wp, int new_wp) {
+	if (prev_wp != new_wp) {
+		bs->wps_last_switch_time = FloatTime();
+	}
+	bs->wps_last_chosen_weapon = new_wp;
+}
+
+void BotWpnSelect_GetDesire(bot_state_t *bs, bot_weapon_desire_t *out) {
+	if (!out) {
+		return;
+	}
+	out->desired_weapon = bs->wps_desired_weapon;
+	out->desire_strength = bs->wps_desire_strength;
+}
+
+int BotWpnSelect_Choose(bot_state_t *bs) {
+	int wp, best_wp, legacy_best, weap_list[16], n_weaps, i;
+	float dist, score, best_score, cur_score, skillCombat, react, eval_dt;
+	float hysteresis, noiseAmp, vis;
+	float miss_score, best_miss_score;
+	int best_miss_wp;
+	weaponinfo_t wi;
+
+	if (!BotWpnSelect_IsActive()) {
+		return -1;
+	}
+	if (bs->enemy < 0) {
+		bs->wps_desired_weapon = BOTWPN_DESIRE_NONE;
+		bs->wps_desire_strength = 0.0f;
+		return -1;
+	}
+
+	skillCombat = trap_Characteristic_BFloat(bs->character, CHARACTERISTIC_AIM_SKILL,
+		0.0f, 1.0f);
+	react = trap_Characteristic_BFloat(bs->character, CHARACTERISTIC_REACTIONTIME,
+		0.0f, 1.0f);
+
+	eval_dt = WPNSEL_EVAL_MIN + (WPNSEL_EVAL_MAX - WPNSEL_EVAL_MIN) *
+		(0.35f + 0.4f * react + 0.25f * (1.0f - skillCombat));
+
+	if (bs->wps_next_eval_time > FloatTime()) {
+		return bs->weaponnum;
+	}
+	bs->wps_next_eval_time = FloatTime() + eval_dt;
+
+	legacy_best = trap_BotChooseBestFightWeapon(bs->ws, bs->inventory);
+	if (legacy_best <= WP_NONE || legacy_best >= WP_NUM_WEAPONS) {
+		return -1;
+	}
+
+	dist = BotWpnSel_EnemyDistance(bs);
+	vis = BotEntityVisible(bs->entitynum, bs->eye, bs->viewangles, 360.0f, bs->enemy);
+	if (vis <= 0.0f) {
+		dist *= 1.15f;
+	}
+
+	n_weaps = 0;
+	weap_list[n_weaps++] = WP_GAUNTLET;
+	weap_list[n_weaps++] = WP_MACHINEGUN;
+	weap_list[n_weaps++] = WP_SHOTGUN;
+	weap_list[n_weaps++] = WP_GRENADE_LAUNCHER;
+	weap_list[n_weaps++] = WP_ROCKET_LAUNCHER;
+	weap_list[n_weaps++] = WP_LIGHTNING;
+	weap_list[n_weaps++] = WP_RAILGUN;
+	weap_list[n_weaps++] = WP_PLASMAGUN;
+	weap_list[n_weaps++] = WP_BFG;
+#ifdef MISSIONPACK
+	weap_list[n_weaps++] = WP_NAILGUN;
+	weap_list[n_weaps++] = WP_PROX_LAUNCHER;
+	weap_list[n_weaps++] = WP_CHAINGUN;
+#endif
+
+	best_wp = legacy_best;
+	best_score = -1e12f;
+	cur_score = -1e12f;
+
+	for (i = 0; i < n_weaps; i++) {
+		wp = weap_list[i];
+		if (!BotWpnSel_HasWeaponAndAmmo(bs, wp)) {
+			continue;
+		}
+		trap_BotGetWeaponInfo(bs->ws, wp, &wi);
+		if (!wi.valid) {
+			continue;
+		}
+
+		score = BotWpnSel_RangeScore(wp, dist);
+		score -= BotWpnSel_AmmoPressure(bs, wp);
+		score -= BotWpnSel_SplashPenalty(bs, wp, dist, &wi);
+
+		if (wp == legacy_best) {
+			score += WPNSEL_LEGACY_BIAS;
+		} else {
+			score += WPNSEL_LEGACY_BIAS * 0.15f;
+		}
+
+		if (wp != bs->weaponnum) {
+			score -= BotWpnSel_SwitchFatigue(bs, skillCombat) *
+				(0.65f + 0.55f * (1.0f - skillCombat));
+			score -= (BotWpnSel_SwitchOutCost(bs, bs->weaponnum) +
+				BotWpnSel_SwitchInCost(&wi)) * WPNSEL_SWITCH_COST_SCALE;
+		}
+
+		noiseAmp = WPNSEL_NOISE_MAX * (0.25f + 0.75f * (1.0f - skillCombat));
+		score += crandom() * noiseAmp;
+
+		if (wp == bs->weaponnum) {
+			cur_score = score;
+		}
+		if (score > best_score) {
+			best_score = score;
+			best_wp = wp;
+		}
+	}
+
+	hysteresis = WPNSEL_HYSTERESIS_BASE +
+		WPNSEL_HYSTERESIS_SKILL * (1.0f - skillCombat);
+
+	if (best_wp != bs->weaponnum) {
+		if (best_score < cur_score + hysteresis) {
+			best_wp = bs->weaponnum;
+		}
+	}
+
+	bs->wps_desired_weapon = BOTWPN_DESIRE_NONE;
+	bs->wps_desire_strength = 0.0f;
+	best_miss_score = -1e12f;
+	best_miss_wp = BOTWPN_DESIRE_NONE;
+	for (i = 0; i < n_weaps; i++) {
+		wp = weap_list[i];
+		if (bs->cur_ps.stats[STAT_WEAPONS] & (1 << wp)) {
+			continue;
+		}
+		trap_BotGetWeaponInfo(bs->ws, wp, &wi);
+		if (!wi.valid) {
+			continue;
+		}
+		miss_score = BotWpnSel_RangeScore(wp, dist);
+		miss_score -= BotWpnSel_SplashPenalty(bs, wp, dist, &wi);
+		if (wp == legacy_best) {
+			miss_score += WPNSEL_LEGACY_BIAS * 0.9f;
+		}
+		if (miss_score > best_miss_score) {
+			best_miss_score = miss_score;
+			best_miss_wp = wp;
+		}
+	}
+	if (best_miss_wp != BOTWPN_DESIRE_NONE &&
+			best_miss_score > best_score + 12.0f) {
+		bs->wps_desired_weapon = best_miss_wp;
+		bs->wps_desire_strength = Com_Clamp(0.0f, 1.0f,
+			(best_miss_score - best_score) / 85.0f);
+	}
+
+	return best_wp;
+}

--- a/ratoa_gamecode/code/game/ai_weapon_select.c
+++ b/ratoa_gamecode/code/game/ai_weapon_select.c
@@ -33,6 +33,8 @@ float BotEntityVisible(int viewer, vec3_t eye, vec3_t viewangles, float fov, int
 #define WPNSEL_SWITCH_COST_SCALE	18.0f
 #define WPNSEL_SPLASH_NEAR_MULT	2.2f
 #define WPNSEL_SPLASH_PENALTY	48.0f
+/* Extra weight on range fit vs legacy bias (higher = hitscan wins at long range). */
+#define WPNSEL_RANGE_WEIGHT		1.45f
 
 static int BotWpnSel_HasWeaponAndAmmo(bot_state_t *bs, int wp) {
 	if (wp <= WP_NONE || wp >= WP_NUM_WEAPONS) {
@@ -80,46 +82,64 @@ static float BotWpnSel_RangeScore(int wp, float dist) {
 		return 15.0f;
 	case WP_MACHINEGUN:
 		if (d < 200.0f) return 88.0f;
-		if (d < 700.0f) return 75.0f;
-		if (d < 1400.0f) return 55.0f;
-		return 35.0f;
+		if (d < 550.0f) return 78.0f;
+		if (d < 1000.0f) return 72.0f;
+		if (d < 1800.0f) return 80.0f;
+		if (d < 3200.0f) return 76.0f;
+		return 62.0f;
 	case WP_LIGHTNING:
-		if (d < 320.0f) return 92.0f;
-		if (d < 600.0f) return 55.0f;
-		return 25.0f;
+		if (d < 280.0f) return 94.0f;
+		if (d < 450.0f) return 58.0f;
+		if (d < 650.0f) return 32.0f;
+		return 14.0f;
 	case WP_RAILGUN:
-		if (d < 200.0f) return 35.0f;
-		if (d < 500.0f) return 70.0f;
-		if (d < 2500.0f) return 90.0f;
-		return 65.0f;
+		if (d < 160.0f) return 38.0f;
+		if (d < 400.0f) return 72.0f;
+		if (d < 1200.0f) return 92.0f;
+		if (d < 3200.0f) return 96.0f;
+		return 82.0f;
 	case WP_ROCKET_LAUNCHER:
+		if (d < 96.0f) return 42.0f;
+		if (d < 320.0f) return 88.0f;
+		if (d < 520.0f) return 78.0f;
+		if (d < 720.0f) return 48.0f;
+		if (d < 1100.0f) return 22.0f;
+		if (d < 1600.0f) return 10.0f;
+		return 4.0f;
 	case WP_GRENADE_LAUNCHER:
-		if (d < 120.0f) return 40.0f;
-		if (d < 900.0f) return 82.0f;
-		if (d < 1600.0f) return 55.0f;
-		return 30.0f;
+		if (d < 96.0f) return 38.0f;
+		if (d < 400.0f) return 76.0f;
+		if (d < 640.0f) return 52.0f;
+		if (d < 900.0f) return 26.0f;
+		return 8.0f;
 	case WP_PLASMAGUN:
-		if (d < 200.0f) return 75.0f;
-		if (d < 1000.0f) return 78.0f;
-		return 45.0f;
+		if (d < 200.0f) return 76.0f;
+		if (d < 700.0f) return 80.0f;
+		if (d < 1100.0f) return 52.0f;
+		if (d < 1600.0f) return 32.0f;
+		return 18.0f;
 	case WP_BFG:
-		if (d < 400.0f) return 50.0f;
-		if (d < 2000.0f) return 72.0f;
-		return 40.0f;
+		if (d < 400.0f) return 52.0f;
+		if (d < 1200.0f) return 68.0f;
+		if (d < 2000.0f) return 48.0f;
+		return 22.0f;
 	case WP_GAUNTLET:
 		if (d < 64.0f) return 100.0f;
 		if (d < 128.0f) return 55.0f;
 		return 10.0f;
 #ifdef MISSIONPACK
 	case WP_NAILGUN:
-		if (d < 900.0f) return 70.0f;
-		return 40.0f;
+		if (d < 700.0f) return 70.0f;
+		if (d < 1400.0f) return 48.0f;
+		return 28.0f;
 	case WP_PROX_LAUNCHER:
-		if (d < 350.0f) return 65.0f;
-		return 35.0f;
+		if (d < 320.0f) return 66.0f;
+		return 24.0f;
 	case WP_CHAINGUN:
-		if (d < 800.0f) return 72.0f;
-		return 48.0f;
+		if (d < 600.0f) return 74.0f;
+		if (d < 1400.0f) return 78.0f;
+		if (d < 2600.0f) return 70.0f;
+		return 52.0f;
 #endif
 	default:
 		return 40.0f;
@@ -341,7 +361,7 @@ int BotWpnSelect_Choose(bot_state_t *bs) {
 			continue;
 		}
 
-		score = BotWpnSel_RangeScore(wp, dist);
+		score = BotWpnSel_RangeScore(wp, dist) * WPNSEL_RANGE_WEIGHT;
 		score -= BotWpnSel_AmmoPressure(bs, wp);
 		score -= BotWpnSel_SplashPenalty(bs, wp, dist, &wi);
 
@@ -392,7 +412,7 @@ int BotWpnSelect_Choose(bot_state_t *bs) {
 		if (!wi.valid) {
 			continue;
 		}
-		miss_score = BotWpnSel_RangeScore(wp, dist);
+		miss_score = BotWpnSel_RangeScore(wp, dist) * WPNSEL_RANGE_WEIGHT;
 		miss_score -= BotWpnSel_SplashPenalty(bs, wp, dist, &wi);
 		if (wp == legacy_best) {
 			miss_score += WPNSEL_LEGACY_BIAS * 0.9f;

--- a/ratoa_gamecode/code/game/ai_weapon_select.h
+++ b/ratoa_gamecode/code/game/ai_weapon_select.h
@@ -1,0 +1,38 @@
+/*
+===========================================================================
+BOT SMART WEAPON SELECT (v1) — situational weapon choice.
+
+Ringfenced: logic in ai_weapon_select.c. Toggle with bot_smartWeaponChoice.
+Include after g_local.h and ai_main.h in .c files (ai_main.h has no guards).
+
+Remove: delete ai_weapon_select.c/h, Makefile/q3asm entries, revert hooks in
+ai_main.h, ai_main.c, ai_dmq3.c.
+===========================================================================
+*/
+
+#ifndef AI_WEAPON_SELECT_H
+#define AI_WEAPON_SELECT_H
+
+struct bot_state_s;
+
+#define BOTWPN_DESIRE_NONE	(-1)
+
+typedef struct bot_weapon_desire_s {
+	int		desired_weapon;		/* WP_* or BOTWPN_DESIRE_NONE */
+	float	desire_strength;	/* 0..1 for future item routing */
+} bot_weapon_desire_t;
+
+void BotWpnSelect_RegisterCvars(void);
+int BotWpnSelect_IsActive(void);
+void BotWpnSelect_Reset(struct bot_state_s *bs);
+/*
+ * Returns chosen WP_* when smart select applies, or -1 to use
+ * trap_BotChooseBestFightWeapon (legacy).
+ */
+int BotWpnSelect_Choose(struct bot_state_s *bs);
+/* Call after weaponnum is committed so fatigue/switch timers stay accurate. */
+void BotWpnSelect_NotifyWeaponCommitted(struct bot_state_s *bs, int prev_wp, int new_wp);
+/* For future item pickup / goal weighting (v1 fills when active + enemy). */
+void BotWpnSelect_GetDesire(struct bot_state_s *bs, bot_weapon_desire_t *out);
+
+#endif /* AI_WEAPON_SELECT_H */

--- a/ratoa_gamecode/code/game/g_client.c
+++ b/ratoa_gamecode/code/game/g_client.c
@@ -2380,11 +2380,16 @@ void ClientUserinfoChanged( int clientNum ) {
 			// pick the team with the least number of players
 			team = PickTeam( clientNum );
 		}
-                client->sess.sessionTeam = team;
+        client->sess.sessionTeam = team;
 	} else if (g_gametype.integer != GT_TOURNAMENT && g_entities[clientNum].r.svFlags & SVF_BOT) {
 		// make sure bots can always join the game, even if it's locked
 		team = TEAM_FREE;
 		client->sess.sessionTeam = team;
+	} else if (g_gametype.integer == GT_TOURNAMENT && g_entities[clientNum].r.svFlags & SVF_BOT) {
+		//For tourney, we want bots to queue and not just sit in spec
+		team = TEAM_SPECTATOR;
+		client->sess.sessionTeam = team;
+		client->sess.spectatorGroup = SPECTATORGROUP_QUEUED;
 	}
 	else {
 		team = client->sess.sessionTeam;

--- a/ratoa_gamecode/code/game/g_client.c
+++ b/ratoa_gamecode/code/game/g_client.c
@@ -2369,55 +2369,63 @@ void ClientUserinfoChanged( int clientNum ) {
 	}
 	//}
 
-	// bots set their team a few frames later
-	if (G_IsTeamGametype() && g_entities[clientNum].r.svFlags & SVF_BOT) {
-		s = Info_ValueForKey( userinfo, "team" );
-		if ( !Q_stricmp( s, "red" ) || !Q_stricmp( s, "r" ) ) {
-			team = TEAM_RED;
-		} else if ( !Q_stricmp( s, "blue" ) || !Q_stricmp( s, "b" ) ) {
-			team = TEAM_BLUE;
+	//This block determines which team a bot should join
+	//and actively sets it in the bot's session data
+	//Bots set their team a few frames later
+	if ( ent->r.svFlags & SVF_BOT ) {
+		if ( G_IsTeamGametype() ) {
+			s = Info_ValueForKey( userinfo, "team" );
+			if ( !Q_stricmp( s, "red" ) || !Q_stricmp( s, "r" ) ) {
+				team = TEAM_RED;
+			} else if ( !Q_stricmp( s, "blue" ) || !Q_stricmp( s, "b" ) ) {
+				team = TEAM_BLUE;
+			} else {
+				team = PickTeam( clientNum );
+			}
 		} else {
-			// pick the team with the least number of players
-			team = PickTeam( clientNum );
+			if ( g_gametype.integer == GT_TOURNAMENT ) {
+				if ( client->sess.sessionTeam == TEAM_SPECTATOR ) {
+					team = TEAM_SPECTATOR;
+				} else {
+					team = client->sess.sessionTeam;
+				}
+			} else {
+				// FFA, LMS, etc. — always join play
+				team = TEAM_FREE;
+			}
 		}
-        client->sess.sessionTeam = team;
-	} else if (g_gametype.integer != GT_TOURNAMENT && g_entities[clientNum].r.svFlags & SVF_BOT) {
-		// make sure bots can always join the game, even if it's locked
-		team = TEAM_FREE;
 		client->sess.sessionTeam = team;
-	} else if (g_gametype.integer == GT_TOURNAMENT && g_entities[clientNum].r.svFlags & SVF_BOT) {
-		//For tourney, we want bots to queue and not just sit in spec
-		team = TEAM_SPECTATOR;
-		client->sess.sessionTeam = team;
-		client->sess.spectatorGroup = SPECTATORGROUP_QUEUED;
-	}
-	else {
+		if ( team == TEAM_SPECTATOR ) {
+			//If a bot is spectating, it should always be in the queue to join the game
+			client->sess.spectatorGroup = SPECTATORGROUP_QUEUED;
+		}
+	} else {
+		//Not a bot so must be a player. Carry over their team from their session data
 		team = client->sess.sessionTeam;
 	}
 
-/*	NOTE: all client side now
-Sago: I am not happy with this exception
- 
-	// team
-	switch( team ) {
-	case TEAM_RED:
-		ForceClientSkin(client, model, "red");
-//		ForceClientSkin(client, headModel, "red");
-		break;
-	case TEAM_BLUE:
-		ForceClientSkin(client, model, "blue");
-//		ForceClientSkin(client, headModel, "blue");
-		break;
-	}
-	// don't ever use a default skin in teamplay, it would just waste memory
-	// however bots will always join a team but they spawn in as spectator
-	if ( g_gametype.integer >= GT_TEAM && team == TEAM_SPECTATOR) {
-		ForceClientSkin(client, model, "red");
-//		ForceClientSkin(client, headModel, "red");
-	}
-*/
+	/*	NOTE: all client side now
+	Sago: I am not happy with this exception
+		// team
+		switch( team ) {
+		case TEAM_RED:
+			ForceClientSkin(client, model, "red");
+	//		ForceClientSkin(client, headModel, "red");
+			break;
+		case TEAM_BLUE:
+			ForceClientSkin(client, model, "blue");
+	//		ForceClientSkin(client, headModel, "blue");
+			break;
+		}
+		// don't ever use a default skin in teamplay, it would just waste memory
+		// however bots will always join a team but they spawn in as spectator
+		if ( g_gametype.integer >= GT_TEAM && team == TEAM_SPECTATOR) {
+			ForceClientSkin(client, model, "red");
+	//		ForceClientSkin(client, headModel, "red");
+		}
+	*/
 
-	if (G_IsTeamGametype()) {
+	if ( G_IsTeamGametype() ) {
 		client->pers.teamInfo = qtrue;
 	} else {
 		s = Info_ValueForKey( userinfo, "teamoverlay" );

--- a/ratoa_gamecode/windows_scripts/game.q3asm
+++ b/ratoa_gamecode/windows_scripts/game.q3asm
@@ -10,6 +10,7 @@ q_shared
 ai_dmnet
 ai_dmq3
 ai_aim_harness
+ai_weapon_select
 ai_team
 ai_main
 ai_chat

--- a/ratoa_gamecode/windows_scripts/game.q3asm
+++ b/ratoa_gamecode/windows_scripts/game.q3asm
@@ -11,6 +11,7 @@ ai_dmnet
 ai_dmq3
 ai_aim_harness
 ai_weapon_select
+ai_bot_tactics
 ai_team
 ai_main
 ai_chat

--- a/ratoa_gamecode/windows_scripts/game.q3asm
+++ b/ratoa_gamecode/windows_scripts/game.q3asm
@@ -9,6 +9,7 @@ q_math
 q_shared
 ai_dmnet
 ai_dmq3
+ai_aim_harness
 ai_team
 ai_main
 ai_chat

--- a/ratoa_gamecode/windows_scripts/game_mp.q3asm
+++ b/ratoa_gamecode/windows_scripts/game_mp.q3asm
@@ -10,6 +10,7 @@ q_shared
 ai_dmnet
 ai_dmq3
 ai_aim_harness
+ai_weapon_select
 ai_team
 ai_main
 ai_chat

--- a/ratoa_gamecode/windows_scripts/game_mp.q3asm
+++ b/ratoa_gamecode/windows_scripts/game_mp.q3asm
@@ -11,6 +11,7 @@ ai_dmnet
 ai_dmq3
 ai_aim_harness
 ai_weapon_select
+ai_bot_tactics
 ai_team
 ai_main
 ai_chat

--- a/ratoa_gamecode/windows_scripts/game_mp.q3asm
+++ b/ratoa_gamecode/windows_scripts/game_mp.q3asm
@@ -9,6 +9,7 @@ q_math
 q_shared
 ai_dmnet
 ai_dmq3
+ai_aim_harness
 ai_team
 ai_main
 ai_chat

--- a/ratoa_gamecode/windows_scripts/windows_compile_game.bat
+++ b/ratoa_gamecode/windows_scripts/windows_compile_game.bat
@@ -23,6 +23,7 @@ cd windows\build\game
 %cc%  ../../../code/game/ai_dmq3.c
 %cc%  ../../../code/game/ai_aim_harness.c
 %cc%  ../../../code/game/ai_weapon_select.c
+%cc%  ../../../code/game/ai_bot_tactics.c
 %cc%  ../../../code/game/ai_main.c
 %cc%  ../../../code/game/ai_team.c
 %cc%  ../../../code/game/ai_vcmd.c

--- a/ratoa_gamecode/windows_scripts/windows_compile_game.bat
+++ b/ratoa_gamecode/windows_scripts/windows_compile_game.bat
@@ -22,6 +22,7 @@ cd windows\build\game
 %cc%  ../../../code/game/ai_dmnet.c
 %cc%  ../../../code/game/ai_dmq3.c
 %cc%  ../../../code/game/ai_aim_harness.c
+%cc%  ../../../code/game/ai_weapon_select.c
 %cc%  ../../../code/game/ai_main.c
 %cc%  ../../../code/game/ai_team.c
 %cc%  ../../../code/game/ai_vcmd.c

--- a/ratoa_gamecode/windows_scripts/windows_compile_game.bat
+++ b/ratoa_gamecode/windows_scripts/windows_compile_game.bat
@@ -21,6 +21,7 @@ cd windows\build\game
 %cc%  ../../../code/game/ai_cmd.c
 %cc%  ../../../code/game/ai_dmnet.c
 %cc%  ../../../code/game/ai_dmq3.c
+%cc%  ../../../code/game/ai_aim_harness.c
 %cc%  ../../../code/game/ai_main.c
 %cc%  ../../../code/game/ai_team.c
 %cc%  ../../../code/game/ai_vcmd.c

--- a/ratoa_gamecode/windows_scripts/windows_compile_game_missionpack.bat
+++ b/ratoa_gamecode/windows_scripts/windows_compile_game_missionpack.bat
@@ -23,6 +23,7 @@ cd windows\build\game
 %cc%  ../../../code/game/ai_dmq3.c
 %cc%  ../../../code/game/ai_aim_harness.c
 %cc%  ../../../code/game/ai_weapon_select.c
+%cc%  ../../../code/game/ai_bot_tactics.c
 %cc%  ../../../code/game/ai_main.c
 %cc%  ../../../code/game/ai_team.c
 %cc%  ../../../code/game/ai_vcmd.c

--- a/ratoa_gamecode/windows_scripts/windows_compile_game_missionpack.bat
+++ b/ratoa_gamecode/windows_scripts/windows_compile_game_missionpack.bat
@@ -22,6 +22,7 @@ cd windows\build\game
 %cc%  ../../../code/game/ai_dmnet.c
 %cc%  ../../../code/game/ai_dmq3.c
 %cc%  ../../../code/game/ai_aim_harness.c
+%cc%  ../../../code/game/ai_weapon_select.c
 %cc%  ../../../code/game/ai_main.c
 %cc%  ../../../code/game/ai_team.c
 %cc%  ../../../code/game/ai_vcmd.c

--- a/ratoa_gamecode/windows_scripts/windows_compile_game_missionpack.bat
+++ b/ratoa_gamecode/windows_scripts/windows_compile_game_missionpack.bat
@@ -21,6 +21,7 @@ cd windows\build\game
 %cc%  ../../../code/game/ai_cmd.c
 %cc%  ../../../code/game/ai_dmnet.c
 %cc%  ../../../code/game/ai_dmq3.c
+%cc%  ../../../code/game/ai_aim_harness.c
 %cc%  ../../../code/game/ai_main.c
 %cc%  ../../../code/game/ai_team.c
 %cc%  ../../../code/game/ai_vcmd.c


### PR DESCRIPTION
Added very early versions of three new bot capabilities:

**bot_humanizeAim <0|1>**
Changes bot aiming behavior to be less jittery and mechanical, more like a human player with mouse input.

**bot_tacticalAI <0|1>**
Adds a small module that allows bots to make scenario-specific decisions, and a very basic event/listener setup.

**bot_smartWeaponChoice <0|1>**
Makes bots consider the appropriateness of the weapon they are weilding i.e. don't attempt to use LG or shotgun past their reasonable ranges.

These are all very early days, and bot shot accuracy is not yet up to par when these are enabled. More work required to refine them and bring back strong bot skill differentiation. But all of these default to zero for now.

Note: Current tactics are:
- If I'm out of ammo and have to use the gauntlet, decide to either charge directly at my opponent, or turn and flee
- If I'm engaging a distant enemy and a closer one appears, choose to stay on target (if they're nearly dead) or switch target
- If someone who is not my target just hurt me, decide to switch target or stay on target
- If I'm fleeing and out of ammo, stop aiming at my opponent