### PR TITLE
Fix: Allow re-join of locked team after disconnect

### DIFF
--- a/ratoa_gamecode/code/game/g_cmds.c
+++ b/ratoa_gamecode/code/game/g_cmds.c
@@ -1661,21 +1661,30 @@ void SetTeam_Force( gentity_t *ent, char *s, gentity_t *by, qboolean tryforce ) 
 	}
 
 	//KK-OAX Check to make sure the team is not locked from Admin
+	// Allow rejoining the same team after disconnect (tracked via playerstore)
 	if ( !force ) {
-		if ( team == TEAM_RED && level.RedTeamLocked ) {
-			trap_SendServerCommand( ent - g_entities,
-					"cp \"Red Team is locked!\n\"" );
-			return;    
+		qboolean rejoinAllowed = qfalse;
+
+		if ( ( team == TEAM_RED || team == TEAM_BLUE || team == TEAM_FREE )
+				&& PlayerStore_getLastTeam( client->pers.guid ) == team ) {
+			rejoinAllowed = qtrue;
 		}
-		if ( team == TEAM_BLUE && level.BlueTeamLocked ) {
-			trap_SendServerCommand( ent - g_entities,
-					"cp \"Blue Team is locked!\n\"" );
-			return;
-		}
-		if ( team == TEAM_FREE && level.FFALocked ) {
-			trap_SendServerCommand( ent - g_entities,
-					"cp \"This Deathmatch is locked!\n\"" );
-			return;
+		if ( !rejoinAllowed ) {
+			if ( team == TEAM_RED && level.RedTeamLocked ) {
+				trap_SendServerCommand( ent - g_entities,
+						"cp \"Red Team is locked!\n\"" );
+				return;
+			}
+			if ( team == TEAM_BLUE && level.BlueTeamLocked ) {
+				trap_SendServerCommand( ent - g_entities,
+						"cp \"Blue Team is locked!\n\"" );
+				return;
+			}
+			if ( team == TEAM_FREE && level.FFALocked ) {
+				trap_SendServerCommand( ent - g_entities,
+						"cp \"This Deathmatch is locked!\n\"" );
+				return;
+			}
 		}
 	}
 	//

--- a/ratoa_gamecode/code/game/g_local.h
+++ b/ratoa_gamecode/code/game/g_local.h
@@ -1441,6 +1441,7 @@ void G_MapMinMaxPlayers(const char *mapname, int *minPlayers, int *maxPlayers);
 void PlayerStoreInit( void );
 void PlayerStore_store(char* guid, playerState_t ps);
 void PlayerStore_restore(char* guid, gclient_t *client);
+team_t PlayerStore_getLastTeam( const char *guid );
 
 //
 // g_vote.c

--- a/ratoa_gamecode/code/game/g_playerstore.c
+++ b/ratoa_gamecode/code/game/g_playerstore.c
@@ -32,6 +32,7 @@ typedef struct {
     int	persistant[MAX_PERSISTANT]; //This is the only information we need to save
     int timePlayed;
     int	accuracy[WP_NUM_WEAPONS][2];
+    team_t lastTeam; // team at store time; used to allow rejoin while teams are locked
 } playerstore_t;
 
 static playerstore_t playerstore[MAX_PLAYERS_STORED];
@@ -78,6 +79,7 @@ void PlayerStore_store(char* guid, playerState_t ps) {
     memcpy(playerstore[place2store].persistant,ps.persistant,sizeof(int[MAX_PERSISTANT]));
     memcpy(playerstore[place2store].accuracy,level.clients[ps.clientNum].accuracy, sizeof(playerstore[0].accuracy) );
     playerstore[place2store].timePlayed = level.time - level.clients[ps.clientNum].pers.enterTime;
+    playerstore[place2store].lastTeam = level.clients[ps.clientNum].sess.sessionTeam;
     G_LogPrintf("Playerstore: Stored player with guid: %s in %u\n", playerstore[place2store].guid,place2store);
 }
 
@@ -102,4 +104,31 @@ void PlayerStore_restore(char* guid, gclient_t *client)  {
         }
     }
     G_LogPrintf("Playerstore: Nothing to restore. Guid: %s\n",guid);
+}
+
+/*
+=================
+PlayerStore_getLastTeam
+
+Returns the team the player was on when their stats were last stored,
+or TEAM_SPECTATOR if unknown / not a playable team.
+=================
+*/
+team_t PlayerStore_getLastTeam( const char *guid ) {
+	int i;
+
+	if ( !guid || strlen( guid ) < GUID_SIZE ) {
+		return TEAM_SPECTATOR;
+	}
+	for ( i = 0; i < MAX_PLAYERS_STORED; i++ ) {
+		if ( !Q_stricmpn( guid, playerstore[i].guid, GUID_SIZE ) ) {
+			if ( playerstore[i].lastTeam == TEAM_RED
+					|| playerstore[i].lastTeam == TEAM_BLUE
+					|| playerstore[i].lastTeam == TEAM_FREE ) {
+				return playerstore[i].lastTeam;
+			}
+			return TEAM_SPECTATOR;
+		}
+	}
+	return TEAM_SPECTATOR;
 }


### PR DESCRIPTION
Targeted fix for #41 

Implemented team re-join for locked matches. Applies in both team-based and free (1v1/FFA) gametypes when game is locked. Caches player GUID on disconnect and permits re-admission to team (RED/BLUE/FREE) only if GUID and TEAM both match.