### PR TITLE
Map list simplification

### DIFF
--- a/docs/CLIENT-COMMANDS.md
+++ b/docs/CLIENT-COMMANDS.md
@@ -28,7 +28,6 @@ Here's an exhaustive listing of valid client console commands for the Devotion m
 | `dropweapon` | Server | Devotion | — | Drop current weapon. |
 | `follow` | Server | Vanilla | <name\|slot> | Spectate a player by id or name. |
 | `followauto` | Server | RatMod | — | Auto-follow killer/action. |
-| `getgtmappage` | Server | RatMod | — | Fetch gametype-filtered map list page (used by `maplist` and vote UI). |
 | `getmappage` | Server | RatMod | — | Fetch map list page for vote UI. |
 | `getrecmappage` | Server | RatMod | — | Fetch recommended maps page for vote UI. |
 | `give` | Server | Vanilla | — | Give items (cheat; requires cheats enabled). |
@@ -39,7 +38,7 @@ Here's an exhaustive listing of valid client console commands for the Devotion m
 | `levelshot` | Server | Vanilla | — | Capture levelshot (cheat). |
 | `loaddeferred` | Local | Vanilla | — | Load deferred player models. |
 | `loaddefered` | Server | Devotion | — | Misspelled alias still registered for demos; loads deferred models on server path. |
-| `maplist` | Local | RatMod | [all] | Outputs a list of server-side maps; by default shows only maps valid for current gametype; `maplist all` lists all maps for any gametype. |
+| `maplist` | Local | RatMod | none | Outputs the server-side map list. |
 | `motd` | Server | RatMod | — | Show MOTD/help text. |
 | `mv` | Local | RatMod | [filter] | Open map vote menu; optional `mv <filter>`. |
 | `nextframe` | Local | Vanilla | — | Advance test model frame. |

--- a/docs/SERVER-COMMANDS.md
+++ b/docs/SERVER-COMMANDS.md
@@ -39,7 +39,6 @@ Commands handled by the Devotion **game** (the server) module. Use them from the
 | `game_memory` | Server console | RatMod | — | Print game memory usage (debug). |
 | `gc` | In-game | Vanilla | — | Send a game command to a specific client (admin). |
 | `gdumpuser` | Server console | RatMod | — | Alias for `dumpuser`. |
-| `getgtmappage` | In-game | RatMod | — | Fetch gametype map list page for vote UI. |
 | `getmappage` | In-game | RatMod | — | Fetch map list page for vote UI. |
 | `getrecmappage` | In-game | RatMod | — | Fetch recommended maps page for vote UI. |
 | `gg` | In-game | RatMod | — | Send a good-game style message. |

--- a/ratoa_gamecode/code/cgame/cg_consolecmds.c
+++ b/ratoa_gamecode/code/cgame/cg_consolecmds.c
@@ -120,7 +120,6 @@ void CG_Randomcolors_f( void ) {
 
 typedef struct {
 	qboolean	active;
-	qboolean	allMaps;
 	qboolean	loaded_all;
 	int		num_cmds;
 	int		num_maps;
@@ -389,82 +388,6 @@ static const char *CG_Maplist_ColorForMap( const char *mapname ) {
 	return S_COLOR_WHITE;
 }
 
-static void CG_Maplist_CurrentGametypeLabel( const char **name, const char **color ) {
-	switch ( cgs.gametype ) {
-	case GT_FFA:
-		*name = "FFA";
-		*color = S_COLOR_WHITE;
-		return;
-	case GT_SINGLE_PLAYER:
-		*name = "Single Player";
-		*color = S_COLOR_WHITE;
-		return;
-	case GT_TOURNAMENT:
-#ifdef WITH_MULTITOURNAMENT
-	case GT_MULTITOURNAMENT:
-#endif
-		*name = "Duel";
-		*color = S_COLOR_CYAN;
-		return;
-	case GT_TEAM:
-		*name = "TDM";
-		*color = S_COLOR_YELLOW;
-		return;
-	case GT_CTF:
-		*name = "CTF";
-		*color = S_COLOR_GREEN;
-		return;
-#ifdef MISSIONPACK
-	case GT_1FCTF:
-		*name = "1FCTF";
-		*color = S_COLOR_GREEN;
-		return;
-	case GT_OBELISK:
-		*name = "Overload";
-		*color = S_COLOR_GREEN;
-		return;
-	case GT_HARVESTER:
-		*name = "Harvester";
-		*color = S_COLOR_GREEN;
-		return;
-#endif
-	case GT_ELIMINATION:
-		*name = "Elimination";
-		*color = S_COLOR_YELLOW;
-		return;
-	case GT_CTF_ELIMINATION:
-		*name = "CTF Elim";
-		*color = S_COLOR_GREEN;
-		return;
-	case GT_LMS:
-		*name = "LMS";
-		*color = S_COLOR_YELLOW;
-		return;
-#ifdef WITH_DOM_GAMETYPE
-	case GT_DOMINATION:
-		*name = "Domination";
-		*color = S_COLOR_YELLOW;
-		return;
-#endif
-#ifdef WITH_DOUBLED_GAMETYPE
-	case GT_DOUBLE_D:
-		*name = "DD";
-		*color = S_COLOR_YELLOW;
-		return;
-#endif
-#ifdef WITH_TREASURE_HUNTER_GAMETYPE
-	case GT_TREASURE_HUNTER:
-		*name = "TH";
-		*color = S_COLOR_YELLOW;
-		return;
-#endif
-	default:
-		*name = "Unknown";
-		*color = S_COLOR_WHITE;
-		return;
-	}
-}
-
 static void CG_Maplist_Reset( void ) {
 	memset( &cg_maplist, 0, sizeof( cg_maplist ) );
 }
@@ -487,11 +410,7 @@ static void CG_Maplist_RequestNextPage( void ) {
 
 	page = ( cg_maplist.num_maps / CG_MAPLIST_MAPS_PER_PAGE )
 		+ ( ( cg_maplist.num_maps % CG_MAPLIST_MAPS_PER_PAGE == 0 ) ? 0 : 1 );
-	if ( cg_maplist.allMaps ) {
-		trap_SendClientCommand( va( "getmappage %i\n", page ) );
-	} else {
-		trap_SendClientCommand( va( "getgtmappage %i\n", page ) );
-	}
+	trap_SendClientCommand( va( "getmappage %i\n", page ) );
 }
 
 static void CG_Maplist_Print( void ) {
@@ -536,16 +455,7 @@ static void CG_Maplist_Print( void ) {
 
 	CG_Maplist_EnsureArenasLoaded();
 
-	if ( cg_maplist.allMaps ) {
-		CG_Printf( "List of maps from server for gametype: All\n" );
-	} else {
-		const char *gtName;
-		const char *gtColor;
-
-		CG_Maplist_CurrentGametypeLabel( &gtName, &gtColor );
-		CG_Printf( "List of maps from server for gametype: %s%s%s\n",
-			gtColor, gtName, S_COLOR_WHITE );
-	}
+	CG_Printf( "List of maps from server\n" );
 	CG_Printf( "%i Maps\n", cg_maplist.num_maps );
 	CG_Printf( "Key: FFA " S_COLOR_CYAN "Tourney " S_COLOR_GREEN "CTF "
 		S_COLOR_YELLOW "TDM\n" );
@@ -638,25 +548,14 @@ qboolean CG_Maplist_HandleMappage( void ) {
 }
 
 static void CG_Maplist_f( void ) {
-	int argc;
-	char arg[MAX_STRING_CHARS];
-
 	if ( !cg.snap ) {
 		CG_Printf( "maplist: not connected to a server\n" );
 		return;
 	}
 
-	argc = trap_Argc();
-	if ( argc > 2 ) {
-		CG_Printf( "usage: maplist [all]\n" );
+	if ( trap_Argc() > 1 ) {
+		CG_Printf( "usage: maplist\n" );
 		return;
-	}
-	if ( argc > 1 ) {
-		trap_Argv( 1, arg, sizeof( arg ) );
-		if ( Q_stricmp( arg, "all" ) ) {
-			CG_Printf( "usage: maplist [all]\n" );
-			return;
-		}
 	}
 
 	if ( cg_maplist.active ) {
@@ -666,7 +565,6 @@ static void CG_Maplist_f( void ) {
 
 	memset( &cg_maplist, 0, sizeof( cg_maplist ) );
 	cg_maplist.active = qtrue;
-	cg_maplist.allMaps = ( argc > 1 );
 
 	CG_Maplist_RequestNextPage();
 }
@@ -1587,7 +1485,6 @@ void CG_InitConsoleCommands( void ) {
 	trap_AddCommand ("setviewpos");
 	trap_AddCommand ("callvote");
 	trap_AddCommand ("getmappage");
-	trap_AddCommand ("getgtmappage");
 	trap_AddCommand ("getrecmappage");
 	trap_AddCommand ("maplist");
 	trap_AddCommand ("vote");

--- a/ratoa_gamecode/code/game/g_cmds.c
+++ b/ratoa_gamecode/code/game/g_cmds.c
@@ -4515,7 +4515,7 @@ void Cmd_Stats_f( gentity_t *ent ) {
 	trap_SendServerCommand( ent-g_entities, va("print \"%d%% level coverage\n\"", n * 100 / max));
 */
 }
-void Cmd_GetMappage_f_impl( gentity_t *ent, qboolean recommendedmaps, qboolean forgametype) {
+void Cmd_GetMappage_f_impl( gentity_t *ent, qboolean recommendedmaps) {
         t_mappage page;
         char string[(MAX_MAPNAME+1)*MAPS_PER_LARGEPAGE+1];
         char arg[MAX_STRING_TOKENS];
@@ -4531,11 +4531,7 @@ void Cmd_GetMappage_f_impl( gentity_t *ent, qboolean recommendedmaps, qboolean f
 	if (pagenum < 0) {
 		pagenum = 0;
 	}
-	if (forgametype) {
-		page = getGTMappage(pagenum, largepage);
-	} else {
-		page = getMappage(pagenum, largepage, recommendedmaps);
-	}
+	page = getMappage(pagenum, largepage, recommendedmaps);
 	if (largepage) {
 		int i;
 		string[0] = '\0';
@@ -4555,15 +4551,11 @@ void Cmd_GetMappage_f_impl( gentity_t *ent, qboolean recommendedmaps, qboolean f
 }
 
 void Cmd_GetMappage_f( gentity_t *ent ) {
-	Cmd_GetMappage_f_impl(ent, qfalse, qfalse);
+	Cmd_GetMappage_f_impl(ent, qfalse);
 }
 
 void Cmd_GetRecMappage_f( gentity_t *ent ) {
-	Cmd_GetMappage_f_impl(ent, qtrue, qfalse);
-}
-
-void Cmd_GetGTMappage_f( gentity_t *ent ) {
-	Cmd_GetMappage_f_impl(ent, qfalse, qtrue);
+	Cmd_GetMappage_f_impl(ent, qtrue);
 }
 
 //KK-OAX This is the table that ClientCommands runs the console entry against. 
@@ -4656,7 +4648,6 @@ commands_t cmds[ ] =
   { "freespectator", CMD_NOTEAM, StopFollowing },
   { "getmappage", 0, Cmd_GetMappage_f },
   { "getrecmappage", 0, Cmd_GetRecMappage_f },
-  { "getgtmappage", 0, Cmd_GetGTMappage_f },
   { "gc", 0, Cmd_GameCommand_f },
   { "motd", 0, Cmd_Motd_f },
   { "help", 0, Cmd_Motd_f },

--- a/ratoa_gamecode/code/game/g_local.h
+++ b/ratoa_gamecode/code/game/g_local.h
@@ -924,7 +924,6 @@ typedef struct {
     qboolean arenasLoaded;
 
     qboolean maplistFromVotemaps;
-    qboolean maplistCached;
     struct maplist_s maplistSource;
     struct maplist_s maplistRecommended;
 
@@ -1467,7 +1466,6 @@ typedef struct {
 extern char custom_vote_info[2048];
 
 extern t_mappage getMappage(int page, qboolean largepage, qboolean recommendedonly);
-extern t_mappage getGTMappage(int page, qboolean largepage);
 void G_BuildMaplistCache( void );
 void getCompleteMaplist(qboolean recommenedonly, int gametypebits_filter, int numPlayers, struct maplist_s *out);
 extern int allowedMap(char *mapname);

--- a/ratoa_gamecode/code/game/g_vote.c
+++ b/ratoa_gamecode/code/game/g_vote.c
@@ -235,7 +235,6 @@ void G_BuildMaplistCache( void ) {
 	}
 
 	BG_Free( buffer );
-	level.maplistCached = qtrue;
 }
 
 /*
@@ -245,33 +244,11 @@ getMappage
  */
 
 t_mappage getMappage(int page, qboolean largepage, qboolean recommenedonly) {
-	if ( !level.maplistCached ) {
-		G_BuildMaplistCache();
-	}
 	return Maplist_MappageFromList( Maplist_GetBase( recommenedonly ), page, largepage );
-}
-
-t_mappage getGTMappage(int page, qboolean largepage) {
-	t_mappage result;
-	struct maplist_s *filtered;
-
-	if ( !level.maplistCached ) {
-		G_BuildMaplistCache();
-	}
-
-	filtered = BG_Alloc( sizeof( *filtered ) );
-	Maplist_FilterCopy( &level.maplistSource, G_GametypeBitsCurrent(), 0, filtered );
-	result = Maplist_MappageFromList( filtered, page, largepage );
-	BG_Free( filtered );
-	return result;
 }
 
 void getCompleteMaplist(qboolean recommenedonly, int gametypebits_filter, int numPlayers, struct maplist_s *out) {
 	const struct maplist_s *base;
-
-	if ( !level.maplistCached ) {
-		G_BuildMaplistCache();
-	}
 
 	base = Maplist_GetBase( recommenedonly );
 	if ( recommenedonly && !level.maplistFromVotemaps && base->num < 1 ) {

--- a/ratoa_gamecode/code/q3_ui/ui_votemenu_map.c
+++ b/ratoa_gamecode/code/q3_ui/ui_votemenu_map.c
@@ -82,19 +82,16 @@ static votemenu_map_t	s_votemenu_map;
 static char pagebuffer[64];
 
 #define MAPPAGE_TYPE_RECOMMENDED 0
-#define MAPPAGE_TYPE_GAMETYPE 1
-#define MAPPAGE_TYPE_ALL 2
-#define MAPPAGE_TYPE_NUM 3
+#define MAPPAGE_TYPE_ALL 1
+#define MAPPAGE_TYPE_NUM 2
 static const char *mappage_type_items[] = {
 	"Recommended",
-	"Gametype",
 	"All",
 	NULL
 };
 
 static const char *getmappage_all_cmd = "getmappage";
 static const char *getmappage_recommened_cmd = "getrecmappage";
-static const char *getmappage_gametype_cmd = "getgtmappage";
 static const char *getmappage_cmd = "getrecmappage";
 
 static int ignore_next_cmd = 0;
@@ -292,9 +289,6 @@ static void VoteMapMenu_TypeEvent( void* ptr, int event ) {
 	if (s_votemenu_map.type.curvalue == MAPPAGE_TYPE_RECOMMENDED) {
 		getmappage_cmd = getmappage_recommened_cmd;
 		current_list = &maplists[MAPPAGE_TYPE_RECOMMENDED];
-	} else if (s_votemenu_map.type.curvalue == MAPPAGE_TYPE_GAMETYPE) {
-		getmappage_cmd = getmappage_gametype_cmd;
-		current_list = &maplists[MAPPAGE_TYPE_GAMETYPE];
 	} else {
 		getmappage_cmd = getmappage_all_cmd;
 		current_list = &maplists[MAPPAGE_TYPE_ALL];
@@ -838,7 +832,6 @@ void UI_VoteMapMenu( void ) {
     Menu_AddItem( &s_votemenu_map.menu, (void*) &s_votemenu_map.sort );
 
     s_votemenu_map.sort.curvalue = trap_Cvar_VariableValue( "ui_mapvote_sort") ? 1 : 0;
-    mappage_type_items[MAPPAGE_TYPE_GAMETYPE] = UI_GetGametypeName(trap_Cvar_VariableValue( "g_gametype"));
 
     trap_Cvar_VariableStringBuffer( "ui_mapvote_filter", 
 		    s_votemenu_map.filter.field.buffer,


### PR DESCRIPTION
Map list was still causing server-side hitches due to the filtering of large map lists by gametype. Since that filtering wasn't particularly valuable, dropped it in favor of returning the unfiltered maplist instead. Accordingly, '\maplist all' is now removed, plain '\maplist' is the only path.