### PR TITLE
Fix IOQ3 hang on load

### DIFF
--- a/ratoa_gamecode/code/q3_ui/ui_menu.c
+++ b/ratoa_gamecode/code/q3_ui/ui_menu.c
@@ -288,27 +288,6 @@ static void Main_MenuDraw( void ) {
 
 /*
 ===============
-UI_SupportsOggVorbis
-
-Probe whether the client engine is capable of loading OGG-format audio files.
-Note: This function is duplicated in cg_main.c as cg_SupportsOggVorbis
-	because they're built as separate QVMs without a suitable cross-linked header
-	to put the function in
-===============
-*/
-static qboolean UI_SupportsOggVorbis( void ) {
-	static int supports_ogg = -1;
-
-	if ( supports_ogg == -1 ) {
-		qhandle_t ogg = trap_S_RegisterSound( "music/sad_synthwave.ogg", qtrue );
-		supports_ogg = ( ogg != 0 ) ? 1 : 0;
-	}
-
-	return (qboolean)supports_ogg;
-}
-
-/*
-===============
 UI_MainMenu
 
 The main menu only comes up when not in a game,
@@ -485,8 +464,5 @@ void UI_MainMenu( void ) {
 	trap_Key_SetCatcher( KEYCATCH_UI );
 	uis.menusp = 0;
 	UI_PushMenu ( &s_main.menu );
-	if ( UI_SupportsOggVorbis() ) {
-		trap_S_StartBackgroundTrack( "music/sad_synthwave.ogg", NULL );
-	}
-		
+	trap_S_StartBackgroundTrack( "music/sad_synthwave.ogg", NULL );
 }


### PR DESCRIPTION
Back in release 0.2.4 I unknowingly introduced a hang-on-load for the IOQ3 client. This was caused by the OGG compatibility test function introduced in commit 735ae5e. Q3E was fine with the test approach but IOQ3 was less tolerant and it caused it to hang. So, since the OGG compatibility check is just a nice-to-have, I've backed it out. Main menu loads the BG music OGG without any testing. On engines that don't support OGG that might  #result in a console warning but otherwise no impact.