### PR TITLE
UI enhancements

### DIFF
--- a/ratoa_gamecode/code/q3_ui/ui_atoms.c
+++ b/ratoa_gamecode/code/q3_ui/ui_atoms.c
@@ -780,6 +780,46 @@ void UI_DrawString( int x, int y, const char* str, int style, vec4_t color )
 
 /*
 =================
+UI_DrawStringSized
+=================
+*/
+void UI_DrawStringSized( int x, int y, const char* str, int style, vec4_t color, int charw, int charh )
+{
+	vec4_t	newcolor;
+	vec4_t	lowlight;
+	float	*drawcolor;
+	vec4_t	dropcolor;
+
+	if( !str ) {
+		return;
+	}
+
+	if( ( style & UI_BLINK ) && ( ( uis.realtime / BLINK_DIVISOR ) & 1 ) ) {
+		return;
+	}
+
+	if( style & UI_PULSE ) {
+		lowlight[0] = 0.8 * color[0];
+		lowlight[1] = 0.8 * color[1];
+		lowlight[2] = 0.8 * color[2];
+		lowlight[3] = 0.8 * color[3];
+		UI_LerpColor( color, lowlight, newcolor, 0.5 + 0.5 * sin( uis.realtime / PULSE_DIVISOR ) );
+		drawcolor = newcolor;
+	} else {
+		drawcolor = color;
+	}
+
+	if( style & UI_DROPSHADOW ) {
+		dropcolor[0] = dropcolor[1] = dropcolor[2] = 0;
+		dropcolor[3] = drawcolor[3];
+		UI_DrawString2( x + 2, y + 2, str, dropcolor, charw, charh );
+	}
+
+	UI_DrawString2( x, y, str, drawcolor, charw, charh );
+}
+
+/*
+=================
 UI_DrawChar
 =================
 */

--- a/ratoa_gamecode/code/q3_ui/ui_local.h
+++ b/ratoa_gamecode/code/q3_ui/ui_local.h
@@ -407,6 +407,20 @@ extern void SpecifyServer_Cache( void );
 
 extern void UI_ArenaServersMenu( void );
 extern void ArenaServers_Cache( void );
+extern void UI_MainMenuServers_Begin( menulist_s *list, menubitmap_s *mappic );
+extern void UI_MainMenuServers_Resume( menulist_s *list, menubitmap_s *mappic );
+extern void UI_MainMenuServers_Update( void );
+extern void UI_MainMenuServers_End( void );
+extern void UI_MainMenuServers_Refresh( void );
+extern qboolean UI_MainMenuServers_IsRefreshing( void );
+extern void UI_MainMenuServers_Connect( menulist_s *list );
+extern void UI_MainMenuServers_Draw( menulist_s *list );
+extern void UI_MainMenuServers_SetColumnFocus( qboolean focus );
+extern qboolean UI_MainMenuServers_GetColumnFocus( void );
+extern qboolean UI_MainMenuServers_MouseRegion( menulist_s *list );
+extern qboolean UI_MainMenuServers_Mouse( menulist_s *list );
+extern qboolean UI_MainMenuServers_MouseClick( menulist_s *list );
+extern void UI_MainMenuServers_UpdatePicture( menubitmap_s *mappic );
 
 //
 // ui_startserver.c
@@ -612,6 +626,7 @@ extern void			UI_DrawProportionalString( int x, int y, const char* str, int styl
 extern void			UI_DrawProportionalString_AutoWrapped( int x, int ystart, int xmax, int ystep, const char* str, int style, vec4_t color );
 extern int			UI_ProportionalStringWidth( const char* str );
 extern void			UI_DrawString( int x, int y, const char* str, int style, vec4_t color );
+extern void			UI_DrawStringSized( int x, int y, const char* str, int style, vec4_t color, int charw, int charh );
 extern void			UI_DrawChar( int x, int y, int ch, int style, vec4_t color );
 extern qboolean 	UI_CursorInRect (int x, int y, int width, int height);
 extern void			UI_AdjustFrom640( float *x, float *y, float *w, float *h );

--- a/ratoa_gamecode/code/q3_ui/ui_menu.c
+++ b/ratoa_gamecode/code/q3_ui/ui_menu.c
@@ -42,9 +42,32 @@ MAIN MENU
 #define ID_TEAMARENA		15
 #define ID_MODS					16
 #define ID_EXIT					17
+#define ID_SERVERLIST			18
+#define ID_REFRESH				19
 
 #define MAIN_BANNER_MODEL				"models/mapobjects/banner/banner5.md3"
 #define MAIN_MENU_VERTICAL_SPACING		34
+#define MAIN_MENU_TOP_Y					140
+#define MAIN_MENU_LEFT_X				48
+#define MAIN_MENU_LIST_X				330
+#define MAIN_MENU_LIST_Y				( MAIN_MENU_TOP_Y + MAIN_MENU_VERTICAL_SPACING )
+#define MAIN_MENU_LIST_WIDTH			45
+#define MAIN_MENU_LIST_HEIGHT			4
+#define MAIN_MENU_LAST_ITEM			5
+#define MAIN_MENU_LEVELSHOT_X			527
+#define MAIN_MENU_LEVELSHOT_Y			MAIN_MENU_TOP_Y
+#define MAIN_MENU_LEVELSHOT_WIDTH		82
+#define MAIN_MENU_LEVELSHOT_HEIGHT		61
+#define MAIN_MENU_SERVERS_HEADER_X		( MAIN_MENU_LEVELSHOT_X + MAIN_MENU_LEVELSHOT_WIDTH )
+#define MAIN_MENU_SCANNING_X			630
+#define MAIN_MENU_SCANNING_Y			346
+#define MAIN_MENU_REFRESH_X				576
+#define MAIN_MENU_REFRESH_Y				398
+#define MAIN_MENU_REFRESH_WIDTH			64
+#define MAIN_MENU_REFRESH_HEIGHT		32
+#define ART_UNKNOWNMAP					"menu/art/unknownmap"
+#define ART_REFRESH0					"menu/art/refresh_0"
+#define ART_REFRESH1					"menu/art/refresh_1"
 
 
 typedef struct {
@@ -60,6 +83,13 @@ typedef struct {
 	menutext_s		teamArena;
 	menutext_s		mods;
 	menutext_s		exit;
+	menutext_s		servers;
+	menulist_s		serverlist;
+	menubitmap_s	mappic;
+	menubitmap_s	refresh;
+
+	qboolean		serverFocus;
+	int				menuCursor;
 
 	//qhandle_t		bannerModel;
 	qhandle_t		bannerLogo;
@@ -67,6 +97,8 @@ typedef struct {
 
 
 static mainmenu_t s_main;
+
+static vec4_t main_menu_dim_red = { 0.7f, 0.0f, 0.0f, 1.0f };
 
 typedef struct {
 	menuframework_s menu;	
@@ -90,6 +122,154 @@ MainMenu_ExitAction
 }*/
 
 
+
+/*
+=================
+Main_MenuServerEvent
+=================
+*/
+static void Main_MenuServerEvent( void *ptr, int event ) {
+	if( event == QM_GOTFOCUS ) {
+		UI_MainMenuServers_UpdatePicture( &s_main.mappic );
+		return;
+	}
+
+	if( event != QM_ACTIVATED ) {
+		return;
+	}
+
+	UI_MainMenuServers_Connect( &s_main.serverlist );
+}
+
+/*
+=================
+Main_MenuRefreshEvent
+=================
+*/
+static void Main_MenuRefreshEvent( void *ptr, int event ) {
+	if( event != QM_ACTIVATED ) {
+		return;
+	}
+
+	UI_MainMenuServers_Refresh();
+}
+
+/*
+=================
+Main_MenuRefreshMouse
+=================
+*/
+static qboolean Main_MenuRefreshMouse( void ) {
+	return UI_CursorInRect( MAIN_MENU_REFRESH_X, MAIN_MENU_REFRESH_Y,
+		MAIN_MENU_REFRESH_WIDTH, MAIN_MENU_REFRESH_HEIGHT );
+}
+
+/*
+=================
+Main_MenuSetLeftActive
+=================
+*/
+static void Main_MenuSetLeftActive( qboolean active ) {
+	int			flags;
+	float		*color;
+
+	if( active ) {
+		flags = QMF_LEFT_JUSTIFY | QMF_PULSEIFFOCUS;
+		color = color_red;
+	} else {
+		flags = QMF_LEFT_JUSTIFY;
+		color = main_menu_dim_red;
+	}
+
+	s_main.singleplayer.generic.flags = flags;
+	s_main.singleplayer.color = color;
+	s_main.multiplayer.generic.flags = flags;
+	s_main.multiplayer.color = color;
+	s_main.setup.generic.flags = flags;
+	s_main.setup.color = color;
+	s_main.demos.generic.flags = flags;
+	s_main.demos.color = color;
+	s_main.mods.generic.flags = flags;
+	s_main.mods.color = color;
+	s_main.exit.generic.flags = flags;
+	s_main.exit.color = color;
+}
+
+/*
+=================
+Main_MenuSetServersHeaderActive
+=================
+*/
+static void Main_MenuSetServersHeaderActive( qboolean active ) {
+	s_main.servers.color = active ? color_red : main_menu_dim_red;
+}
+
+/*
+=================
+Main_MenuUpdateFocus
+=================
+*/
+static void Main_MenuUpdateFocus( void ) {
+	menuframework_s	*m;
+	menucommon_s	*item;
+	int				i;
+
+	m = &s_main.menu;
+
+	if( Main_MenuRefreshMouse() ) {
+		s_main.serverFocus = qfalse;
+		UI_MainMenuServers_SetColumnFocus( qfalse );
+		Main_MenuSetLeftActive( qtrue );
+		Main_MenuSetServersHeaderActive( qfalse );
+		for( i = 0; i < m->nitems; i++ ) {
+			if( ((menucommon_s*)m->items[i])->id == ID_REFRESH ) {
+				Menu_SetCursor( m, i );
+				return;
+			}
+		}
+	}
+
+	if( UI_MainMenuServers_MouseRegion( &s_main.serverlist ) ) {
+		UI_MainMenuServers_Mouse( &s_main.serverlist );
+		s_main.serverFocus = qtrue;
+		UI_MainMenuServers_SetColumnFocus( qtrue );
+		Main_MenuSetLeftActive( qfalse );
+		Main_MenuSetServersHeaderActive( qtrue );
+		Menu_SetCursorToItem( m, &s_main.serverlist );
+		return;
+	}
+
+	for( i = 0; i < m->nitems; i++ ) {
+		item = (menucommon_s*)m->items[i];
+		if( item->flags & ( QMF_GRAYED | QMF_INACTIVE | QMF_HIDDEN ) ) {
+			continue;
+		}
+		if( item->type != MTYPE_PTEXT ) {
+			continue;
+		}
+		if( UI_CursorInRect( item->left, item->top,
+			item->right - item->left + 1, item->bottom - item->top + 1 ) ) {
+			s_main.serverFocus = qfalse;
+			UI_MainMenuServers_SetColumnFocus( qfalse );
+			Main_MenuSetLeftActive( qtrue );
+			Main_MenuSetServersHeaderActive( qfalse );
+			Menu_SetCursor( m, i );
+			return;
+		}
+	}
+
+	if( s_main.serverFocus ) {
+		UI_MainMenuServers_SetColumnFocus( qtrue );
+		Main_MenuSetLeftActive( qfalse );
+		Main_MenuSetServersHeaderActive( qtrue );
+		Menu_SetCursorToItem( m, &s_main.serverlist );
+		return;
+	}
+
+	UI_MainMenuServers_SetColumnFocus( qfalse );
+	Main_MenuSetLeftActive( qtrue );
+	Main_MenuSetServersHeaderActive( qfalse );
+}
 
 /*
 =================
@@ -158,7 +338,9 @@ MainMenu_Cache
 void MainMenu_Cache( void ) {
 	//s_main.bannerModel = trap_R_RegisterModel( MAIN_BANNER_MODEL );
 	s_main.bannerLogo = trap_R_RegisterShaderNoMip( "ratmod_menulogo_white" );
-
+	trap_R_RegisterShaderNoMip( ART_UNKNOWNMAP );
+	trap_R_RegisterShaderNoMip( ART_REFRESH0 );
+	trap_R_RegisterShaderNoMip( ART_REFRESH1 );
 }
 
 sfxHandle_t ErrorMessage_Key(int key)
@@ -170,92 +352,159 @@ sfxHandle_t ErrorMessage_Key(int key)
 
 /*
 ===============
+Main_MenuKey
+===============
+*/
+static sfxHandle_t Main_MenuKey( int key ) {
+	menuframework_s	*m;
+	menucommon_s	*item;
+	sfxHandle_t		sound;
+	int				i;
+
+	m = &s_main.menu;
+
+	Main_MenuUpdateFocus();
+
+	if( key == K_MOUSE1 ) {
+		if( Main_MenuRefreshMouse() ) {
+			if( !UI_MainMenuServers_IsRefreshing() ) {
+				Main_MenuRefreshEvent( &s_main.refresh, QM_ACTIVATED );
+			}
+			return menu_move_sound;
+		}
+
+		if( UI_MainMenuServers_MouseRegion( &s_main.serverlist ) ) {
+			if( UI_MainMenuServers_MouseClick( &s_main.serverlist ) ) {
+				return menu_move_sound;
+			}
+		}
+
+		for( i = 0; i < m->nitems; i++ ) {
+			item = (menucommon_s*)m->items[i];
+			if( item->flags & ( QMF_INACTIVE | QMF_HIDDEN | QMF_GRAYED ) ) {
+				continue;
+			}
+			if( item->type != MTYPE_PTEXT ) {
+				continue;
+			}
+			if( UI_CursorInRect( item->left, item->top,
+				item->right - item->left + 1, item->bottom - item->top + 1 ) ) {
+				return Menu_ActivateItem( m, item );
+			}
+		}
+
+		return menu_null_sound;
+	}
+
+	if( key == K_RIGHTARROW || key == K_KP_RIGHTARROW ) {
+		if( !s_main.serverFocus ) {
+			s_main.menuCursor = m->cursor;
+			s_main.serverFocus = qtrue;
+			UI_MainMenuServers_SetColumnFocus( qtrue );
+			Main_MenuSetLeftActive( qfalse );
+			Main_MenuSetServersHeaderActive( qtrue );
+			Menu_SetCursorToItem( m, &s_main.serverlist );
+			Menu_CursorMoved( m );
+			return menu_move_sound;
+		}
+	}
+
+	if( key == K_LEFTARROW || key == K_KP_LEFTARROW ) {
+		if( s_main.serverFocus ) {
+			s_main.serverFocus = qfalse;
+			UI_MainMenuServers_SetColumnFocus( qfalse );
+			Main_MenuSetLeftActive( qtrue );
+			Main_MenuSetServersHeaderActive( qfalse );
+			m->cursor = s_main.menuCursor;
+			Menu_CursorMoved( m );
+			return menu_move_sound;
+		}
+	}
+
+	if( s_main.serverFocus ) {
+		if( key == K_MWHEELUP ) {
+			ScrollList_Key( &s_main.serverlist, K_UPARROW );
+			return menu_move_sound;
+		}
+
+		if( key == K_MWHEELDOWN ) {
+			ScrollList_Key( &s_main.serverlist, K_DOWNARROW );
+			return menu_move_sound;
+		}
+
+		if( key == K_UPARROW || key == K_DOWNARROW ) {
+			sound = ScrollList_Key( &s_main.serverlist, key );
+			return sound ? sound : menu_buzz_sound;
+		}
+
+		if( key == K_ENTER || key == K_KP_ENTER ) {
+			UI_MainMenuServers_Connect( &s_main.serverlist );
+			return menu_move_sound;
+		}
+
+		if( key == K_ESCAPE || key == K_MOUSE2 ) {
+			return Menu_DefaultKey( m, key );
+		}
+
+		return 0;
+	}
+
+	if( key == K_DOWNARROW || key == K_TAB ) {
+		if( m->cursor == MAIN_MENU_LAST_ITEM ) {
+			m->cursor_prev = m->cursor;
+			m->cursor = 0;
+			Menu_CursorMoved( m );
+			return menu_move_sound;
+		}
+	}
+
+	if( key == K_UPARROW ) {
+		if( m->cursor == 0 ) {
+			m->cursor_prev = m->cursor;
+			m->cursor = MAIN_MENU_LAST_ITEM;
+			Menu_CursorMoved( m );
+			return menu_move_sound;
+		}
+	}
+
+	return Menu_DefaultKey( m, key );
+}
+
+/*
+===============
 Main_MenuDraw
 TTimo: this function is common to the main menu and errorMessage menu
 ===============
 */
 
 static void Main_MenuDraw( void ) {
-	//refdef_t		refdef;
-	//refEntity_t		ent;
-	//vec3_t			origin;
-	//vec3_t			angles;
-	//float			adjust;
-	//float			x, y, w, h;
 	vec4_t			color = {1.0, 1.0, 0, 1};
 
-	//// setup the refdef
+	UI_DrawHandlePic( 320 - 60, 0, 120, 120, s_main.bannerLogo );
 
-	//memset( &refdef, 0, sizeof( refdef ) );
-
-	//refdef.rdflags = RDF_NOWORLDMODEL;
-
-	//AxisClear( refdef.viewaxis );
-
-	//x = 0;
-	//y = 0;
-	//w = 640;
-	//h = 120;
-	//UI_AdjustFrom640( &x, &y, &w, &h );
-	//refdef.x = x;
-	//refdef.y = y;
-	//refdef.width = w;
-	//refdef.height = h;
-
-	//adjust = 0; // JDC: Kenneth asked me to stop this 1.0 * sin( (float)uis.realtime / 1000 );
-	//refdef.fov_x = 60 + adjust;
-	//refdef.fov_y = 19.6875 + adjust;
-
-	//refdef.time = uis.realtime;
-
-	//origin[0] = 300;
-	//origin[1] = 0;
-	//origin[2] = -32;
-
-	//trap_R_ClearScene();
-
-	//// add the model
-
-	//memset( &ent, 0, sizeof(ent) );
-
-	//adjust = 5.0 * sin( (float)uis.realtime / 5000 );
-	//VectorSet( angles, 0, 180 + adjust, 0 );
-	//AnglesToAxis( angles, ent.axis );
-	//ent.hModel = s_main.bannerModel;
-	//VectorCopy( origin, ent.origin );
-	//VectorCopy( origin, ent.lightingOrigin );
-	//ent.renderfx = RF_LIGHTING_ORIGIN | RF_NOSHADOW;
-	//VectorCopy( ent.origin, ent.oldorigin );
-
-	//trap_R_AddRefEntityToScene( &ent );
-
-	//trap_R_RenderScene( &refdef );
-
-	UI_DrawHandlePic( 320-60, 0, 120, 120, s_main.bannerLogo );
-	
 	if (strlen(s_errorMessage.errorMessage))
 	{
 		UI_DrawProportionalString_AutoWrapped( 320, 192, 600, 20, s_errorMessage.errorMessage, UI_CENTER|UI_SMALLFONT|UI_DROPSHADOW, menu_text_color );
 	}
 	else
 	{
-		// standard menu drawing
-		Menu_Draw( &s_main.menu );		
+		UI_MainMenuServers_Resume( &s_main.serverlist, &s_main.mappic );
+
+		UI_MainMenuServers_Update();
+
+		Main_MenuUpdateFocus();
+
+		if( UI_MainMenuServers_IsRefreshing() ) {
+			UI_DrawString( MAIN_MENU_SCANNING_X, MAIN_MENU_SCANNING_Y, "Scanning...", UI_RIGHT | UI_SMALLFONT, menu_text_color );
+		}
+
+		Menu_Draw( &s_main.menu );
+		UI_MainMenuServers_Draw( &s_main.serverlist );
 	}
 
-		UI_DrawProportionalString( 320, 372, "", UI_CENTER|UI_SMALLFONT, color );
-		//UI_DrawString( 320, 386, "RatArena(c) 2017-2021 Ratmod Team", UI_CENTER|UI_SMALLFONT, color );
-		//UI_DrawString( 320, 400, "based on OpenArena(c) 2005-2012 OpenArena Team", UI_CENTER|UI_SMALLFONT, color );
-		//UI_DrawString( 320, 414, "Ratmod/OpenArena comes with ABSOLUTELY NO WARRANTY; this is free software", UI_CENTER|UI_SMALLFONT, color );
-		//UI_DrawString( 320, 428, "and you are welcome to redistribute it under certain conditions;", UI_CENTER|UI_SMALLFONT, color );
-		//UI_DrawString( 320, 444, "read COPYING for details.", UI_CENTER|UI_SMALLFONT, color );
-                
-        //Draw version.
-		//color[0] = 0;
-                UI_DrawString( 320, 480-34, COMPILE_VERSION, UI_CENTER|UI_DROPSHADOW|UI_SMALLFONT, color_red );
-				UI_DrawString( 320, 480-20, "https://github.com/alcachofass/devotion", UI_CENTER|UI_DROPSHADOW|UI_SMALLFONT, color_red );
-                //if((int)trap_Cvar_VariableValue("protocol")!=71)
-                    //UI_DrawString( 0, 480-14, va("^7Protocol: %i",(int)trap_Cvar_VariableValue("protocol")), UI_SMALLFONT, color);
+	UI_DrawProportionalString( 320, 372, "", UI_CENTER|UI_SMALLFONT, color );
+	UI_DrawString( 320, 480-34, COMPILE_VERSION, UI_CENTER|UI_DROPSHADOW|UI_SMALLFONT, color_red );
+	UI_DrawString( 320, 480-20, "https://github.com/alcachofass/devotion", UI_CENTER|UI_DROPSHADOW|UI_SMALLFONT, color_red );
 }
 
 
@@ -298,7 +547,7 @@ and that local cinematics are killed
 void UI_MainMenu( void ) {
 	int		y;
 	qboolean teamArena = qfalse;
-	int		style = UI_CENTER | UI_DROPSHADOW;
+	int		style = UI_LEFT | UI_DROPSHADOW;
 
 	trap_Cvar_Set( "sv_killserver", "1" );
         trap_Cvar_SetValue( "handicap", 100 ); //Reset handicap during server change, it must be ser per game
@@ -326,29 +575,16 @@ void UI_MainMenu( void ) {
 	}
 
 	s_main.menu.draw = Main_MenuDraw;
+	s_main.menu.key = Main_MenuKey;
 	s_main.menu.fullscreen = qtrue;
 	s_main.menu.wrapAround = qtrue;
 	s_main.menu.showlogo = qtrue;
 
-	//y = 134;
-	y = 154;
+	y = MAIN_MENU_TOP_Y;
 
-	/*
-	s_main.introduction.generic.type		= MTYPE_PTEXT;
-	s_main.introduction.generic.flags		= QMF_CENTER_JUSTIFY|QMF_PULSEIFFOCUS;
-	s_main.introduction.generic.x			= 320;
-	s_main.introduction.generic.y			= y;
-	s_main.introduction.generic.id			= ID_INTRODUCTION;
-	s_main.introduction.generic.callback	= Main_MenuEvent; 
-	s_main.introduction.string				= "INTRODUCTION";
-	s_main.introduction.color				= color_red;
-	s_main.introduction.style				= style;
-
-	y += MAIN_MENU_VERTICAL_SPACING;
-	*/	
 	s_main.singleplayer.generic.type		= MTYPE_PTEXT;
-	s_main.singleplayer.generic.flags		= QMF_CENTER_JUSTIFY|QMF_PULSEIFFOCUS;
-	s_main.singleplayer.generic.x			= 320;
+	s_main.singleplayer.generic.flags		= QMF_LEFT_JUSTIFY|QMF_PULSEIFFOCUS;
+	s_main.singleplayer.generic.x			= MAIN_MENU_LEFT_X;
 	s_main.singleplayer.generic.y			= y;
 	s_main.singleplayer.generic.id			= ID_SINGLEPLAYER;
 	s_main.singleplayer.generic.callback	= Main_MenuEvent; 
@@ -358,8 +594,8 @@ void UI_MainMenu( void ) {
 
 	y += MAIN_MENU_VERTICAL_SPACING;
 	s_main.multiplayer.generic.type			= MTYPE_PTEXT;
-	s_main.multiplayer.generic.flags		= QMF_CENTER_JUSTIFY|QMF_PULSEIFFOCUS;
-	s_main.multiplayer.generic.x			= 320;
+	s_main.multiplayer.generic.flags		= QMF_LEFT_JUSTIFY|QMF_PULSEIFFOCUS;
+	s_main.multiplayer.generic.x			= MAIN_MENU_LEFT_X;
 	s_main.multiplayer.generic.y			= y;
 	s_main.multiplayer.generic.id			= ID_MULTIPLAYER;
 	s_main.multiplayer.generic.callback		= Main_MenuEvent; 
@@ -369,8 +605,8 @@ void UI_MainMenu( void ) {
 
 	y += MAIN_MENU_VERTICAL_SPACING;
 	s_main.setup.generic.type				= MTYPE_PTEXT;
-	s_main.setup.generic.flags				= QMF_CENTER_JUSTIFY|QMF_PULSEIFFOCUS;
-	s_main.setup.generic.x					= 320;
+	s_main.setup.generic.flags				= QMF_LEFT_JUSTIFY|QMF_PULSEIFFOCUS;
+	s_main.setup.generic.x					= MAIN_MENU_LEFT_X;
 	s_main.setup.generic.y					= y;
 	s_main.setup.generic.id					= ID_SETUP;
 	s_main.setup.generic.callback			= Main_MenuEvent; 
@@ -380,56 +616,19 @@ void UI_MainMenu( void ) {
 
 	y += MAIN_MENU_VERTICAL_SPACING;
 	s_main.demos.generic.type				= MTYPE_PTEXT;
-	s_main.demos.generic.flags				= QMF_CENTER_JUSTIFY|QMF_PULSEIFFOCUS;
-	s_main.demos.generic.x					= 320;
+	s_main.demos.generic.flags				= QMF_LEFT_JUSTIFY|QMF_PULSEIFFOCUS;
+	s_main.demos.generic.x					= MAIN_MENU_LEFT_X;
 	s_main.demos.generic.y					= y;
 	s_main.demos.generic.id					= ID_DEMOS;
 	s_main.demos.generic.callback			= Main_MenuEvent; 
-	s_main.demos.string						= "DEMOS";
+	s_main.demos.string						= "REPLAYS";
 	s_main.demos.color						= color_red;
 	s_main.demos.style						= style;
 
-	/*y += MAIN_MENU_VERTICAL_SPACING;
-	s_main.cinematics.generic.type			= MTYPE_PTEXT;
-	s_main.cinematics.generic.flags			= QMF_CENTER_JUSTIFY|QMF_PULSEIFFOCUS;
-	s_main.cinematics.generic.x				= 320;
-	s_main.cinematics.generic.y				= y;
-	s_main.cinematics.generic.id			= ID_CINEMATICS;
-	s_main.cinematics.generic.callback		= Main_MenuEvent; 
-	s_main.cinematics.string				= "CINEMATICS";
-	s_main.cinematics.color					= color_red;
-	s_main.cinematics.style					= style;*/
-/*
-    y += MAIN_MENU_VERTICAL_SPACING;
-	s_main.challenges.generic.type			= MTYPE_PTEXT;
-	s_main.challenges.generic.flags			= QMF_CENTER_JUSTIFY|QMF_PULSEIFFOCUS;
-	s_main.challenges.generic.x				= 320;
-	s_main.challenges.generic.y				= y;
-	s_main.challenges.generic.id			= ID_CHALLENGES;
-	s_main.challenges.generic.callback		= Main_MenuEvent;
-	s_main.challenges.string				= "STATISTICS";
-	s_main.challenges.color					= color_red;
-	s_main.challenges.style					= style;
-*/
-
-	//if (UI_TeamArenaExists()) {
-	//	teamArena = qtrue;
-	//	y += MAIN_MENU_VERTICAL_SPACING;
-	//	s_main.teamArena.generic.type			= MTYPE_PTEXT;
-	//	s_main.teamArena.generic.flags			= QMF_CENTER_JUSTIFY|QMF_PULSEIFFOCUS;
-	//	s_main.teamArena.generic.x				= 320;
-	//	s_main.teamArena.generic.y				= y;
-	//	s_main.teamArena.generic.id				= ID_TEAMARENA;
-	//	s_main.teamArena.generic.callback		= Main_MenuEvent; 
-	//	s_main.teamArena.string					= "MISSION PACK";
-	//	s_main.teamArena.color					= color_red;
-	//	s_main.teamArena.style					= style;
-	//}
-
 	y += MAIN_MENU_VERTICAL_SPACING;
 	s_main.mods.generic.type			= MTYPE_PTEXT;
-	s_main.mods.generic.flags			= QMF_CENTER_JUSTIFY|QMF_PULSEIFFOCUS;
-	s_main.mods.generic.x				= 320;
+	s_main.mods.generic.flags			= QMF_LEFT_JUSTIFY|QMF_PULSEIFFOCUS;
+	s_main.mods.generic.x				= MAIN_MENU_LEFT_X;
 	s_main.mods.generic.y				= y;
 	s_main.mods.generic.id				= ID_MODS;
 	s_main.mods.generic.callback		= Main_MenuEvent; 
@@ -439,8 +638,8 @@ void UI_MainMenu( void ) {
 
 	y += MAIN_MENU_VERTICAL_SPACING;
 	s_main.exit.generic.type				= MTYPE_PTEXT;
-	s_main.exit.generic.flags				= QMF_CENTER_JUSTIFY|QMF_PULSEIFFOCUS;
-	s_main.exit.generic.x					= 320;
+	s_main.exit.generic.flags				= QMF_LEFT_JUSTIFY|QMF_PULSEIFFOCUS;
+	s_main.exit.generic.x					= MAIN_MENU_LEFT_X;
 	s_main.exit.generic.y					= y;
 	s_main.exit.generic.id					= ID_EXIT;
 	s_main.exit.generic.callback			= Main_MenuEvent; 
@@ -448,18 +647,57 @@ void UI_MainMenu( void ) {
 	s_main.exit.color						= color_red;
 	s_main.exit.style						= style;
 
-//	Menu_AddItem( &s_main.menu,	&s_main.introduction );
+	s_main.servers.generic.type				= MTYPE_PTEXT;
+	s_main.servers.generic.flags			= QMF_RIGHT_JUSTIFY | QMF_INACTIVE;
+	s_main.servers.generic.x				= MAIN_MENU_SERVERS_HEADER_X;
+	s_main.servers.generic.y				= MAIN_MENU_TOP_Y;
+	s_main.servers.string					= "SERVERS";
+	s_main.servers.color					= color_red;
+	s_main.servers.style					= UI_RIGHT | UI_DROPSHADOW;
+
+	s_main.serverlist.generic.type			= MTYPE_SCROLLLIST;
+	s_main.serverlist.generic.flags			= QMF_HIGHLIGHT_IF_FOCUS | QMF_HIDDEN | QMF_INACTIVE;
+	s_main.serverlist.generic.id			= ID_SERVERLIST;
+	s_main.serverlist.generic.callback		= Main_MenuServerEvent;
+	s_main.serverlist.generic.x				= MAIN_MENU_LIST_X;
+	s_main.serverlist.generic.y				= MAIN_MENU_LIST_Y;
+	s_main.serverlist.width					= MAIN_MENU_LIST_WIDTH;
+	s_main.serverlist.height				= MAIN_MENU_LIST_HEIGHT;
+
+	s_main.refresh.generic.type				= MTYPE_BITMAP;
+	s_main.refresh.generic.name				= ART_REFRESH0;
+	s_main.refresh.generic.flags			= QMF_LEFT_JUSTIFY | QMF_PULSEIFFOCUS | QMF_MOUSEONLY;
+	s_main.refresh.generic.callback			= Main_MenuRefreshEvent;
+	s_main.refresh.generic.id				= ID_REFRESH;
+	s_main.refresh.generic.x				= MAIN_MENU_REFRESH_X;
+	s_main.refresh.generic.y				= MAIN_MENU_REFRESH_Y;
+	s_main.refresh.width					= MAIN_MENU_REFRESH_WIDTH;
+	s_main.refresh.height					= MAIN_MENU_REFRESH_HEIGHT;
+	s_main.refresh.focuspic					= ART_REFRESH1;
+
+	s_main.mappic.generic.type				= MTYPE_BITMAP;
+	s_main.mappic.generic.flags				= QMF_LEFT_JUSTIFY | QMF_INACTIVE | QMF_HIDDEN;
+	s_main.mappic.generic.x					= MAIN_MENU_LEVELSHOT_X;
+	s_main.mappic.generic.y					= MAIN_MENU_LEVELSHOT_Y;
+	s_main.mappic.width						= MAIN_MENU_LEVELSHOT_WIDTH;
+	s_main.mappic.height					= MAIN_MENU_LEVELSHOT_HEIGHT;
+	s_main.mappic.errorpic				= ART_UNKNOWNMAP;
+
 	Menu_AddItem( &s_main.menu,	&s_main.singleplayer );
 	Menu_AddItem( &s_main.menu,	&s_main.multiplayer );
 	Menu_AddItem( &s_main.menu,	&s_main.setup );
 	Menu_AddItem( &s_main.menu,	&s_main.demos );
-	//Menu_AddItem( &s_main.menu,	&s_main.cinematics );
-    //Menu_AddItem( &s_main.menu,	&s_main.challenges );
 	if (teamArena) {
 		Menu_AddItem( &s_main.menu,	&s_main.teamArena );
 	}
 	Menu_AddItem( &s_main.menu,	&s_main.mods );
-	Menu_AddItem( &s_main.menu,	&s_main.exit );             
+	Menu_AddItem( &s_main.menu,	&s_main.exit );
+	Menu_AddItem( &s_main.menu,	&s_main.servers );
+	Menu_AddItem( &s_main.menu,	&s_main.mappic );
+	Menu_AddItem( &s_main.menu,	&s_main.refresh );
+	Menu_AddItem( &s_main.menu,	&s_main.serverlist );
+
+	UI_MainMenuServers_Begin( &s_main.serverlist, &s_main.mappic );
 
 	trap_Key_SetCatcher( KEYCATCH_UI );
 	uis.menusp = 0;

--- a/ratoa_gamecode/code/q3_ui/ui_servers2.c
+++ b/ratoa_gamecode/code/q3_ui/ui_servers2.c
@@ -93,6 +93,23 @@ MULTIPLAYER MENU (SERVER BROWSER)
 #define UIAS_GLOBAL5			5
 #define UIAS_FAVORITES			6
 
+#define MM_REFRESH_MASTERS		0
+#define MM_REFRESH_PINGING		1
+
+#define MAINMENU_MAX_ADDRESSES		1024
+#define MAINMENU_CACHE_FILE			"devotion_servers.cache"
+#define MAINMENU_MASTER_STABLE_MS	2000
+#define MAINMENU_MASTER_TIMEOUT_MS	15000
+#define MAINMENU_MASTER_BOOT_MS		750
+#define MAINMENU_PINGS_PER_TICK		4
+#define MAINMENU_PING_INTERVAL_MS	50
+#define MAINMENU_MAX_CACHE_WRITTEN	128
+#define MAINMENU_MAX_DISCOVERY_ADDRESSES	128
+#define MAINMENU_SCAN_TIMEOUT_MS		90000
+#define MAINMENU_PING_STALL_MS		10000
+#define MAINMENU_PING_UNKNOWN		(-1)
+#define MAINMENU_GAMETYPE_UNKNOWN	(-1)
+
 #define SORT_HOST			0
 #define SORT_MAP			1
 #define SORT_CLIENTS                    2
@@ -304,6 +321,8 @@ static arenaservers_t	g_arenaservers;
 
 static servernode_t		g_globalserverlist[MAX_GLOBALSERVERS];
 static int				g_numglobalservers;
+static servernode_t		g_mainmenu_serverlist[MAX_GLOBALSERVERS];
+static int				g_mainmenu_numservers;
 static servernode_t		g_localserverlist[MAX_LOCALSERVERS];
 static int				g_numlocalservers;
 static servernode_t		g_favoriteserverlist[MAX_FAVORITESERVERS];
@@ -316,6 +335,28 @@ static int				g_fullservers;
 
 static int				g_onlyhumans;
 static int                              g_hideprivate;
+
+static menulist_s			*g_mainmenu_list = NULL;
+static menubitmap_s			*g_mainmenu_mappic = NULL;
+static int					g_mainmenu_refresh_phase;
+static int					g_mainmenu_scan_start_time;
+static int					g_mainmenu_active_query_master;
+static int					g_mainmenu_last_ping_time;
+static int					g_mainmenu_master_last_count[UIAS_GLOBAL5 + 1];
+static int					g_mainmenu_master_merged_idx[UIAS_GLOBAL5 + 1];
+static int					g_mainmenu_master_stable_time[UIAS_GLOBAL5 + 1];
+static int					g_mainmenu_master_query_time[UIAS_GLOBAL5 + 1];
+static qboolean				g_mainmenu_master_done[UIAS_GLOBAL5 + 1];
+static qboolean				g_mainmenu_master_query_sent[UIAS_GLOBAL5 + 1];
+static char					g_mainmenu_cache_written[MAINMENU_MAX_CACHE_WRITTEN][MAX_ADDRESSLENGTH];
+static int					g_mainmenu_cache_written_count;
+static char					g_mainmenu_addresses[MAINMENU_MAX_ADDRESSES][MAX_ADDRESSLENGTH];
+static int					g_mainmenu_numaddresses;
+static int					g_mainmenu_discovery_addresses;
+static int					g_mainmenu_last_ping_activity;
+
+static void ArenaServers_StopRefresh( void );
+static void ArenaServers_UpdateMainMenuList( void );
 
 /*
  *Removes illigal chars but keeps colors
@@ -546,6 +587,698 @@ static qboolean ArenaServers_Filtered(servernode_t *servernodeptr) {
 
 /*
 =================
+MainMenuServers_IsDevotionMod
+=================
+*/
+static qboolean MainMenuServers_IsDevotionMod( const char *gamename ) {
+	return gamename && gamename[0] && !Q_stricmp( gamename, "devotion" );
+}
+
+/*
+=================
+MainMenuServers_AddressExists
+=================
+*/
+static qboolean MainMenuServers_AddressExists( const char *adrstr ) {
+	int		i;
+
+	for( i = 0; i < g_mainmenu_numaddresses; i++ ) {
+		if( !Q_stricmp( g_mainmenu_addresses[i], adrstr ) ) {
+			return qtrue;
+		}
+	}
+
+	return qfalse;
+}
+
+/*
+=================
+MainMenuServers_AddAddress
+=================
+*/
+static void MainMenuServers_AddAddress( const char *adrstr ) {
+	if( !adrstr || !adrstr[0] || MainMenuServers_AddressExists( adrstr ) ) {
+		return;
+	}
+
+	if( g_mainmenu_numaddresses >= MAINMENU_MAX_ADDRESSES ) {
+		return;
+	}
+
+	Q_strncpyz( g_mainmenu_addresses[g_mainmenu_numaddresses], adrstr, MAX_ADDRESSLENGTH );
+	g_mainmenu_numaddresses++;
+}
+
+/*
+=================
+MainMenuServers_AddDiscoveryAddress
+=================
+*/
+static void MainMenuServers_AddDiscoveryAddress( const char *adrstr ) {
+	if( g_mainmenu_discovery_addresses >= MAINMENU_MAX_DISCOVERY_ADDRESSES ) {
+		return;
+	}
+
+	if( !adrstr || !adrstr[0] || MainMenuServers_AddressExists( adrstr ) ) {
+		return;
+	}
+
+	if( g_mainmenu_numaddresses >= MAINMENU_MAX_ADDRESSES ) {
+		return;
+	}
+
+	MainMenuServers_AddAddress( adrstr );
+	g_mainmenu_discovery_addresses++;
+}
+
+/*
+=================
+MainMenuServers_ClearPendingPings
+=================
+*/
+static void MainMenuServers_ClearPendingPings( void ) {
+	int		i;
+
+	for( i = 0; i < MAX_PINGREQUESTS; i++ ) {
+		g_arenaservers.pinglist[i].adrstr[0] = '\0';
+		trap_LAN_ClearPing( i );
+	}
+}
+
+/*
+=================
+MainMenuServers_AnyPendingPings
+=================
+*/
+static qboolean MainMenuServers_AnyPendingPings( void ) {
+	int		i;
+
+	for( i = 0; i < MAX_PINGREQUESTS; i++ ) {
+		if( g_arenaservers.pinglist[i].adrstr[0] ) {
+			return qtrue;
+		}
+	}
+
+	return trap_LAN_GetPingQueueCount() > 0;
+}
+
+/*
+=================
+MainMenuServers_FinishRefreshIfDone
+=================
+*/
+static void MainMenuServers_FinishRefreshIfDone( void ) {
+	if( g_arenaservers.currentping < g_arenaservers.numqueriedservers ) {
+		return;
+	}
+
+	if( !MainMenuServers_AnyPendingPings() ) {
+		ArenaServers_StopRefresh();
+		return;
+	}
+
+	if( g_mainmenu_last_ping_activity &&
+		uis.realtime - g_mainmenu_last_ping_activity > MAINMENU_PING_STALL_MS ) {
+		MainMenuServers_ClearPendingPings();
+		ArenaServers_StopRefresh();
+	}
+}
+
+/*
+=================
+MainMenuServers_AddCachedAddresses
+=================
+*/
+static void MainMenuServers_AddCachedAddresses( void ) {
+	int		i;
+
+	for( i = 0; i < *g_arenaservers.numservers; i++ ) {
+		if( !MainMenuServers_IsDevotionMod( g_arenaservers.serverlist[i].gamename ) ) {
+			continue;
+		}
+		MainMenuServers_AddAddress( g_arenaservers.serverlist[i].adrstr );
+	}
+}
+
+/*
+=================
+MainMenuServers_InsertCachedServer
+=================
+*/
+static qboolean MainMenuServers_HasPing( servernode_t *servernodeptr );
+
+static void MainMenuServers_InsertCachedServer( const char *adrstr, const char *hostname, const char *mapname, int pingtime ) {
+	servernode_t	*servernodeptr;
+	int				i;
+
+	for( i = 0; i < *g_arenaservers.numservers; i++ ) {
+		if( !Q_stricmp( g_arenaservers.serverlist[i].adrstr, adrstr ) ) {
+			return;
+		}
+	}
+
+	if( *g_arenaservers.numservers >= g_arenaservers.maxservers ) {
+		return;
+	}
+
+	servernodeptr = g_arenaservers.serverlist + (*g_arenaservers.numservers);
+	(*g_arenaservers.numservers)++;
+
+	Q_strncpyz( servernodeptr->adrstr, adrstr, MAX_ADDRESSLENGTH );
+	Q_strncpyz( servernodeptr->hostname, hostname, sizeof( servernodeptr->hostname ) );
+	Q_strncpyz( servernodeptr->mapname, mapname, sizeof( servernodeptr->mapname ) );
+	Q_strncpyz( servernodeptr->gamename, "devotion", sizeof( servernodeptr->gamename ) );
+	servernodeptr->pingtime = pingtime;
+	servernodeptr->gametype = MAINMENU_GAMETYPE_UNKNOWN;
+	servernodeptr->maxclients = 0;
+	servernodeptr->numclients = 0;
+	servernodeptr->humanclients = 0;
+}
+
+/*
+=================
+MainMenuServers_LoadCache
+=================
+*/
+static void MainMenuServers_LoadCache( void ) {
+	fileHandle_t	f;
+	int				len;
+	char			buffer[4096];
+	char			*cursor;
+	char			*line;
+	char			*adr;
+	char			*host;
+	char			*map;
+	char			*pingstr;
+	int				pingtime;
+
+	len = trap_FS_FOpenFile( MAINMENU_CACHE_FILE, &f, FS_READ );
+	if( len <= 0 ) {
+		return;
+	}
+
+	if( len >= (int)sizeof( buffer ) ) {
+		len = sizeof( buffer ) - 1;
+	}
+
+	trap_FS_Read( buffer, len, f );
+	trap_FS_FCloseFile( f );
+	buffer[len] = '\0';
+
+	cursor = buffer;
+	while( cursor && *cursor ) {
+		line = cursor;
+		cursor = strchr( cursor, '\n' );
+		if( cursor ) {
+			*cursor = '\0';
+			cursor++;
+		}
+
+		adr = line;
+		host = strchr( line, '\t' );
+		pingstr = NULL;
+		if( host ) {
+			*host = '\0';
+			host++;
+			map = strchr( host, '\t' );
+			if( map ) {
+				*map = '\0';
+				map++;
+				pingstr = strchr( map, '\t' );
+				if( pingstr ) {
+					*pingstr = '\0';
+					pingstr++;
+				}
+			} else {
+				map = "";
+			}
+		} else {
+			host = "";
+			map = "";
+		}
+
+		if( !adr[0] ) {
+			continue;
+		}
+
+		pingtime = MAINMENU_PING_UNKNOWN;
+		if( pingstr && pingstr[0] ) {
+			pingtime = atoi( pingstr );
+			if( pingtime < 0 ) {
+				pingtime = MAINMENU_PING_UNKNOWN;
+			}
+		}
+
+		MainMenuServers_InsertCachedServer( adr, host, map, pingtime );
+		MainMenuServers_AddAddress( adr );
+
+		if( g_mainmenu_cache_written_count < MAINMENU_MAX_CACHE_WRITTEN ) {
+			Q_strncpyz( g_mainmenu_cache_written[g_mainmenu_cache_written_count], adr, MAX_ADDRESSLENGTH );
+			g_mainmenu_cache_written_count++;
+		}
+	}
+}
+
+/*
+=================
+MainMenuServers_IsCacheWritten
+=================
+*/
+static qboolean MainMenuServers_IsCacheWritten( const char *adrstr ) {
+	int		i;
+
+	for( i = 0; i < g_mainmenu_cache_written_count; i++ ) {
+		if( !Q_stricmp( g_mainmenu_cache_written[i], adrstr ) ) {
+			return qtrue;
+		}
+	}
+
+	return qfalse;
+}
+
+/*
+=================
+MainMenuServers_CacheServer
+=================
+*/
+static void MainMenuServers_CacheServer( servernode_t *servernodeptr ) {
+	fileHandle_t	f;
+	char			line[MAX_ADDRESSLENGTH + MAX_HOSTNAMELENGTH + MAX_MAPNAMELENGTH + 16];
+	char			hostname[MAX_HOSTNAMELENGTH + 3];
+
+	if( !g_mainmenu_list || !servernodeptr ) {
+		return;
+	}
+
+	if( !MainMenuServers_IsDevotionMod( servernodeptr->gamename ) ) {
+		return;
+	}
+
+	if( MainMenuServers_IsCacheWritten( servernodeptr->adrstr ) ) {
+		return;
+	}
+
+	if( g_mainmenu_cache_written_count < MAINMENU_MAX_CACHE_WRITTEN ) {
+		Q_strncpyz( g_mainmenu_cache_written[g_mainmenu_cache_written_count],
+			servernodeptr->adrstr, MAX_ADDRESSLENGTH );
+		g_mainmenu_cache_written_count++;
+	}
+
+	Q_strncpyz( hostname, servernodeptr->hostname, sizeof( hostname ) );
+	Q_CleanStrWithColor( hostname );
+	if( MainMenuServers_HasPing( servernodeptr ) ) {
+		Com_sprintf( line, sizeof( line ), "%s\t%s\t%s\t%d\n",
+			servernodeptr->adrstr, hostname, servernodeptr->mapname, servernodeptr->pingtime );
+	} else {
+		Com_sprintf( line, sizeof( line ), "%s\t%s\t%s\n",
+			servernodeptr->adrstr, hostname, servernodeptr->mapname );
+	}
+
+	trap_FS_FOpenFile( MAINMENU_CACHE_FILE, &f, FS_APPEND );
+	trap_FS_Write( line, strlen( line ), f );
+	trap_FS_FCloseFile( f );
+}
+
+/*
+=================
+MainMenuServers_SaveCache
+=================
+*/
+static void MainMenuServers_SaveCache( void ) {
+	fileHandle_t	f;
+	int				i;
+	servernode_t	*servernodeptr;
+	char			line[MAX_ADDRESSLENGTH + MAX_HOSTNAMELENGTH + MAX_MAPNAMELENGTH + 16];
+	char			hostname[MAX_HOSTNAMELENGTH + 3];
+
+	trap_FS_FOpenFile( MAINMENU_CACHE_FILE, &f, FS_WRITE );
+
+	for( i = 0; i < *g_arenaservers.numservers; i++ ) {
+		servernodeptr = &g_arenaservers.serverlist[i];
+		if( !MainMenuServers_IsDevotionMod( servernodeptr->gamename ) ) {
+			continue;
+		}
+
+		Q_strncpyz( hostname, servernodeptr->hostname, sizeof( hostname ) );
+		Q_CleanStrWithColor( hostname );
+		if( MainMenuServers_HasPing( servernodeptr ) ) {
+			Com_sprintf( line, sizeof( line ), "%s\t%s\t%s\t%d\n",
+				servernodeptr->adrstr, hostname, servernodeptr->mapname, servernodeptr->pingtime );
+		} else {
+			Com_sprintf( line, sizeof( line ), "%s\t%s\t%s\n",
+				servernodeptr->adrstr, hostname, servernodeptr->mapname );
+		}
+		trap_FS_Write( line, strlen( line ), f );
+	}
+
+	trap_FS_FCloseFile( f );
+}
+
+/*
+=================
+UI_MainMenuServers_UpdatePicture
+=================
+*/
+void UI_MainMenuServers_UpdatePicture( menubitmap_s *mappic ) {
+	static char		picname[64];
+	servernode_t	*servernodeptr;
+	menulist_s		*list;
+	table_t			*tableptr;
+
+	if( !mappic || !g_mainmenu_list ) {
+		return;
+	}
+
+	list = g_mainmenu_list;
+	if( !list->numitems ) {
+		mappic->generic.name = NULL;
+		mappic->shader = 0;
+		return;
+	}
+
+	tableptr = &g_arenaservers.table[list->curvalue];
+	servernodeptr = tableptr->servernode;
+	if( !servernodeptr || !servernodeptr->mapname[0] ) {
+		mappic->generic.name = NULL;
+		mappic->shader = 0;
+		return;
+	}
+
+	Com_sprintf( picname, sizeof( picname ), "levelshots/%s.tga", servernodeptr->mapname );
+	mappic->generic.name = picname;
+	mappic->shader = 0;
+}
+
+/*
+=================
+ArenaServers_UpdateMainMenuList
+=================
+*/
+#define MAIN_MENU_SERVER_INFO_LINE_COUNT	5
+#define MAIN_MENU_SERVER_INFO_GAP		0
+#define MAIN_MENU_MAPNAME_MAX_FRIENDLY	25
+#define MAIN_MENU_SERVER_NAME_LINE_HEIGHT	SMALLCHAR_HEIGHT
+#define MAIN_MENU_SERVER_INFO_LINE_HEIGHT	TINYCHAR_HEIGHT
+#define MAIN_MENU_SERVER_CONTENT_HEIGHT	( MAIN_MENU_SERVER_NAME_LINE_HEIGHT + MAIN_MENU_SERVER_INFO_LINE_COUNT * MAIN_MENU_SERVER_INFO_LINE_HEIGHT )
+#define MAIN_MENU_SERVER_TEXT_PAD		4
+#define MAIN_MENU_SERVER_TEXT_RIGHT_X	( MAIN_MENU_LEVELSHOT_X - MAIN_MENU_SERVER_TEXT_PAD )
+#define MAIN_MENU_SERVER_BLOCK_HEIGHT	( MAIN_MENU_SERVER_CONTENT_HEIGHT >= MAIN_MENU_LEVELSHOT_HEIGHT ? MAIN_MENU_SERVER_CONTENT_HEIGHT : MAIN_MENU_LEVELSHOT_HEIGHT ) + MAIN_MENU_SERVER_INFO_GAP
+#define MAIN_MENU_LEVELSHOT_X			527
+#define MAIN_MENU_LEVELSHOT_Y_OFFSET	( -2 )
+#define MAIN_MENU_LEVELSHOT_WIDTH		82
+#define MAIN_MENU_LEVELSHOT_HEIGHT		61
+#define MAIN_MENU_UNKNOWNMAP			"menu/art/unknownmap"
+
+static qhandle_t g_mainmenu_unknownmap_shader = 0;
+static qboolean g_mainmenu_server_column_focus = qfalse;
+
+void UI_MainMenuServers_SetColumnFocus( qboolean focus ) {
+	g_mainmenu_server_column_focus = focus;
+}
+
+qboolean UI_MainMenuServers_GetColumnFocus( void ) {
+	return g_mainmenu_server_column_focus;
+}
+
+static int MainMenuServers_MouseIndex( menulist_s *list ) {
+	int		x;
+	int		y;
+	int		w;
+	int		h;
+	int		index;
+
+	if( !list || !list->numitems ) {
+		return -1;
+	}
+
+	x = list->generic.x - 2;
+	y = list->generic.y;
+	w = MAIN_MENU_LEVELSHOT_X + MAIN_MENU_LEVELSHOT_WIDTH - x;
+	h = list->height * MAIN_MENU_SERVER_BLOCK_HEIGHT;
+
+	if( !UI_CursorInRect( x, y, w, h ) ) {
+		return -1;
+	}
+
+	index = ( uis.cursory - y ) / MAIN_MENU_SERVER_BLOCK_HEIGHT;
+	if( index < 0 || index >= list->height ) {
+		return -1;
+	}
+
+	index += list->top;
+	if( index >= list->numitems ) {
+		return -1;
+	}
+
+	return index;
+}
+
+qboolean UI_MainMenuServers_MouseRegion( menulist_s *list ) {
+	return MainMenuServers_MouseIndex( list ) >= 0;
+}
+
+static void MainMenuServers_GetMapFriendlyName( const char *mapname, char *out, int outlen ) {
+	const char	*arenaInfo;
+	const char	*longname;
+	int			len;
+
+	if( !out || outlen <= 0 ) {
+		return;
+	}
+
+	out[0] = '\0';
+
+	if( !mapname || !mapname[0] ) {
+		return;
+	}
+
+	arenaInfo = UI_GetArenaInfoByMap( mapname );
+	if( !arenaInfo ) {
+		return;
+	}
+
+	longname = Info_ValueForKey( arenaInfo, "longname" );
+	if( !longname || !longname[0] ) {
+		return;
+	}
+
+	Q_strncpyz( out, longname, outlen );
+	len = strlen( out );
+	if( len > MAIN_MENU_MAPNAME_MAX_FRIENDLY ) {
+		out[MAIN_MENU_MAPNAME_MAX_FRIENDLY] = '\0';
+	}
+}
+
+static void MainMenuServers_DrawEntryString( int rightX, int y, const char *str, int style, vec4_t color, qboolean compact ) {
+	int		charw;
+	int		charh;
+	int		x;
+
+	if( !str || !str[0] ) {
+		return;
+	}
+
+	charw = SMALLCHAR_WIDTH;
+	charh = compact ? TINYCHAR_HEIGHT : SMALLCHAR_HEIGHT;
+
+	x = rightX - Q_PrintStrlen( str ) * charw;
+	style &= ~UI_FORMATMASK;
+	UI_DrawStringSized( x, y, str, style, color, charw, charh );
+}
+
+static qboolean MainMenuServers_HasPing( servernode_t *servernodeptr ) {
+	if( !servernodeptr ) {
+		return qfalse;
+	}
+
+	if( servernodeptr->pingtime < 0 ) {
+		return qfalse;
+	}
+
+	if( servernodeptr->pingtime >= ArenaServers_MaxPing() ) {
+		return qfalse;
+	}
+
+	return qtrue;
+}
+
+static char *MainMenuServers_PingColor( servernode_t *servernodeptr ) {
+	if( servernodeptr->pingtime < servernodeptr->minPing ) {
+		return S_COLOR_BLUE;
+	}
+	if( servernodeptr->maxPing && servernodeptr->pingtime > servernodeptr->maxPing ) {
+		return S_COLOR_BLUE;
+	}
+	if( servernodeptr->pingtime < 200 ) {
+		return S_COLOR_GREEN;
+	}
+	if( servernodeptr->pingtime < 400 ) {
+		return S_COLOR_YELLOW;
+	}
+	return S_COLOR_RED;
+}
+
+static const char *MainMenuServers_GametypeName( int gametype ) {
+	switch( gametype ) {
+	case GT_FFA:
+		return "FFA";
+	case GT_TOURNAMENT:
+		return "Duel";
+	case GT_SINGLE_PLAYER:
+		return "SP";
+	case GT_TEAM:
+		return "TDM";
+	case GT_CTF:
+		return "CTF";
+#ifdef MISSIONPACK
+	case GT_1FCTF:
+		return "1FCTF";
+	case GT_OBELISK:
+		return "Overload";
+	case GT_HARVESTER:
+		return "Harvester";
+#endif
+	case GT_ELIMINATION:
+		return "Elimination";
+	case GT_CTF_ELIMINATION:
+		return "CTF Elim";
+	case GT_LMS:
+		return "LMS";
+#ifdef WITH_DOM_GAMETYPE
+	case GT_DOMINATION:
+		return "Domination";
+#endif
+#ifdef WITH_DOUBLED_GAMETYPE
+	case GT_DOUBLE_D:
+		return "Double Dom";
+#endif
+#ifdef WITH_TREASURE_HUNTER_GAMETYPE
+	case GT_TREASURE_HUNTER:
+		return "Treasure Hunter";
+#endif
+#ifdef WITH_MULTITOURNAMENT
+	case GT_MULTITOURNAMENT:
+		return "Multi-Duel";
+#endif
+	default:
+		return "???";
+	}
+}
+
+static char *MainMenuServers_GametypeColor( int gametype ) {
+	switch( gametype ) {
+	case GT_FFA:
+	case GT_SINGLE_PLAYER:
+	case GT_LMS:
+		return S_COLOR_GREEN;
+	case GT_TOURNAMENT:
+#ifdef WITH_MULTITOURNAMENT
+	case GT_MULTITOURNAMENT:
+#endif
+		return S_COLOR_YELLOW;
+	case GT_TEAM:
+		return S_COLOR_CYAN;
+	case GT_CTF:
+#ifdef MISSIONPACK
+	case GT_1FCTF:
+#endif
+	case GT_CTF_ELIMINATION:
+		return S_COLOR_RED;
+	case GT_ELIMINATION:
+		return S_COLOR_MAGENTA;
+#ifdef MISSIONPACK
+	case GT_OBELISK:
+	case GT_HARVESTER:
+		return S_COLOR_BLUE;
+#endif
+#ifdef WITH_DOM_GAMETYPE
+	case GT_DOMINATION:
+		return S_COLOR_BLUE;
+#endif
+#ifdef WITH_DOUBLED_GAMETYPE
+	case GT_DOUBLE_D:
+		return S_COLOR_BLUE;
+#endif
+#ifdef WITH_TREASURE_HUNTER_GAMETYPE
+	case GT_TREASURE_HUNTER:
+		return S_COLOR_BLUE;
+#endif
+	default:
+		return S_COLOR_WHITE;
+	}
+}
+
+static void MainMenuServers_DrawLevelshot( int x, int y, const char *mapname ) {
+	char		picname[64];
+	qhandle_t	shader;
+
+	if( !mapname || !mapname[0] ) {
+		return;
+	}
+
+	Com_sprintf( picname, sizeof( picname ), "levelshots/%s.tga", mapname );
+	shader = trap_R_RegisterShaderNoMip( picname );
+	if( !shader ) {
+		if( !g_mainmenu_unknownmap_shader ) {
+			g_mainmenu_unknownmap_shader = trap_R_RegisterShaderNoMip( MAIN_MENU_UNKNOWNMAP );
+		}
+		shader = g_mainmenu_unknownmap_shader;
+	}
+
+	UI_DrawHandlePic( x, y, MAIN_MENU_LEVELSHOT_WIDTH, MAIN_MENU_LEVELSHOT_HEIGHT, shader );
+}
+
+static void ArenaServers_UpdateMainMenuList( void ) {
+	int				i;
+	int				j;
+	int				count;
+	int				curvalue;
+	servernode_t	*servernodeptr;
+	table_t			*tableptr;
+	menulist_s		*list;
+
+	list = g_mainmenu_list;
+	if( !list ) {
+		return;
+	}
+
+	curvalue = list->curvalue;
+
+	if( *g_arenaservers.numservers > 0 ) {
+		qsort( g_arenaservers.serverlist, *g_arenaservers.numservers, sizeof( servernode_t ), ArenaServers_Compare );
+	}
+
+	servernodeptr = g_arenaservers.serverlist;
+	count = *g_arenaservers.numservers;
+	for( i = 0, j = 0; i < count; i++, servernodeptr++ ) {
+		if( !MainMenuServers_IsDevotionMod( servernodeptr->gamename ) ) {
+			continue;
+		}
+
+		tableptr = &g_arenaservers.table[j];
+		tableptr->servernode = servernodeptr;
+		tableptr->buff[0] = '\0';
+		j++;
+	}
+
+	list->numitems = j;
+	if( curvalue >= j ) {
+		list->curvalue = j > 0 ? j - 1 : 0;
+	} else {
+		list->curvalue = curvalue;
+	}
+	if( list->top > list->curvalue ) {
+		list->top = list->curvalue;
+	}
+	if( list->top < 0 ) {
+		list->top = 0;
+	}
+
+	UI_MainMenuServers_UpdatePicture( g_mainmenu_mappic );
+}
+
+/*
+=================
 ArenaServers_UpdateMenu
 =================
 */
@@ -557,6 +1290,11 @@ static void ArenaServers_UpdateMenu( void ) {
 	servernode_t*	servernodeptr;
 	table_t*		tableptr;
 	char			*b, *pingColor;
+
+	if( g_mainmenu_list ) {
+		ArenaServers_UpdateMainMenuList();
+		return;
+	}
 
 	if( g_arenaservers.numqueriedservers > 0 ) {
 		// servers found
@@ -916,25 +1654,59 @@ static void ArenaServers_Insert( char* adrstr, char* info, int pingtime )
 {
 	servernode_t*	servernodeptr;
 	char*			s;
+	char			savedGamename[64];
 	int				i;
+	qboolean		existing;
 
+	existing = qfalse;
+	servernodeptr = NULL;
+	savedGamename[0] = '\0';
 
-	if ((pingtime >= ArenaServers_MaxPing()) && (g_servertype != UIAS_FAVORITES))
-	{
-		// slow global or local servers do not get entered
-		return;
+	for( i = 0; i < *g_arenaservers.numservers; i++ ) {
+		if( !Q_stricmp( g_arenaservers.serverlist[i].adrstr, adrstr ) ) {
+			servernodeptr = &g_arenaservers.serverlist[i];
+			existing = qtrue;
+			break;
+		}
 	}
 
-	if (*g_arenaservers.numservers >= g_arenaservers.maxservers) {
-		// list full;
-		servernodeptr = g_arenaservers.serverlist+(*g_arenaservers.numservers)-1;
-	} else {
-		// next slot
-		servernodeptr = g_arenaservers.serverlist+(*g_arenaservers.numservers);
-		(*g_arenaservers.numservers)++;
+	if( !existing ) {
+		if ((pingtime >= ArenaServers_MaxPing()) && (g_servertype != UIAS_FAVORITES) && !g_mainmenu_list)
+		{
+			// slow global or local servers do not get entered
+			return;
+		}
+
+		if (*g_arenaservers.numservers >= g_arenaservers.maxservers) {
+			if( g_mainmenu_list ) {
+				return;
+			}
+			// list full;
+			servernodeptr = g_arenaservers.serverlist+(*g_arenaservers.numservers)-1;
+		} else {
+			// next slot
+			servernodeptr = g_arenaservers.serverlist+(*g_arenaservers.numservers);
+			(*g_arenaservers.numservers)++;
+		}
+	}
+
+	if( g_mainmenu_list && existing ) {
+		Q_strncpyz( savedGamename, servernodeptr->gamename, sizeof( savedGamename ) );
 	}
 
 	Q_strncpyz( servernodeptr->adrstr, adrstr, MAX_ADDRESSLENGTH );
+
+	if( g_mainmenu_list && !info[0] ) {
+		if( existing ) {
+			if( pingtime < ArenaServers_MaxPing() ) {
+				servernodeptr->pingtime = pingtime;
+			}
+			ArenaServers_UpdateMainMenuList();
+		} else {
+			(*g_arenaservers.numservers)--;
+		}
+		return;
+	}
 
 	Q_strncpyz( servernodeptr->hostname, Info_ValueForKey( info, "hostname"), MAX_HOSTNAMELENGTH );
 	Q_CleanStrWithColor( servernodeptr->hostname );
@@ -988,9 +1760,25 @@ static void ArenaServers_Insert( char* adrstr, char* info, int pingtime )
 		servernodeptr->gametype = i;//-1;
 		Q_strncpyz( servernodeptr->gamename, s, sizeof(servernodeptr->gamename) );
 	}
+	else if( g_mainmenu_list && existing && savedGamename[0] ) {
+		servernodeptr->gametype = i;
+		Q_strncpyz( servernodeptr->gamename, savedGamename, sizeof(servernodeptr->gamename) );
+	}
 	else {
 		servernodeptr->gametype = i;
 		Q_strncpyz( servernodeptr->gamename, gamenames[i], sizeof(servernodeptr->gamename) );
+	}
+
+	if( g_mainmenu_list ) {
+		if( !MainMenuServers_IsDevotionMod( servernodeptr->gamename ) ) {
+			if( !existing ) {
+				(*g_arenaservers.numservers)--;
+			}
+			return;
+		}
+
+		MainMenuServers_CacheServer( servernodeptr );
+		ArenaServers_UpdateMainMenuList();
 	}
 }
 
@@ -1132,8 +1920,353 @@ static void ArenaServers_StopRefresh( void )
 	qsort( g_arenaservers.serverlist, *g_arenaservers.numservers, sizeof( servernode_t ), ArenaServers_Compare);
 
 	ArenaServers_UpdateMenu();
+
+	if( g_mainmenu_list ) {
+		MainMenuServers_SaveCache();
+	}
 }
 
+
+/*
+=================
+MainMenuServers_IsMasterDefined
+=================
+*/
+static qboolean MainMenuServers_IsMasterDefined( int masterIndex ) {
+	char	masterstr[64];
+	char	cvarname[sizeof( "sv_master5" )];
+
+	if( masterIndex < UIAS_GLOBAL1 || masterIndex > UIAS_GLOBAL5 ) {
+		return qfalse;
+	}
+
+	Com_sprintf( cvarname, sizeof( cvarname ), "sv_master%d", masterIndex );
+	trap_Cvar_VariableStringBuffer( cvarname, masterstr, sizeof( masterstr ) );
+	return masterstr[0] != '\0';
+}
+
+/*
+=================
+MainMenuServers_MergeFromMasterIncremental
+=================
+*/
+static void MainMenuServers_MergeFromMasterIncremental( int masterIndex ) {
+	int		i;
+	int		count;
+	char	adrstr[MAX_ADDRESSLENGTH];
+
+	count = trap_LAN_GetServerCount( masterIndex );
+	if( count < 0 ) {
+		return;
+	}
+
+	if( count < g_mainmenu_master_merged_idx[masterIndex] ) {
+		g_mainmenu_master_merged_idx[masterIndex] = 0;
+	}
+
+	for( i = g_mainmenu_master_merged_idx[masterIndex]; i < count; i++ ) {
+		trap_LAN_GetServerAddressString( masterIndex, i, adrstr, MAX_ADDRESSLENGTH );
+		if( adrstr[0] ) {
+			MainMenuServers_AddDiscoveryAddress( adrstr );
+		}
+	}
+
+	g_mainmenu_master_merged_idx[masterIndex] = count;
+}
+
+/*
+=================
+MainMenuServers_IssueMasterQuery
+=================
+*/
+static void MainMenuServers_IssueMasterQuery( int masterIndex ) {
+	char	protocol[32];
+
+	g_mainmenu_master_query_time[masterIndex] = uis.realtime;
+	g_mainmenu_master_query_sent[masterIndex] = qtrue;
+	g_mainmenu_active_query_master = masterIndex;
+	g_mainmenu_master_last_count[masterIndex] = -1;
+
+	protocol[0] = '\0';
+	trap_Cvar_VariableStringBuffer( "debug_protocol", protocol, sizeof( protocol ) );
+	if( strlen( protocol ) ) {
+		trap_Cmd_ExecuteText( EXEC_NOW, va( "globalservers %d %s\n", masterIndex - 1, protocol ) );
+	} else {
+		trap_Cmd_ExecuteText( EXEC_NOW, va( "globalservers %d %d\n", masterIndex - 1, (int)trap_Cvar_VariableValue( "protocol" ) ) );
+	}
+}
+
+/*
+=================
+MainMenuServers_AllMastersFinished
+=================
+*/
+static qboolean MainMenuServers_AllMastersFinished( void ) {
+	int			m;
+	qboolean	found;
+
+	found = qfalse;
+	for( m = UIAS_GLOBAL1; m <= UIAS_GLOBAL5; m++ ) {
+		if( !MainMenuServers_IsMasterDefined( m ) ) {
+			continue;
+		}
+		found = qtrue;
+		if( !g_mainmenu_master_done[m] ) {
+			return qfalse;
+		}
+	}
+
+	return found;
+}
+
+/*
+=================
+MainMenuServers_BeginPingPhase
+=================
+*/
+static void MainMenuServers_BeginPingPhase( void ) {
+	g_mainmenu_refresh_phase = MM_REFRESH_PINGING;
+	g_arenaservers.numqueriedservers = g_mainmenu_numaddresses;
+	g_arenaservers.currentping = 0;
+	g_mainmenu_last_ping_time = 0;
+	g_mainmenu_active_query_master = 0;
+
+	if( !g_mainmenu_numaddresses ) {
+		ArenaServers_StopRefresh();
+	}
+}
+
+/*
+=================
+MainMenuServers_PollMasters
+=================
+*/
+static void MainMenuServers_PollMasters( void ) {
+	int		m;
+	int		count;
+
+	for( m = UIAS_GLOBAL1; m <= UIAS_GLOBAL5; m++ ) {
+		if( !MainMenuServers_IsMasterDefined( m ) ) {
+			continue;
+		}
+
+		if( g_mainmenu_master_done[m] ) {
+			continue;
+		}
+
+		if( !g_mainmenu_master_query_sent[m] &&
+			uis.realtime - g_mainmenu_scan_start_time > MAINMENU_MASTER_BOOT_MS &&
+			g_mainmenu_active_query_master == 0 ) {
+			MainMenuServers_IssueMasterQuery( m );
+			continue;
+		}
+
+		count = trap_LAN_GetServerCount( m );
+
+		if( count < 0 ) {
+			if( g_mainmenu_master_query_sent[m] &&
+				uis.realtime - g_mainmenu_master_query_time[m] > MAINMENU_MASTER_TIMEOUT_MS ) {
+				g_mainmenu_master_done[m] = qtrue;
+				if( g_mainmenu_active_query_master == m ) {
+					g_mainmenu_active_query_master = 0;
+				}
+			}
+			continue;
+		}
+
+		MainMenuServers_MergeFromMasterIncremental( m );
+
+		if( g_mainmenu_active_query_master == m ) {
+			g_mainmenu_active_query_master = 0;
+		}
+
+		if( count != g_mainmenu_master_last_count[m] ) {
+			g_mainmenu_master_last_count[m] = count;
+			g_mainmenu_master_stable_time[m] = uis.realtime;
+			continue;
+		}
+
+		if( g_mainmenu_master_query_sent[m] &&
+			uis.realtime - g_mainmenu_master_stable_time[m] >= MAINMENU_MASTER_STABLE_MS ) {
+			g_mainmenu_master_done[m] = qtrue;
+		}
+	}
+
+	if( MainMenuServers_AllMastersFinished() ) {
+		MainMenuServers_BeginPingPhase();
+	}
+}
+
+/*
+=================
+MainMenuServers_StartRefresh
+=================
+*/
+static void MainMenuServers_StartRefresh( void ) {
+	int		i;
+
+	if( g_arenaservers.refreshservers ) {
+		return;
+	}
+
+	memset( g_mainmenu_addresses, 0, sizeof( g_mainmenu_addresses ) );
+	g_mainmenu_numaddresses = 0;
+	g_mainmenu_discovery_addresses = 0;
+	g_mainmenu_last_ping_activity = 0;
+	memset( g_mainmenu_master_last_count, -1, sizeof( g_mainmenu_master_last_count ) );
+	memset( g_mainmenu_master_merged_idx, 0, sizeof( g_mainmenu_master_merged_idx ) );
+	memset( g_mainmenu_master_stable_time, 0, sizeof( g_mainmenu_master_stable_time ) );
+	memset( g_mainmenu_master_query_time, 0, sizeof( g_mainmenu_master_query_time ) );
+	memset( g_mainmenu_master_done, 0, sizeof( g_mainmenu_master_done ) );
+	memset( g_mainmenu_master_query_sent, 0, sizeof( g_mainmenu_master_query_sent ) );
+	g_mainmenu_cache_written_count = 0;
+
+	for( i = 0; i < MAX_PINGREQUESTS; i++ ) {
+		g_arenaservers.pinglist[i].adrstr[0] = '\0';
+		trap_LAN_ClearPing( i );
+	}
+
+	g_arenaservers.refreshservers = qtrue;
+	g_arenaservers.currentping = 0;
+	g_arenaservers.nextpingtime = 0;
+	g_arenaservers.numqueriedservers = 0;
+	g_mainmenu_refresh_phase = MM_REFRESH_MASTERS;
+	g_mainmenu_scan_start_time = uis.realtime;
+	g_mainmenu_active_query_master = 0;
+	g_mainmenu_last_ping_time = 0;
+	g_mainmenu_last_ping_activity = uis.realtime;
+
+	MainMenuServers_AddCachedAddresses();
+
+	ArenaServers_UpdateMainMenuList();
+
+	if( !MainMenuServers_IsMasterDefined( UIAS_GLOBAL1 ) &&
+		!MainMenuServers_IsMasterDefined( UIAS_GLOBAL2 ) &&
+		!MainMenuServers_IsMasterDefined( UIAS_GLOBAL3 ) &&
+		!MainMenuServers_IsMasterDefined( UIAS_GLOBAL4 ) &&
+		!MainMenuServers_IsMasterDefined( UIAS_GLOBAL5 ) ) {
+		MainMenuServers_BeginPingPhase();
+	}
+}
+
+/*
+=================
+MainMenuServers_DoRefresh
+=================
+*/
+static void MainMenuServers_DoRefresh( void ) {
+	int		i;
+	int		j;
+	int		time;
+	int		maxPing;
+	int		pingsSent;
+	char	adrstr[MAX_ADDRESSLENGTH];
+	char	info[MAX_INFO_STRING];
+
+	if( g_mainmenu_refresh_phase == MM_REFRESH_MASTERS ) {
+		MainMenuServers_PollMasters();
+		ArenaServers_UpdateMainMenuList();
+		return;
+	}
+
+	if( uis.realtime - g_mainmenu_scan_start_time > MAINMENU_SCAN_TIMEOUT_MS ) {
+		MainMenuServers_ClearPendingPings();
+		ArenaServers_StopRefresh();
+		ArenaServers_UpdateMainMenuList();
+		return;
+	}
+
+	maxPing = ArenaServers_MaxPing();
+	for( i = 0; i < MAX_PINGREQUESTS; i++ ) {
+		trap_LAN_GetPing( i, adrstr, MAX_ADDRESSLENGTH, &time );
+		if( !adrstr[0] ) {
+			continue;
+		}
+
+		for( j = 0; j < MAX_PINGREQUESTS; j++ ) {
+			if( !Q_stricmp( adrstr, g_arenaservers.pinglist[j].adrstr ) ) {
+				break;
+			}
+		}
+
+		if( j < MAX_PINGREQUESTS ) {
+			if( !time ) {
+				time = uis.realtime - g_arenaservers.pinglist[j].start;
+				if( time < maxPing ) {
+					continue;
+				}
+			}
+
+			if( time > maxPing ) {
+				info[0] = '\0';
+				time = maxPing;
+			} else {
+				trap_LAN_GetPingInfo( i, info, MAX_INFO_STRING );
+			}
+
+			ArenaServers_Insert( adrstr, info, time );
+			g_arenaservers.pinglist[j].adrstr[0] = '\0';
+			g_mainmenu_last_ping_activity = uis.realtime;
+		}
+
+		trap_LAN_ClearPing( i );
+	}
+
+	for( j = 0; j < MAX_PINGREQUESTS; j++ ) {
+		if( !g_arenaservers.pinglist[j].adrstr[0] ) {
+			continue;
+		}
+
+		time = uis.realtime - g_arenaservers.pinglist[j].start;
+		if( time < maxPing ) {
+			continue;
+		}
+
+		ArenaServers_Insert( g_arenaservers.pinglist[j].adrstr, "", maxPing );
+		g_arenaservers.pinglist[j].adrstr[0] = '\0';
+		g_mainmenu_last_ping_activity = uis.realtime;
+	}
+
+	MainMenuServers_FinishRefreshIfDone();
+	if( !g_arenaservers.refreshservers ) {
+		return;
+	}
+
+	if( uis.realtime - g_mainmenu_last_ping_time < MAINMENU_PING_INTERVAL_MS ) {
+		ArenaServers_UpdateMainMenuList();
+		return;
+	}
+
+	g_mainmenu_last_ping_time = uis.realtime;
+
+	pingsSent = 0;
+	while( pingsSent < MAINMENU_PINGS_PER_TICK &&
+		g_arenaservers.currentping < g_arenaservers.numqueriedservers ) {
+		if( trap_LAN_GetPingQueueCount() >= MAX_PINGREQUESTS ) {
+			break;
+		}
+
+		for( j = 0; j < MAX_PINGREQUESTS; j++ ) {
+			if( !g_arenaservers.pinglist[j].adrstr[0] ) {
+				break;
+			}
+		}
+
+		if( j >= MAX_PINGREQUESTS ) {
+			break;
+		}
+
+		Q_strncpyz( adrstr, g_mainmenu_addresses[g_arenaservers.currentping], MAX_ADDRESSLENGTH );
+		Q_strncpyz( g_arenaservers.pinglist[j].adrstr, adrstr, MAX_ADDRESSLENGTH );
+		g_arenaservers.pinglist[j].start = uis.realtime;
+		trap_Cmd_ExecuteText( EXEC_NOW, va( "ping %s\n", adrstr ) );
+		g_arenaservers.currentping++;
+		pingsSent++;
+		g_mainmenu_last_ping_activity = uis.realtime;
+	}
+
+	ArenaServers_UpdateMainMenuList();
+}
 
 /*
 =================
@@ -1148,6 +2281,11 @@ static void ArenaServers_DoRefresh( void )
 	int		maxPing;
 	char	adrstr[MAX_ADDRESSLENGTH];
 	char	info[MAX_INFO_STRING];
+
+	if( g_mainmenu_list ) {
+		MainMenuServers_DoRefresh();
+		return;
+	}
 
 	if (uis.realtime < g_arenaservers.refreshtime)
 	{
@@ -1983,6 +3121,303 @@ UI_ArenaServersMenu
 =================
 */
 void UI_ArenaServersMenu( void ) {
+	UI_MainMenuServers_End();
 	ArenaServers_MenuInit();
 	UI_PushMenu( &g_arenaservers.menu );
+}
+
+/*
+=================
+UI_MainMenuServers_Begin
+=================
+*/
+void UI_MainMenuServers_Begin( menulist_s *list, menubitmap_s *mappic ) {
+	int		i;
+
+	g_mainmenu_list = list;
+	g_mainmenu_mappic = mappic;
+	list->itemnames = (const char **)g_arenaservers.items;
+	for( i = 0; i < MAX_LISTBOXITEMS; i++ ) {
+		g_arenaservers.items[i] = g_arenaservers.table[i].buff;
+	}
+
+	g_gametype = GAMES_DEVOTION;
+	g_sortkey = SORT_HOST;
+	g_emptyservers = 1;
+	g_fullservers = 1;
+	g_onlyhumans = 1;
+	g_hideprivate = 0;
+
+	g_arenaservers.serverlist = g_mainmenu_serverlist;
+	g_arenaservers.numservers = &g_mainmenu_numservers;
+	g_arenaservers.maxservers = MAX_GLOBALSERVERS;
+
+	if( g_arenaservers.refreshservers ) {
+		ArenaServers_StopRefresh();
+	}
+
+	memset( g_mainmenu_serverlist, 0, g_arenaservers.maxservers * sizeof( servernode_t ) );
+	g_mainmenu_numservers = 0;
+	MainMenuServers_LoadCache();
+	ArenaServers_UpdateMainMenuList();
+
+	MainMenuServers_StartRefresh();
+}
+
+/*
+=================
+UI_MainMenuServers_Resume
+=================
+*/
+void UI_MainMenuServers_Resume( menulist_s *list, menubitmap_s *mappic ) {
+	int		i;
+
+	if( g_mainmenu_list ) {
+		return;
+	}
+
+	g_mainmenu_list = list;
+	g_mainmenu_mappic = mappic;
+	list->itemnames = (const char **)g_arenaservers.items;
+	for( i = 0; i < MAX_LISTBOXITEMS; i++ ) {
+		g_arenaservers.items[i] = g_arenaservers.table[i].buff;
+	}
+
+	g_gametype = GAMES_DEVOTION;
+	g_sortkey = SORT_HOST;
+	g_emptyservers = 1;
+	g_fullservers = 1;
+	g_onlyhumans = 1;
+	g_hideprivate = 0;
+
+	g_arenaservers.serverlist = g_mainmenu_serverlist;
+	g_arenaservers.numservers = &g_mainmenu_numservers;
+	g_arenaservers.maxservers = MAX_GLOBALSERVERS;
+
+	if( g_arenaservers.refreshservers ) {
+		ArenaServers_StopRefresh();
+	}
+
+	ArenaServers_UpdateMainMenuList();
+}
+
+/*
+=================
+UI_MainMenuServers_Update
+=================
+*/
+void UI_MainMenuServers_Update( void ) {
+	if( g_arenaservers.refreshservers ) {
+		ArenaServers_DoRefresh();
+	}
+	ArenaServers_UpdateMainMenuList();
+}
+
+/*
+=================
+UI_MainMenuServers_End
+=================
+*/
+void UI_MainMenuServers_End( void ) {
+	if( g_arenaservers.refreshservers && g_mainmenu_list ) {
+		ArenaServers_StopRefresh();
+	}
+
+	g_mainmenu_list = NULL;
+	g_mainmenu_mappic = NULL;
+	g_mainmenu_refresh_phase = 0;
+	g_mainmenu_scan_start_time = 0;
+	g_mainmenu_active_query_master = 0;
+	g_mainmenu_numaddresses = 0;
+	g_mainmenu_discovery_addresses = 0;
+	g_mainmenu_cache_written_count = 0;
+	g_mainmenu_last_ping_activity = 0;
+	g_mainmenu_server_column_focus = qfalse;
+	memset( g_mainmenu_master_done, 0, sizeof( g_mainmenu_master_done ) );
+	memset( g_mainmenu_master_query_sent, 0, sizeof( g_mainmenu_master_query_sent ) );
+}
+
+/*
+=================
+UI_MainMenuServers_IsRefreshing
+=================
+*/
+qboolean UI_MainMenuServers_IsRefreshing( void ) {
+	return g_arenaservers.refreshservers;
+}
+
+/*
+=================
+UI_MainMenuServers_Refresh
+=================
+*/
+void UI_MainMenuServers_Refresh( void ) {
+	if( !g_mainmenu_list ) {
+		return;
+	}
+
+	if( g_arenaservers.refreshservers ) {
+		ArenaServers_StopRefresh();
+	}
+
+	MainMenuServers_StartRefresh();
+	ArenaServers_UpdateMainMenuList();
+}
+
+/*
+=================
+UI_MainMenuServers_Draw
+=================
+*/
+void UI_MainMenuServers_Draw( menulist_s *list ) {
+	int				i;
+	int				y;
+	int				base;
+	int				style;
+	qboolean		hasfocus;
+	float			*color;
+	char			line[MAX_STRING_CHARS];
+	char			friendly[MAX_STRING_CHARS];
+	servernode_t	*servernodeptr;
+	table_t			*tableptr;
+
+	if( !list || !list->numitems ) {
+		return;
+	}
+
+	hasfocus = UI_MainMenuServers_GetColumnFocus();
+
+	base = list->top;
+	y = list->generic.y;
+
+	for( i = base; i < base + list->height && i < list->numitems; i++ ) {
+		int	blockY;
+
+		tableptr = &g_arenaservers.table[i];
+		servernodeptr = tableptr->servernode;
+		if( !servernodeptr ) {
+			continue;
+		}
+
+		blockY = y;
+
+		if( i == list->curvalue && hasfocus ) {
+			UI_FillRect( list->generic.x - 2, blockY - 2,
+				MAIN_MENU_LEVELSHOT_X + MAIN_MENU_LEVELSHOT_WIDTH - list->generic.x + 2,
+				MAIN_MENU_SERVER_BLOCK_HEIGHT, listbar_color );
+			color = text_color_highlight;
+			style = hasfocus ? ( UI_PULSE | UI_SMALLFONT ) : UI_SMALLFONT;
+		} else {
+			color = text_color_normal;
+			style = UI_SMALLFONT;
+		}
+
+		Q_strncpyz( line, servernodeptr->hostname, sizeof( line ) );
+		MainMenuServers_DrawEntryString( MAIN_MENU_SERVER_TEXT_RIGHT_X, y, line, style, color, qfalse );
+		y += MAIN_MENU_SERVER_NAME_LINE_HEIGHT;
+
+		if( MainMenuServers_HasPing( servernodeptr ) ) {
+			Com_sprintf( line, sizeof( line ), "^7Ping: %s%d", MainMenuServers_PingColor( servernodeptr ), servernodeptr->pingtime );
+			MainMenuServers_DrawEntryString( MAIN_MENU_SERVER_TEXT_RIGHT_X, y, line, UI_SMALLFONT, color, qtrue );
+		}
+		y += MAIN_MENU_SERVER_INFO_LINE_HEIGHT;
+
+		Com_sprintf( line, sizeof( line ), "^7Players: %d/%d", servernodeptr->humanclients, servernodeptr->maxclients );
+		MainMenuServers_DrawEntryString( MAIN_MENU_SERVER_TEXT_RIGHT_X, y, line, UI_SMALLFONT, color, qtrue );
+		y += MAIN_MENU_SERVER_INFO_LINE_HEIGHT;
+
+		if( servernodeptr->gametype >= 0 && servernodeptr->gametype < GT_MAX_GAME_TYPE ) {
+			Com_sprintf( line, sizeof( line ), "^7Gametype: %s%s",
+				MainMenuServers_GametypeColor( servernodeptr->gametype ),
+				MainMenuServers_GametypeName( servernodeptr->gametype ) );
+			MainMenuServers_DrawEntryString( MAIN_MENU_SERVER_TEXT_RIGHT_X, y, line, UI_SMALLFONT, color, qtrue );
+		}
+		y += MAIN_MENU_SERVER_INFO_LINE_HEIGHT;
+
+		if( servernodeptr->mapname[0] ) {
+			Com_sprintf( line, sizeof( line ), "^7Map: %s", servernodeptr->mapname );
+			MainMenuServers_DrawEntryString( MAIN_MENU_SERVER_TEXT_RIGHT_X, y, line, UI_SMALLFONT, color, qtrue );
+		}
+		y += MAIN_MENU_SERVER_INFO_LINE_HEIGHT;
+
+		MainMenuServers_GetMapFriendlyName( servernodeptr->mapname, friendly, sizeof( friendly ) );
+		if( friendly[0] ) {
+			Com_sprintf( line, sizeof( line ), "^7%s", friendly );
+			MainMenuServers_DrawEntryString( MAIN_MENU_SERVER_TEXT_RIGHT_X, y, line, UI_SMALLFONT, color, qtrue );
+		}
+		y += MAIN_MENU_SERVER_INFO_LINE_HEIGHT;
+		MainMenuServers_DrawLevelshot( MAIN_MENU_LEVELSHOT_X,
+			blockY + ( MAIN_MENU_SERVER_BLOCK_HEIGHT - MAIN_MENU_LEVELSHOT_HEIGHT ) / 2 + MAIN_MENU_LEVELSHOT_Y_OFFSET,
+			servernodeptr->mapname );
+		y = blockY + MAIN_MENU_SERVER_BLOCK_HEIGHT;
+	}
+}
+
+/*
+=================
+UI_MainMenuServers_Mouse
+=================
+*/
+qboolean UI_MainMenuServers_Mouse( menulist_s *list ) {
+	int		index;
+
+	index = MainMenuServers_MouseIndex( list );
+	if( index < 0 ) {
+		return qfalse;
+	}
+
+	if( index != list->curvalue ) {
+		list->oldvalue = list->curvalue;
+		list->curvalue = index;
+		if( list->generic.callback ) {
+			list->generic.callback( list, QM_GOTFOCUS );
+		}
+	}
+
+	return qtrue;
+}
+
+/*
+=================
+UI_MainMenuServers_MouseClick
+=================
+*/
+qboolean UI_MainMenuServers_MouseClick( menulist_s *list ) {
+	if( !UI_MainMenuServers_Mouse( list ) ) {
+		return qfalse;
+	}
+
+	UI_MainMenuServers_Connect( list );
+	return qtrue;
+}
+
+/*
+=================
+UI_MainMenuServers_Connect
+=================
+*/
+void UI_MainMenuServers_Connect( menulist_s *list ) {
+	servernode_t	*servernodeptr;
+	table_t			*tableptr;
+
+	if( !list || !list->numitems ) {
+		return;
+	}
+
+	tableptr = &g_arenaservers.table[list->curvalue];
+	servernodeptr = tableptr->servernode;
+	if( !servernodeptr ) {
+		return;
+	}
+
+	if( !ui_setupchecked.integer ) {
+		UI_FirstConnectMenu();
+		return;
+	}
+
+	if( servernodeptr->needPass ) {
+		UI_SpecifyPasswordMenu( va( "connect %s\n", servernodeptr->adrstr ), servernodeptr->hostname );
+	} else {
+		trap_Cmd_ExecuteText( EXEC_APPEND, va( "connect %s\n", servernodeptr->adrstr ) );
+	}
 }						  

--- a/ratoa_gamecode/code/q3_ui/ui_servers2.c
+++ b/ratoa_gamecode/code/q3_ui/ui_servers2.c
@@ -35,13 +35,15 @@ MULTIPLAYER MENU (SERVER BROWSER)
 #define MAX_GLOBALSERVERS		256
 #define MAX_PINGREQUESTS		32
 #define MAX_ADDRESSLENGTH		64
-#define MAX_HOSTNAMELENGTH		31
+#define MAX_HOSTNAMELENGTH		80
+#define HOSTNAME_DISPLAY_LEN	28
 #define MAX_MAPNAMELENGTH		20
 #define MAX_LISTBOXITEMS		256
 #define MAX_LOCALSERVERS		124
 #define MAX_STATUSLENGTH		64
 #define MAX_LEAGUELENGTH		28
 #define MAX_LISTBOXWIDTH		70
+#define MAX_LISTBOXBUFF			256
 
 #define ART_BACK0			"menu/art/back_0"
 #define ART_BACK1			"menu/art/back_1"
@@ -112,6 +114,8 @@ MULTIPLAYER MENU (SERVER BROWSER)
 #define MAINMENU_PING_STALL_MS		10000
 #define MAINMENU_PING_UNKNOWN		(-1)
 #define MAINMENU_GAMETYPE_UNKNOWN	(-1)
+/* Rebuild/sort the visible list at most this often while a scan is running. */
+#define SERVERLIST_UI_UPDATE_MS		250
 
 #define SORT_HOST			0
 #define SORT_MAP			1
@@ -265,7 +269,7 @@ typedef struct servernode_s {
 } servernode_t; 
 
 typedef struct {
-	char			buff[MAX_LISTBOXWIDTH+64]; //	+60 gives room for color codes... Sago: I need four more
+	char			buff[MAX_LISTBOXBUFF];
 	servernode_t*	servernode;
 } table_t;
 
@@ -350,37 +354,353 @@ static int					g_mainmenu_cache_written_count;
 static char					g_mainmenu_addresses[MAINMENU_MAX_ADDRESSES][MAX_ADDRESSLENGTH];
 static int					g_mainmenu_numaddresses;
 static int					g_mainmenu_last_ping_activity;
+static qboolean				g_serverlist_ui_dirty;
+static int					g_serverlist_last_ui_update;
 
 static void ArenaServers_StopRefresh( void );
 static void ArenaServers_UpdateMainMenuList( void );
+static void ArenaServers_UpdateMenu( void );
+static void ArenaServers_MarkListDirty( void );
+static void ArenaServers_FlushListUI( qboolean force );
 
 /*
- *Removes illigal chars but keeps colors
- */
-char *Q_CleanStrWithColor( char *string ) {
-	char*	d;
-	char*	s;
-	int		c;
+=================
+ArenaServers_NormalizeAddress
 
-	s = string;
-	d = string;
-	while ((c = *s) != 0 ) {
-		if ( Q_IsColorString( s ) ) {
-			*d++ = c;
-			*d++ = ( s[1] == '0' ) ? '7' : s[1];
-			s += 2;
+Trim whitespace and lowercase so master duplicates compare equal.
+=================
+*/
+static void ArenaServers_NormalizeAddress( char *adrstr ) {
+	char	*s;
+	char	*d;
+
+	if( !adrstr ) {
+		return;
+	}
+
+	s = adrstr;
+	while( *s && ( *s == ' ' || *s == '\t' ) ) {
+		s++;
+	}
+	if( s != adrstr ) {
+		d = adrstr;
+		while( *s ) {
+			*d++ = *s++;
 		}
-		else if ( c >= 0x20 && c <= 0x7E ) {
-			*d++ = c;
-			s++;
-		}
-		else {
-			s++;
+		*d = '\0';
+	}
+
+	d = adrstr + strlen( adrstr );
+	while( d > adrstr && ( d[-1] == ' ' || d[-1] == '\t' ) ) {
+		d--;
+		*d = '\0';
+	}
+
+	Q_strlwr( adrstr );
+}
+
+/*
+=================
+ArenaServers_SameAddress
+=================
+*/
+static qboolean ArenaServers_SameAddress( const char *a, const char *b ) {
+	char	left[MAX_ADDRESSLENGTH];
+	char	right[MAX_ADDRESSLENGTH];
+
+	if( !a || !b ) {
+		return qfalse;
+	}
+
+	Q_strncpyz( left, a, sizeof( left ) );
+	Q_strncpyz( right, b, sizeof( right ) );
+	ArenaServers_NormalizeAddress( left );
+	ArenaServers_NormalizeAddress( right );
+	return !Q_stricmp( left, right );
+}
+
+/*
+=================
+ArenaServers_ParsePort
+=================
+*/
+static int ArenaServers_ParsePort( const char *adrstr ) {
+	const char	*colon;
+
+	if( !adrstr ) {
+		return 0;
+	}
+
+	colon = strrchr( adrstr, ':' );
+	if( !colon || !colon[1] ) {
+		return 0;
+	}
+
+	return atoi( colon + 1 );
+}
+
+/*
+=================
+ArenaServers_PreferAddress
+
+When the same server is advertised on many ports (A51 registers ~32 decoy
+ports in the 32000s on masters), prefer a real game port and/or better ping.
+=================
+*/
+static qboolean ArenaServers_PreferAddress( const char *candidate, int candPing,
+	const char *current, int curPing ) {
+	int			candPort;
+	int			curPort;
+	qboolean	candGame;
+	qboolean	curGame;
+
+	if( candPing > 0 && ( curPing <= 0 || candPing < curPing ) ) {
+		return qtrue;
+	}
+	if( curPing > 0 && ( candPing <= 0 || curPing < candPing ) ) {
+		return qfalse;
+	}
+
+	candPort = ArenaServers_ParsePort( candidate );
+	curPort = ArenaServers_ParsePort( current );
+	candGame = ( candPort >= 26000 && candPort < 30000 );
+	curGame = ( curPort >= 26000 && curPort < 30000 );
+	if( candGame != curGame ) {
+		return candGame;
+	}
+	if( candPort > 0 && curPort > 0 && candPort != curPort ) {
+		return candPort < curPort;
+	}
+
+	return qfalse;
+}
+
+/*
+=================
+ArenaServers_SameIdentity
+
+True when two replies describe the same logical server (hostname+map+gametype),
+even if advertised on different ports.
+=================
+*/
+static qboolean ArenaServers_SameIdentity( const char *hostnameA, const char *mapnameA, int gametypeA,
+	const char *hostnameB, const char *mapnameB, int gametypeB ) {
+	char	hostA[MAX_HOSTNAMELENGTH + 3];
+	char	hostB[MAX_HOSTNAMELENGTH + 3];
+
+	if( !hostnameA || !hostnameB || !hostnameA[0] || !hostnameB[0] ) {
+		return qfalse;
+	}
+	if( !Q_stricmp( hostnameA, "No Response" ) || !Q_stricmp( hostnameB, "No Response" ) ) {
+		return qfalse;
+	}
+	if( gametypeA != gametypeB ) {
+		return qfalse;
+	}
+	if( !mapnameA || !mapnameB || Q_stricmp( mapnameA, mapnameB ) ) {
+		return qfalse;
+	}
+
+	Q_strncpyz( hostA, hostnameA, sizeof( hostA ) );
+	Q_strncpyz( hostB, hostnameB, sizeof( hostB ) );
+	Q_CleanStr( hostA );
+	Q_CleanStr( hostB );
+	if( !hostA[0] || !hostB[0] ) {
+		return qfalse;
+	}
+
+	return !Q_stricmp( hostA, hostB );
+}
+
+/*
+=================
+ArenaServers_DedupeServerList
+
+Remove duplicate addresses and same-identity clones (multi-port decoys),
+keeping the better address/ping.
+=================
+*/
+static void ArenaServers_DedupeServerList( servernode_t *serverlist, int *numservers ) {
+	int		i;
+	int		j;
+	qboolean	same;
+
+	if( !serverlist || !numservers || *numservers < 2 ) {
+		return;
+	}
+
+	for( i = 0; i < *numservers; i++ ) {
+		for( j = i + 1; j < *numservers; ) {
+			same = ArenaServers_SameAddress( serverlist[i].adrstr, serverlist[j].adrstr );
+			if( !same ) {
+				same = ArenaServers_SameIdentity(
+					serverlist[i].hostname, serverlist[i].mapname, serverlist[i].gametype,
+					serverlist[j].hostname, serverlist[j].mapname, serverlist[j].gametype );
+			}
+			if( !same ) {
+				j++;
+				continue;
+			}
+
+			if( ArenaServers_PreferAddress(
+					serverlist[j].adrstr, serverlist[j].pingtime,
+					serverlist[i].adrstr, serverlist[i].pingtime ) ) {
+				serverlist[i] = serverlist[j];
+			}
+
+			if( j < *numservers - 1 ) {
+				memmove( &serverlist[j], &serverlist[j + 1],
+					( *numservers - j - 1 ) * sizeof( servernode_t ) );
+			}
+			( *numservers )--;
+			memset( &serverlist[*numservers], 0, sizeof( servernode_t ) );
 		}
 	}
-	*d = '\0';
+}
 
-	return string;
+/*
+=================
+ArenaServers_PrepareHostname
+
+Keep color codes, map black (^0) to white (^7), truncate to a fixed visible
+length (color codes do not count), strip leading spaces, collapse runs of
+spaces to a single space, and append a white reset.
+
+Some servers (e.g. Area 51) encode colours as "^^0X" instead of "^X".
+=================
+*/
+static void ArenaServers_PrepareHostname( char *hostname ) {
+	char		temp[MAX_HOSTNAMELENGTH];
+	char		*s;
+	char		*d;
+	int			visible;
+	int			written;
+	qboolean	lastWasSpace;
+
+	if( !hostname ) {
+		return;
+	}
+
+	Q_strncpyz( temp, hostname, sizeof( temp ) );
+
+	s = temp;
+	while( *s == ' ' || *s == '\t' ) {
+		s++;
+	}
+
+	d = hostname;
+	visible = 0;
+	written = 0;
+	lastWasSpace = qfalse;
+
+	/* leave room for trailing ^7 and NUL */
+	while( *s && visible < HOSTNAME_DISPLAY_LEN && written + 3 < MAX_HOSTNAMELENGTH ) {
+		/* Area 51 / OSP style: ^^0X means colour X */
+		if( s[0] == '^' && s[1] == '^' && s[2] == '0' &&
+			s[3] >= '0' && s[3] <= '8' ) {
+			if( written + 2 >= MAX_HOSTNAMELENGTH - 1 ) {
+				break;
+			}
+			*d++ = '^';
+			*d++ = ( s[3] == '0' ) ? '7' : s[3];
+			s += 4;
+			written += 2;
+			continue;
+		}
+		if( s[0] == '^' && s[1] == '^' ) {
+			/* escaped caret */
+			*d++ = '^';
+			s += 2;
+			visible++;
+			written++;
+			lastWasSpace = qfalse;
+			continue;
+		}
+		if( s[0] == '^' && s[1] >= '0' && s[1] <= '8' ) {
+			*d++ = '^';
+			*d++ = ( s[1] == '0' ) ? '7' : s[1];
+			s += 2;
+			written += 2;
+			continue;
+		}
+		if( s[0] == '^' && s[1] ) {
+			/* unknown ^X — drop the caret, keep the character */
+			s++;
+			continue;
+		}
+		if( s[0] == '^' ) {
+			break;
+		}
+		if( *s == ' ' || *s == '\t' ) {
+			if( lastWasSpace ) {
+				s++;
+				continue;
+			}
+			*d++ = ' ';
+			s++;
+			visible++;
+			written++;
+			lastWasSpace = qtrue;
+			continue;
+		}
+		*d++ = *s++;
+		visible++;
+		written++;
+		lastWasSpace = qfalse;
+	}
+
+	*d++ = '^';
+	*d++ = '7';
+	*d = '\0';
+}
+
+/*
+=================
+ArenaServers_CopyField
+
+Copy src into dest padded to visibleWidth printable characters. Color codes
+are copied through but do not count toward width, so columns stay aligned.
+Returns bytes written (not including trailing NUL).
+=================
+*/
+static int ArenaServers_CopyField( const char *src, char *dest, int destBytes, int visibleWidth ) {
+	const char	*s;
+	char		*d;
+	int			visible;
+	int			written;
+
+	if( !src || !dest || destBytes < 1 ) {
+		return 0;
+	}
+
+	s = src;
+	d = dest;
+	visible = 0;
+	written = 0;
+
+	while( *s && visible < visibleWidth && written + 1 < destBytes ) {
+		if( s[0] == '^' && s[1] >= '0' && s[1] <= '8' ) {
+			if( written + 2 >= destBytes ) {
+				break;
+			}
+			*d++ = *s++;
+			*d++ = *s++;
+			written += 2;
+			continue;
+		}
+		*d++ = *s++;
+		written++;
+		visible++;
+	}
+
+	while( visible < visibleWidth && written + 1 < destBytes ) {
+		*d++ = ' ';
+		written++;
+		visible++;
+	}
+
+	*d = '\0';
+	return written;
 }
 
 
@@ -410,13 +730,19 @@ static int QDECL ArenaServers_Compare( const void *arg1, const void *arg2 ) {
 	float			f2;
 	servernode_t*	t1;
 	servernode_t*	t2;
+	char			host1[MAX_HOSTNAMELENGTH + 3];
+	char			host2[MAX_HOSTNAMELENGTH + 3];
 
 	t1 = (servernode_t *)arg1;
 	t2 = (servernode_t *)arg2;
 
 	switch( g_sortkey ) {
 	case SORT_HOST:
-		return Q_stricmp( t1->hostname, t2->hostname );
+		Q_strncpyz( host1, t1->hostname, sizeof( host1 ) );
+		Q_strncpyz( host2, t2->hostname, sizeof( host2 ) );
+		Q_CleanStr( host1 );
+		Q_CleanStr( host2 );
+		return Q_stricmp( host1, host2 );
 
 	case SORT_MAP:
 		return Q_stricmp( t1->mapname, t2->mapname );
@@ -468,7 +794,11 @@ static int QDECL ArenaServers_Compare( const void *arg1, const void *arg2 ) {
 		if( t1->pingtime > t2->pingtime ) {
 			return 1;
 		}
-		return Q_stricmp( t1->hostname, t2->hostname );
+		Q_strncpyz( host1, t1->hostname, sizeof( host1 ) );
+		Q_strncpyz( host2, t2->hostname, sizeof( host2 ) );
+		Q_CleanStr( host1 );
+		Q_CleanStr( host2 );
+		return Q_stricmp( host1, host2 );
 	}
 
 	return 0;
@@ -517,57 +847,6 @@ static void ArenaServers_UpdatePicture( void ) {
 	g_arenaservers.mappic.shader = 0;
 }
 
-/*
-=================
-	Q_strcpyColor - This function will return the real length of the string if numChars
-		len of character data is desired. It looks for color codes and adds 2 to the length
-		for each combo found. This is used to make color strings show up correctly in column
-		formatted environments. Otherwise, the columns will be off 2 * num of color codes.
-=================
-*/
-int Q_strcpyColor( const char *src, char *dest, int numChars )
-{
-int count, len;
-char *d;
-const char *s;
-
-	if( !src || !dest )
-	{
-		return 0;
-	}
-
-	count = len = 0;
-	s = src;
-	d = dest;
-
-	while( *s && count < numChars )
-	{
-		if( Q_IsColorString( s ))
-		{
-			*d++ = *s++;
-			*d++ = *s++;
-			len += 2;
-			continue;
-		}
-		*d = *s;
-		s++;
-		d++;
-		count++;
-		len++;
-	}
-
-	// Now fill up the end of the string with space characters if needed...
-	while( count < numChars )
-	{
-		*d = ' ';
-                //d[len] = ' ';
-		d++;
-		len++;
-		count++;
-	}
-	return len;
-}
-
 static qboolean ArenaServers_Filtered(servernode_t *servernodeptr) {
 	char	hostname[MAX_HOSTNAMELENGTH+3];
 	char	filter[MAX_EDIT_LINE];
@@ -577,8 +856,8 @@ static qboolean ArenaServers_Filtered(servernode_t *servernodeptr) {
 	}
 
 
-	Q_strncpyz(hostname, servernodeptr->hostname, sizeof(hostname));
-	Q_CleanStr(hostname);
+	Q_strncpyz( hostname, servernodeptr->hostname, sizeof( hostname ) );
+	Q_CleanStr( hostname );
 	Q_strncpyz(filter, g_arenaservers.filter.field.buffer, MAX_EDIT_LINE);
 	Q_CleanStr(filter);
 
@@ -602,9 +881,17 @@ MainMenuServers_AddressExists
 */
 static qboolean MainMenuServers_AddressExists( const char *adrstr ) {
 	int		i;
+	char	normalized[MAX_ADDRESSLENGTH];
+
+	if( !adrstr || !adrstr[0] ) {
+		return qfalse;
+	}
+
+	Q_strncpyz( normalized, adrstr, sizeof( normalized ) );
+	ArenaServers_NormalizeAddress( normalized );
 
 	for( i = 0; i < g_mainmenu_numaddresses; i++ ) {
-		if( !Q_stricmp( g_mainmenu_addresses[i], adrstr ) ) {
+		if( ArenaServers_SameAddress( g_mainmenu_addresses[i], normalized ) ) {
 			return qtrue;
 		}
 	}
@@ -618,7 +905,15 @@ MainMenuServers_AddAddress
 =================
 */
 static void MainMenuServers_AddAddress( const char *adrstr ) {
-	if( !adrstr || !adrstr[0] || MainMenuServers_AddressExists( adrstr ) ) {
+	char	normalized[MAX_ADDRESSLENGTH];
+
+	if( !adrstr || !adrstr[0] ) {
+		return;
+	}
+
+	Q_strncpyz( normalized, adrstr, sizeof( normalized ) );
+	ArenaServers_NormalizeAddress( normalized );
+	if( !normalized[0] || MainMenuServers_AddressExists( normalized ) ) {
 		return;
 	}
 
@@ -626,7 +921,7 @@ static void MainMenuServers_AddAddress( const char *adrstr ) {
 		return;
 	}
 
-	Q_strncpyz( g_mainmenu_addresses[g_mainmenu_numaddresses], adrstr, MAX_ADDRESSLENGTH );
+	Q_strncpyz( g_mainmenu_addresses[g_mainmenu_numaddresses], normalized, MAX_ADDRESSLENGTH );
 	g_mainmenu_numaddresses++;
 }
 
@@ -636,14 +931,6 @@ MainMenuServers_AddDiscoveryAddress
 =================
 */
 static void MainMenuServers_AddDiscoveryAddress( const char *adrstr ) {
-	if( !adrstr || !adrstr[0] || MainMenuServers_AddressExists( adrstr ) ) {
-		return;
-	}
-
-	if( g_mainmenu_numaddresses >= MAINMENU_MAX_ADDRESSES ) {
-		return;
-	}
-
 	MainMenuServers_AddAddress( adrstr );
 }
 
@@ -725,10 +1012,21 @@ static qboolean MainMenuServers_HasPing( servernode_t *servernodeptr );
 
 static void MainMenuServers_InsertCachedServer( const char *adrstr, const char *hostname, const char *mapname, int pingtime ) {
 	servernode_t	*servernodeptr;
+	char			normalized[MAX_ADDRESSLENGTH];
 	int				i;
 
+	if( !adrstr || !adrstr[0] ) {
+		return;
+	}
+
+	Q_strncpyz( normalized, adrstr, sizeof( normalized ) );
+	ArenaServers_NormalizeAddress( normalized );
+	if( !normalized[0] ) {
+		return;
+	}
+
 	for( i = 0; i < g_numglobalservers; i++ ) {
-		if( !Q_stricmp( g_globalserverlist[i].adrstr, adrstr ) ) {
+		if( ArenaServers_SameAddress( g_globalserverlist[i].adrstr, normalized ) ) {
 			return;
 		}
 	}
@@ -740,9 +1038,9 @@ static void MainMenuServers_InsertCachedServer( const char *adrstr, const char *
 	servernodeptr = &g_globalserverlist[g_numglobalservers];
 	g_numglobalservers++;
 
-	Q_strncpyz( servernodeptr->adrstr, adrstr, MAX_ADDRESSLENGTH );
+	Q_strncpyz( servernodeptr->adrstr, normalized, MAX_ADDRESSLENGTH );
 	Q_strncpyz( servernodeptr->hostname, hostname, sizeof( servernodeptr->hostname ) );
-	Q_CleanStrWithColor( servernodeptr->hostname );
+	ArenaServers_PrepareHostname( servernodeptr->hostname );
 	Q_strncpyz( servernodeptr->mapname, mapname, sizeof( servernodeptr->mapname ) );
 	Q_strncpyz( servernodeptr->gamename, "devotion", sizeof( servernodeptr->gamename ) );
 	servernodeptr->pingtime = pingtime;
@@ -861,7 +1159,6 @@ MainMenuServers_CacheServer
 static void MainMenuServers_CacheServer( servernode_t *servernodeptr ) {
 	fileHandle_t	f;
 	char			line[MAX_ADDRESSLENGTH + MAX_HOSTNAMELENGTH + MAX_MAPNAMELENGTH + 16];
-	char			hostname[MAX_HOSTNAMELENGTH + 3];
 
 	if( !servernodeptr ) {
 		return;
@@ -881,14 +1178,12 @@ static void MainMenuServers_CacheServer( servernode_t *servernodeptr ) {
 		g_mainmenu_cache_written_count++;
 	}
 
-	Q_strncpyz( hostname, servernodeptr->hostname, sizeof( hostname ) );
-	Q_CleanStrWithColor( hostname );
 	if( MainMenuServers_HasPing( servernodeptr ) ) {
 		Com_sprintf( line, sizeof( line ), "%s\t%s\t%s\t%d\n",
-			servernodeptr->adrstr, hostname, servernodeptr->mapname, servernodeptr->pingtime );
+			servernodeptr->adrstr, servernodeptr->hostname, servernodeptr->mapname, servernodeptr->pingtime );
 	} else {
 		Com_sprintf( line, sizeof( line ), "%s\t%s\t%s\n",
-			servernodeptr->adrstr, hostname, servernodeptr->mapname );
+			servernodeptr->adrstr, servernodeptr->hostname, servernodeptr->mapname );
 	}
 
 	trap_FS_FOpenFile( MAINMENU_CACHE_FILE, &f, FS_APPEND );
@@ -906,7 +1201,6 @@ static void MainMenuServers_SaveCache( void ) {
 	int				i;
 	servernode_t	*servernodeptr;
 	char			line[MAX_ADDRESSLENGTH + MAX_HOSTNAMELENGTH + MAX_MAPNAMELENGTH + 16];
-	char			hostname[MAX_HOSTNAMELENGTH + 3];
 
 	trap_FS_FOpenFile( MAINMENU_CACHE_FILE, &f, FS_WRITE );
 
@@ -916,14 +1210,12 @@ static void MainMenuServers_SaveCache( void ) {
 			continue;
 		}
 
-		Q_strncpyz( hostname, servernodeptr->hostname, sizeof( hostname ) );
-		Q_CleanStrWithColor( hostname );
 		if( MainMenuServers_HasPing( servernodeptr ) ) {
 			Com_sprintf( line, sizeof( line ), "%s\t%s\t%s\t%d\n",
-				servernodeptr->adrstr, hostname, servernodeptr->mapname, servernodeptr->pingtime );
+				servernodeptr->adrstr, servernodeptr->hostname, servernodeptr->mapname, servernodeptr->pingtime );
 		} else {
 			Com_sprintf( line, sizeof( line ), "%s\t%s\t%s\n",
-				servernodeptr->adrstr, hostname, servernodeptr->mapname );
+				servernodeptr->adrstr, servernodeptr->hostname, servernodeptr->mapname );
 		}
 		trap_FS_Write( line, strlen( line ), f );
 	}
@@ -1225,6 +1517,38 @@ static void MainMenuServers_DrawLevelshot( int x, int y, const char *mapname ) {
 	UI_DrawHandlePic( x, y, MAIN_MENU_LEVELSHOT_WIDTH, MAIN_MENU_LEVELSHOT_HEIGHT, shader );
 }
 
+/*
+=================
+ArenaServers_MarkListDirty / ArenaServers_FlushListUI
+
+Inserts only mark the list dirty. While a scan is running we rebuild/sort the
+visible UI at most every SERVERLIST_UI_UPDATE_MS so per-reply work stays O(1).
+=================
+*/
+static void ArenaServers_MarkListDirty( void ) {
+	g_serverlist_ui_dirty = qtrue;
+}
+
+static void ArenaServers_FlushListUI( qboolean force ) {
+	if( !force ) {
+		if( !g_serverlist_ui_dirty ) {
+			return;
+		}
+		if( uis.realtime - g_serverlist_last_ui_update < SERVERLIST_UI_UPDATE_MS ) {
+			return;
+		}
+	}
+
+	g_serverlist_ui_dirty = qfalse;
+	g_serverlist_last_ui_update = uis.realtime;
+
+	if( g_mainmenu_list ) {
+		ArenaServers_UpdateMainMenuList();
+	} else {
+		ArenaServers_UpdateMenu();
+	}
+}
+
 static void ArenaServers_UpdateMainMenuList( void ) {
 	int				i;
 	int				j;
@@ -1282,11 +1606,14 @@ ArenaServers_UpdateMenu
 static void ArenaServers_UpdateMenu( void ) {
 	int				i;
 	int				j;
-	int				count, bufAddr;
+	int				count;
+	int				n;
+	int				remaining;
 	char*			buff;
+	char*			b;
 	servernode_t*	servernodeptr;
 	table_t*		tableptr;
-	char			*b, *pingColor;
+	char			*pingColor;
 
 	if( g_mainmenu_list ) {
 		ArenaServers_UpdateMainMenuList();
@@ -1536,40 +1863,40 @@ static void ArenaServers_UpdateMenu( void ) {
 			pingColor = S_COLOR_RED;
 		}
 
-                /*
-		Com_sprintf( buff, MAX_LISTBOXWIDTH, "%-20.20s %-12.12s %2d/%2d %-8.8s %3s %s%3d ", 
-			servernodeptr->hostname, servernodeptr->mapname, servernodeptr->numclients,
- 			servernodeptr->maxclients, servernodeptr->gamename,
-			netnames[servernodeptr->nettype], pingColor, servernodeptr->pingtime ); //, servernodeptr->bPB ? "Yes" : "No"
-                 */
-                b = buff;
-                *b++ = '^';
-                *b++ = '7';
-		bufAddr = Q_strcpyColor( servernodeptr->hostname, b, 30 );
-		b += bufAddr; 
-		*b++ = ' ';
-                *b++ = '^';
-                *b++ = '7';
-	
-		bufAddr = Q_strcpyColor( servernodeptr->mapname, b, 16 );
-		b += bufAddr;
-		*b++ = ' ';
-	
-                if(g_onlyhumans == 0)
-                    Com_sprintf( b, 8, "%2d/%2d ", servernodeptr->numclients, servernodeptr->maxclients );
-                else
-                    Com_sprintf( b, 8, "%2d/%2d ", servernodeptr->humanclients, servernodeptr->maxclients );
-		b += 6;
-	
-		bufAddr = Q_strcpyColor( servernodeptr->gamename, b, 8 );
-		b += bufAddr;
-		*b++ = ' ';
-                
-                bufAddr = Q_strcpyColor( netnames[servernodeptr->nettype], b, 3 );
-                b += bufAddr;
-                *b++ = ' ';
-                
-		Com_sprintf( b, 12, "%s%3d ", 	pingColor, servernodeptr->pingtime );
+		b = buff;
+		remaining = (int)sizeof( tableptr->buff );
+
+		n = ArenaServers_CopyField( servernodeptr->hostname, b, remaining, HOSTNAME_DISPLAY_LEN );
+		b += n;
+		remaining -= n;
+		if( remaining > 3 ) {
+			*b++ = '^';
+			*b++ = '7';
+			*b++ = ' ';
+			remaining -= 3;
+		}
+
+		n = ArenaServers_CopyField( servernodeptr->mapname, b, remaining, 16 );
+		b += n;
+		remaining -= n;
+		if( remaining > 3 ) {
+			*b++ = '^';
+			*b++ = '7';
+			*b++ = ' ';
+			remaining -= 3;
+		}
+
+		if( g_onlyhumans == 0 ) {
+			Com_sprintf( b, remaining, "%2d/%2d %-8.8s %3s %s%3d ",
+				servernodeptr->numclients, servernodeptr->maxclients,
+				servernodeptr->gamename, netnames[servernodeptr->nettype],
+				pingColor, servernodeptr->pingtime );
+		} else {
+			Com_sprintf( b, remaining, "%2d/%2d %-8.8s %3s %s%3d ",
+				servernodeptr->humanclients, servernodeptr->maxclients,
+				servernodeptr->gamename, netnames[servernodeptr->nettype],
+				pingColor, servernodeptr->pingtime );
+		}
 		j++;
 	}
 
@@ -1653,14 +1980,35 @@ static void ArenaServers_Insert( char* adrstr, char* info, int pingtime )
 	servernode_t*	serverlist;
 	char*			s;
 	char			savedGamename[64];
+	char			normalized[MAX_ADDRESSLENGTH];
+	char			hostname[MAX_HOSTNAMELENGTH + 3];
+	char			mapname[MAX_MAPNAMELENGTH];
+	char			gamename[16];
 	int				i;
+	int				gametype;
 	int				*numservers;
 	int				maxservers;
 	qboolean		existing;
+	qboolean		keepExistingAddress;
 
 	existing = qfalse;
+	keepExistingAddress = qfalse;
 	servernodeptr = NULL;
 	savedGamename[0] = '\0';
+	hostname[0] = '\0';
+	mapname[0] = '\0';
+	gamename[0] = '\0';
+	gametype = 0;
+
+	if( !adrstr || !adrstr[0] ) {
+		return;
+	}
+
+	Q_strncpyz( normalized, adrstr, sizeof( normalized ) );
+	ArenaServers_NormalizeAddress( normalized );
+	if( !normalized[0] ) {
+		return;
+	}
 
 	if( g_internet_scan ) {
 		serverlist = g_globalserverlist;
@@ -1673,10 +2021,53 @@ static void ArenaServers_Insert( char* adrstr, char* info, int pingtime )
 	}
 
 	for( i = 0; i < *numservers; i++ ) {
-		if( !Q_stricmp( serverlist[i].adrstr, adrstr ) ) {
+		if( ArenaServers_SameAddress( serverlist[i].adrstr, normalized ) ) {
 			servernodeptr = &serverlist[i];
 			existing = qtrue;
 			break;
+		}
+	}
+
+	/* Parse identity up front so multi-port decoys collapse into one row. */
+	if( info && info[0] ) {
+		Q_strncpyz( hostname, Info_ValueForKey( info, "hostname" ), sizeof( hostname ) );
+		ArenaServers_PrepareHostname( hostname );
+
+		Q_strncpyz( mapname, Info_ValueForKey( info, "mapname" ), sizeof( mapname ) );
+		Q_CleanStr( mapname );
+		Q_strupr( mapname );
+
+		gametype = atoi( Info_ValueForKey( info, "gametype" ) );
+		if( gametype < 0 ) {
+			gametype = 0;
+		}
+#ifdef WITH_MULTITOURNAMENT
+		else if( gametype > 13 ) {
+			gametype = 14;
+		}
+#else
+		else if( gametype > 12 ) {
+			gametype = 13;
+		}
+#endif
+
+		s = Info_ValueForKey( info, "game" );
+		if( *s ) {
+			Q_strncpyz( gamename, s, sizeof( gamename ) );
+		} else {
+			Q_strncpyz( gamename, gamenames[gametype], sizeof( gamename ) );
+		}
+
+		if( !existing ) {
+			for( i = 0; i < *numservers; i++ ) {
+				if( ArenaServers_SameIdentity(
+						serverlist[i].hostname, serverlist[i].mapname, serverlist[i].gametype,
+						hostname, mapname, gametype ) ) {
+					servernodeptr = &serverlist[i];
+					existing = qtrue;
+					break;
+				}
+			}
 		}
 	}
 
@@ -1702,34 +2093,41 @@ static void ArenaServers_Insert( char* adrstr, char* info, int pingtime )
 		Q_strncpyz( savedGamename, servernodeptr->gamename, sizeof( savedGamename ) );
 	}
 
-	Q_strncpyz( servernodeptr->adrstr, adrstr, MAX_ADDRESSLENGTH );
+	if( existing && servernodeptr->hostname[0] &&
+		ArenaServers_SameIdentity(
+			servernodeptr->hostname, servernodeptr->mapname, servernodeptr->gametype,
+			hostname, mapname, gametype ) &&
+		!ArenaServers_PreferAddress( normalized, pingtime, servernodeptr->adrstr, servernodeptr->pingtime ) ) {
+		keepExistingAddress = qtrue;
+	}
+
+	if( !keepExistingAddress ) {
+		Q_strncpyz( servernodeptr->adrstr, normalized, MAX_ADDRESSLENGTH );
+	}
 
 	if( g_internet_scan && !info[0] ) {
 		if( existing ) {
 			if( pingtime < ArenaServers_MaxPing() ) {
 				servernodeptr->pingtime = pingtime;
 			}
-			if( g_mainmenu_list ) {
-				ArenaServers_UpdateMainMenuList();
-			}
+			ArenaServers_MarkListDirty();
 		} else {
 			(*numservers)--;
 		}
 		return;
 	}
 
-	Q_strncpyz( servernodeptr->hostname, Info_ValueForKey( info, "hostname"), MAX_HOSTNAMELENGTH );
-	Q_CleanStrWithColor( servernodeptr->hostname );
-
-	Q_strncpyz( servernodeptr->mapname, Info_ValueForKey( info, "mapname"), MAX_MAPNAMELENGTH );
-	Q_CleanStr( servernodeptr->mapname );
-	Q_strupr( servernodeptr->mapname );
+	Q_strncpyz( servernodeptr->hostname, hostname, sizeof( servernodeptr->hostname ) );
+	Q_strncpyz( servernodeptr->mapname, mapname, sizeof( servernodeptr->mapname ) );
 
 	servernodeptr->numclients = atoi( Info_ValueForKey( info, "clients") );
 	servernodeptr->humanclients = atoi( Info_ValueForKey( info, "g_humanplayers") );
 	servernodeptr->needPass = atoi( Info_ValueForKey( info, "g_needpass") );
 	servernodeptr->maxclients = atoi( Info_ValueForKey( info, "sv_maxclients") );
-	servernodeptr->pingtime   = pingtime;
+	if( !keepExistingAddress || pingtime <= 0 ||
+		servernodeptr->pingtime <= 0 || pingtime < servernodeptr->pingtime ) {
+		servernodeptr->pingtime = pingtime;
+	}
 	servernodeptr->minPing    = atoi( Info_ValueForKey( info, "minPing") );
 	servernodeptr->maxPing    = atoi( Info_ValueForKey( info, "maxPing") );
 
@@ -1750,40 +2148,22 @@ static void ArenaServers_Insert( char* adrstr, char* info, int pingtime )
 	
 	servernodeptr->nettype = atoi(Info_ValueForKey(info, "nettype"));
 
-	s = Info_ValueForKey( info, "game");
-	i = atoi( Info_ValueForKey( info, "gametype") );
-	if( i < 0 ) {
-		i = 0;
-	}
-#ifdef WITH_MULTITOURNAMENT
-	else if( i > 13 ) {
-		i = 14;
-	}
-#else
-	else if( i > 12 ) {
-		i = 13;
-	}
-#endif
-	if( *s ) {
-		servernodeptr->gametype = i;
-		Q_strncpyz( servernodeptr->gamename, s, sizeof(servernodeptr->gamename) );
+	servernodeptr->gametype = gametype;
+	if( gamename[0] ) {
+		Q_strncpyz( servernodeptr->gamename, gamename, sizeof(servernodeptr->gamename) );
 	}
 	else if( g_internet_scan && existing && savedGamename[0] ) {
-		servernodeptr->gametype = i;
 		Q_strncpyz( servernodeptr->gamename, savedGamename, sizeof(servernodeptr->gamename) );
 	}
 	else {
-		servernodeptr->gametype = i;
-		Q_strncpyz( servernodeptr->gamename, gamenames[i], sizeof(servernodeptr->gamename) );
+		Q_strncpyz( servernodeptr->gamename, gamenames[gametype], sizeof(servernodeptr->gamename) );
 	}
 
 	if( g_internet_scan ) {
 		if( MainMenuServers_IsDevotionMod( servernodeptr->gamename ) ) {
 			MainMenuServers_CacheServer( servernodeptr );
 		}
-		if( g_mainmenu_list ) {
-			ArenaServers_UpdateMainMenuList();
-		}
+		ArenaServers_MarkListDirty();
 	}
 }
 
@@ -1928,17 +2308,18 @@ static void ArenaServers_StopRefresh( void )
 			g_arenaservers.currentping       = *g_arenaservers.numservers;
 			g_arenaservers.numqueriedservers = *g_arenaservers.numservers; 
 		}
+
+		if( was_internet ) {
+			ArenaServers_DedupeServerList( g_globalserverlist, &g_numglobalservers );
+		}
 	
 		// sort
 		qsort( g_arenaservers.serverlist, *g_arenaservers.numservers, sizeof( servernode_t ), ArenaServers_Compare);
 
-		ArenaServers_UpdateMenu();
+		ArenaServers_FlushListUI( qtrue );
 
 		if( was_internet ) {
 			MainMenuServers_SaveCache();
-			if( g_mainmenu_list ) {
-				ArenaServers_UpdateMainMenuList();
-			}
 		}
 	}
 }
@@ -1984,8 +2365,8 @@ static qboolean MainMenuServers_AnyMasterDefined( void ) {
 MainMenuServers_MergeFromGlobalIncremental
 
 Copy newly arrived addresses from the engine's combined AS_GLOBAL list.
-ioquake3 dedupes master responses into that list; we still skip addresses
-already present from the devotion cache priority queue.
+Masters often return overlapping servers; we always de-dupe by normalized
+address into g_mainmenu_addresses before pinging.
 =================
 */
 static void MainMenuServers_MergeFromGlobalIncremental( void ) {
@@ -2043,6 +2424,7 @@ MainMenuServers_BeginPingPhase
 =================
 */
 static void MainMenuServers_BeginPingPhase( void ) {
+	ArenaServers_DedupeServerList( g_globalserverlist, &g_numglobalservers );
 	g_mainmenu_refresh_phase = MM_REFRESH_PINGING;
 	g_arenaservers.numqueriedservers = g_mainmenu_numaddresses;
 	g_arenaservers.currentping = 0;
@@ -2140,13 +2522,13 @@ static void MainMenuServers_StartRefresh( void ) {
 	g_mainmenu_last_ping_time = 0;
 	g_mainmenu_last_ping_activity = uis.realtime;
 
+	/* Drop previous scan results so master overlaps cannot accumulate across refreshes. */
+	memset( g_globalserverlist, 0, sizeof( g_globalserverlist ) );
+	g_numglobalservers = 0;
+	MainMenuServers_LoadCache();
 	MainMenuServers_AddCachedAddresses();
-
-	if( g_mainmenu_list ) {
-		ArenaServers_UpdateMainMenuList();
-	} else if( g_servertype == UIAS_INTERNET ) {
-		ArenaServers_UpdateMenu();
-	}
+	ArenaServers_MarkListDirty();
+	ArenaServers_FlushListUI( qtrue );
 
 	if( !MainMenuServers_AnyMasterDefined() ) {
 		MainMenuServers_BeginPingPhase();
@@ -2169,18 +2551,13 @@ static void MainMenuServers_DoRefresh( void ) {
 
 	if( g_mainmenu_refresh_phase == MM_REFRESH_MASTERS ) {
 		MainMenuServers_PollMasters();
-		if( g_mainmenu_list ) {
-			ArenaServers_UpdateMainMenuList();
-		} else if( g_servertype == UIAS_INTERNET ) {
-			ArenaServers_UpdateMenu();
-		}
+		ArenaServers_FlushListUI( qfalse );
 		return;
 	}
 
 	if( uis.realtime - g_mainmenu_scan_start_time > MAINMENU_SCAN_TIMEOUT_MS ) {
 		MainMenuServers_ClearPendingPings();
 		ArenaServers_StopRefresh();
-		ArenaServers_UpdateMainMenuList();
 		return;
 	}
 
@@ -2192,7 +2569,7 @@ static void MainMenuServers_DoRefresh( void ) {
 		}
 
 		for( j = 0; j < MAX_PINGREQUESTS; j++ ) {
-			if( !Q_stricmp( adrstr, g_arenaservers.pinglist[j].adrstr ) ) {
+			if( ArenaServers_SameAddress( adrstr, g_arenaservers.pinglist[j].adrstr ) ) {
 				break;
 			}
 		}
@@ -2241,11 +2618,7 @@ static void MainMenuServers_DoRefresh( void ) {
 	}
 
 	if( uis.realtime - g_mainmenu_last_ping_time < MAINMENU_PING_INTERVAL_MS ) {
-		if( g_mainmenu_list ) {
-			ArenaServers_UpdateMainMenuList();
-		} else if( g_servertype == UIAS_INTERNET ) {
-			ArenaServers_UpdateMenu();
-		}
+		ArenaServers_FlushListUI( qfalse );
 		return;
 	}
 
@@ -2268,20 +2641,31 @@ static void MainMenuServers_DoRefresh( void ) {
 			break;
 		}
 
+		/* skip any address we somehow queued twice */
 		Q_strncpyz( adrstr, g_mainmenu_addresses[g_arenaservers.currentping], MAX_ADDRESSLENGTH );
+		g_arenaservers.currentping++;
+		if( !adrstr[0] ) {
+			continue;
+		}
+		for( i = 0; i < MAX_PINGREQUESTS; i++ ) {
+			if( g_arenaservers.pinglist[i].adrstr[0] &&
+				ArenaServers_SameAddress( adrstr, g_arenaservers.pinglist[i].adrstr ) ) {
+				adrstr[0] = '\0';
+				break;
+			}
+		}
+		if( !adrstr[0] ) {
+			continue;
+		}
+
 		Q_strncpyz( g_arenaservers.pinglist[j].adrstr, adrstr, MAX_ADDRESSLENGTH );
 		g_arenaservers.pinglist[j].start = uis.realtime;
 		trap_Cmd_ExecuteText( EXEC_NOW, va( "ping %s\n", adrstr ) );
-		g_arenaservers.currentping++;
 		pingsSent++;
 		g_mainmenu_last_ping_activity = uis.realtime;
 	}
 
-	if( g_mainmenu_list ) {
-		ArenaServers_UpdateMainMenuList();
-	} else if( g_servertype == UIAS_INTERNET ) {
-		ArenaServers_UpdateMenu();
-	}
+	ArenaServers_FlushListUI( qfalse );
 }
 
 /*
@@ -2433,7 +2817,8 @@ static void ArenaServers_DoRefresh( void )
 	}
 
 	// update the user interface with ping status
-	ArenaServers_UpdateMenu();
+	ArenaServers_MarkListDirty();
+	ArenaServers_FlushListUI( qfalse );
 }
 
 

--- a/ratoa_gamecode/code/q3_ui/ui_servers2.c
+++ b/ratoa_gamecode/code/q3_ui/ui_servers2.c
@@ -86,12 +86,16 @@ MULTIPLAYER MENU (SERVER BROWSER)
 #define GR_LETTERS			31
 
 #define UIAS_LOCAL			0
-#define UIAS_GLOBAL1			1
-#define UIAS_GLOBAL2			2
-#define UIAS_GLOBAL3			3
-#define UIAS_GLOBAL4			4
-#define UIAS_GLOBAL5			5
-#define UIAS_FAVORITES			6
+#define UIAS_INTERNET			1
+#define UIAS_FAVORITES			2
+
+/* Engine LAN master source indices (sv_master1..5) */
+#define AS_MASTER1			1
+#define AS_MASTER2			2
+#define AS_MASTER3			3
+#define AS_MASTER4			4
+#define AS_MASTER5			5
+#define AS_MASTER_MAX			5
 
 #define MM_REFRESH_MASTERS		0
 #define MM_REFRESH_PINGING		1
@@ -104,7 +108,6 @@ MULTIPLAYER MENU (SERVER BROWSER)
 #define MAINMENU_PINGS_PER_TICK		4
 #define MAINMENU_PING_INTERVAL_MS	50
 #define MAINMENU_MAX_CACHE_WRITTEN	128
-#define MAINMENU_MAX_DISCOVERY_ADDRESSES	128
 #define MAINMENU_SCAN_TIMEOUT_MS		90000
 #define MAINMENU_PING_STALL_MS		10000
 #define MAINMENU_PING_UNKNOWN		(-1)
@@ -154,10 +157,6 @@ MULTIPLAYER MENU (SERVER BROWSER)
 static const char *master_items[] = {
 	"Local",
 	"Internet",
-	"Internet(2)",
-	"Internet(3)",
-	"Internet(4)",
-	"Internet(5)",
 	"Favorites",
 	NULL
 };
@@ -321,8 +320,6 @@ static arenaservers_t	g_arenaservers;
 
 static servernode_t		g_globalserverlist[MAX_GLOBALSERVERS];
 static int				g_numglobalservers;
-static servernode_t		g_mainmenu_serverlist[MAX_GLOBALSERVERS];
-static int				g_mainmenu_numservers;
 static servernode_t		g_localserverlist[MAX_LOCALSERVERS];
 static int				g_numlocalservers;
 static servernode_t		g_favoriteserverlist[MAX_FAVORITESERVERS];
@@ -338,21 +335,20 @@ static int                              g_hideprivate;
 
 static menulist_s			*g_mainmenu_list = NULL;
 static menubitmap_s			*g_mainmenu_mappic = NULL;
+static qboolean				g_internet_scan;
 static int					g_mainmenu_refresh_phase;
 static int					g_mainmenu_scan_start_time;
-static int					g_mainmenu_active_query_master;
 static int					g_mainmenu_last_ping_time;
-static int					g_mainmenu_master_last_count[UIAS_GLOBAL5 + 1];
-static int					g_mainmenu_master_merged_idx[UIAS_GLOBAL5 + 1];
-static int					g_mainmenu_master_stable_time[UIAS_GLOBAL5 + 1];
-static int					g_mainmenu_master_query_time[UIAS_GLOBAL5 + 1];
-static qboolean				g_mainmenu_master_done[UIAS_GLOBAL5 + 1];
-static qboolean				g_mainmenu_master_query_sent[UIAS_GLOBAL5 + 1];
+static int					g_mainmenu_master_last_count;
+static int					g_mainmenu_master_merged_idx;
+static int					g_mainmenu_master_stable_time;
+static int					g_mainmenu_master_query_time;
+static qboolean				g_mainmenu_master_query_sent;
+static qboolean				g_mainmenu_masters_done;
 static char					g_mainmenu_cache_written[MAINMENU_MAX_CACHE_WRITTEN][MAX_ADDRESSLENGTH];
 static int					g_mainmenu_cache_written_count;
 static char					g_mainmenu_addresses[MAINMENU_MAX_ADDRESSES][MAX_ADDRESSLENGTH];
 static int					g_mainmenu_numaddresses;
-static int					g_mainmenu_discovery_addresses;
 static int					g_mainmenu_last_ping_activity;
 
 static void ArenaServers_StopRefresh( void );
@@ -371,11 +367,16 @@ char *Q_CleanStrWithColor( char *string ) {
 	while ((c = *s) != 0 ) {
 		if ( Q_IsColorString( s ) ) {
 			*d++ = c;
+			*d++ = ( s[1] == '0' ) ? '7' : s[1];
+			s += 2;
 		}
 		else if ( c >= 0x20 && c <= 0x7E ) {
 			*d++ = c;
+			s++;
 		}
-		s++;
+		else {
+			s++;
+		}
 	}
 	*d = '\0';
 
@@ -635,10 +636,6 @@ MainMenuServers_AddDiscoveryAddress
 =================
 */
 static void MainMenuServers_AddDiscoveryAddress( const char *adrstr ) {
-	if( g_mainmenu_discovery_addresses >= MAINMENU_MAX_DISCOVERY_ADDRESSES ) {
-		return;
-	}
-
 	if( !adrstr || !adrstr[0] || MainMenuServers_AddressExists( adrstr ) ) {
 		return;
 	}
@@ -648,7 +645,6 @@ static void MainMenuServers_AddDiscoveryAddress( const char *adrstr ) {
 	}
 
 	MainMenuServers_AddAddress( adrstr );
-	g_mainmenu_discovery_addresses++;
 }
 
 /*
@@ -712,11 +708,11 @@ MainMenuServers_AddCachedAddresses
 static void MainMenuServers_AddCachedAddresses( void ) {
 	int		i;
 
-	for( i = 0; i < *g_arenaservers.numservers; i++ ) {
-		if( !MainMenuServers_IsDevotionMod( g_arenaservers.serverlist[i].gamename ) ) {
+	for( i = 0; i < g_numglobalservers; i++ ) {
+		if( !MainMenuServers_IsDevotionMod( g_globalserverlist[i].gamename ) ) {
 			continue;
 		}
-		MainMenuServers_AddAddress( g_arenaservers.serverlist[i].adrstr );
+		MainMenuServers_AddAddress( g_globalserverlist[i].adrstr );
 	}
 }
 
@@ -731,21 +727,22 @@ static void MainMenuServers_InsertCachedServer( const char *adrstr, const char *
 	servernode_t	*servernodeptr;
 	int				i;
 
-	for( i = 0; i < *g_arenaservers.numservers; i++ ) {
-		if( !Q_stricmp( g_arenaservers.serverlist[i].adrstr, adrstr ) ) {
+	for( i = 0; i < g_numglobalservers; i++ ) {
+		if( !Q_stricmp( g_globalserverlist[i].adrstr, adrstr ) ) {
 			return;
 		}
 	}
 
-	if( *g_arenaservers.numservers >= g_arenaservers.maxservers ) {
+	if( g_numglobalservers >= MAX_GLOBALSERVERS ) {
 		return;
 	}
 
-	servernodeptr = g_arenaservers.serverlist + (*g_arenaservers.numservers);
-	(*g_arenaservers.numservers)++;
+	servernodeptr = &g_globalserverlist[g_numglobalservers];
+	g_numglobalservers++;
 
 	Q_strncpyz( servernodeptr->adrstr, adrstr, MAX_ADDRESSLENGTH );
 	Q_strncpyz( servernodeptr->hostname, hostname, sizeof( servernodeptr->hostname ) );
+	Q_CleanStrWithColor( servernodeptr->hostname );
 	Q_strncpyz( servernodeptr->mapname, mapname, sizeof( servernodeptr->mapname ) );
 	Q_strncpyz( servernodeptr->gamename, "devotion", sizeof( servernodeptr->gamename ) );
 	servernodeptr->pingtime = pingtime;
@@ -866,7 +863,7 @@ static void MainMenuServers_CacheServer( servernode_t *servernodeptr ) {
 	char			line[MAX_ADDRESSLENGTH + MAX_HOSTNAMELENGTH + MAX_MAPNAMELENGTH + 16];
 	char			hostname[MAX_HOSTNAMELENGTH + 3];
 
-	if( !g_mainmenu_list || !servernodeptr ) {
+	if( !servernodeptr ) {
 		return;
 	}
 
@@ -913,8 +910,8 @@ static void MainMenuServers_SaveCache( void ) {
 
 	trap_FS_FOpenFile( MAINMENU_CACHE_FILE, &f, FS_WRITE );
 
-	for( i = 0; i < *g_arenaservers.numservers; i++ ) {
-		servernodeptr = &g_arenaservers.serverlist[i];
+	for( i = 0; i < g_numglobalservers; i++ ) {
+		servernodeptr = &g_globalserverlist[i];
 		if( !MainMenuServers_IsDevotionMod( servernodeptr->gamename ) ) {
 			continue;
 		}
@@ -1244,12 +1241,12 @@ static void ArenaServers_UpdateMainMenuList( void ) {
 
 	curvalue = list->curvalue;
 
-	if( *g_arenaservers.numservers > 0 ) {
-		qsort( g_arenaservers.serverlist, *g_arenaservers.numservers, sizeof( servernode_t ), ArenaServers_Compare );
+	if( g_numglobalservers > 0 ) {
+		qsort( g_globalserverlist, g_numglobalservers, sizeof( servernode_t ), ArenaServers_Compare );
 	}
 
-	servernodeptr = g_arenaservers.serverlist;
-	count = *g_arenaservers.numservers;
+	servernodeptr = g_globalserverlist;
+	count = g_numglobalservers;
 	for( i = 0, j = 0; i < count; i++, servernodeptr++ ) {
 		if( !MainMenuServers_IsDevotionMod( servernodeptr->gamename ) ) {
 			continue;
@@ -1319,7 +1316,7 @@ static void ArenaServers_UpdateMenu( void ) {
 			g_arenaservers.go.generic.flags			&= ~QMF_GRAYED;
 
 			// update status bar
-			if( g_servertype >= UIAS_GLOBAL1 && g_servertype <= UIAS_GLOBAL5 ) {
+			if( g_servertype == UIAS_INTERNET ) {
 				g_arenaservers.statusbar.string = quake3worldMessage;
 			}
 			else {
@@ -1356,7 +1353,7 @@ static void ArenaServers_UpdateMenu( void ) {
 			}
 
 			// update status bar
-			if( g_servertype >= UIAS_GLOBAL1 && g_servertype <= UIAS_GLOBAL5 ) {
+			if( g_servertype == UIAS_INTERNET ) {
 				g_arenaservers.statusbar.string = quake3worldMessage;
 			}
 			else {
@@ -1653,78 +1650,89 @@ ArenaServers_Insert
 static void ArenaServers_Insert( char* adrstr, char* info, int pingtime )
 {
 	servernode_t*	servernodeptr;
+	servernode_t*	serverlist;
 	char*			s;
 	char			savedGamename[64];
 	int				i;
+	int				*numservers;
+	int				maxservers;
 	qboolean		existing;
 
 	existing = qfalse;
 	servernodeptr = NULL;
 	savedGamename[0] = '\0';
 
-	for( i = 0; i < *g_arenaservers.numservers; i++ ) {
-		if( !Q_stricmp( g_arenaservers.serverlist[i].adrstr, adrstr ) ) {
-			servernodeptr = &g_arenaservers.serverlist[i];
+	if( g_internet_scan ) {
+		serverlist = g_globalserverlist;
+		numservers = &g_numglobalservers;
+		maxservers = MAX_GLOBALSERVERS;
+	} else {
+		serverlist = g_arenaservers.serverlist;
+		numservers = g_arenaservers.numservers;
+		maxservers = g_arenaservers.maxservers;
+	}
+
+	for( i = 0; i < *numservers; i++ ) {
+		if( !Q_stricmp( serverlist[i].adrstr, adrstr ) ) {
+			servernodeptr = &serverlist[i];
 			existing = qtrue;
 			break;
 		}
 	}
 
 	if( !existing ) {
-		if ((pingtime >= ArenaServers_MaxPing()) && (g_servertype != UIAS_FAVORITES) && !g_mainmenu_list)
-		{
-			// slow global or local servers do not get entered
+		if( ( pingtime >= ArenaServers_MaxPing() ) && ( g_servertype != UIAS_FAVORITES ) && !g_internet_scan ) {
+			/* slow local servers do not get entered */
 			return;
 		}
 
-		if (*g_arenaservers.numservers >= g_arenaservers.maxservers) {
-			if( g_mainmenu_list ) {
+		if( *numservers >= maxservers ) {
+			if( g_internet_scan ) {
 				return;
 			}
-			// list full;
-			servernodeptr = g_arenaservers.serverlist+(*g_arenaservers.numservers)-1;
+			/* list full; overwrite last */
+			servernodeptr = serverlist + (*numservers) - 1;
 		} else {
-			// next slot
-			servernodeptr = g_arenaservers.serverlist+(*g_arenaservers.numservers);
-			(*g_arenaservers.numservers)++;
+			servernodeptr = serverlist + (*numservers);
+			(*numservers)++;
 		}
 	}
 
-	if( g_mainmenu_list && existing ) {
+	if( g_internet_scan && existing ) {
 		Q_strncpyz( savedGamename, servernodeptr->gamename, sizeof( savedGamename ) );
 	}
 
 	Q_strncpyz( servernodeptr->adrstr, adrstr, MAX_ADDRESSLENGTH );
 
-	if( g_mainmenu_list && !info[0] ) {
+	if( g_internet_scan && !info[0] ) {
 		if( existing ) {
 			if( pingtime < ArenaServers_MaxPing() ) {
 				servernodeptr->pingtime = pingtime;
 			}
-			ArenaServers_UpdateMainMenuList();
+			if( g_mainmenu_list ) {
+				ArenaServers_UpdateMainMenuList();
+			}
 		} else {
-			(*g_arenaservers.numservers)--;
+			(*numservers)--;
 		}
 		return;
 	}
 
 	Q_strncpyz( servernodeptr->hostname, Info_ValueForKey( info, "hostname"), MAX_HOSTNAMELENGTH );
 	Q_CleanStrWithColor( servernodeptr->hostname );
-	//Q_strupr( servernodeptr->hostname );
 
 	Q_strncpyz( servernodeptr->mapname, Info_ValueForKey( info, "mapname"), MAX_MAPNAMELENGTH );
 	Q_CleanStr( servernodeptr->mapname );
 	Q_strupr( servernodeptr->mapname );
 
 	servernodeptr->numclients = atoi( Info_ValueForKey( info, "clients") );
-        servernodeptr->humanclients = atoi( Info_ValueForKey( info, "g_humanplayers") );
-        servernodeptr->needPass = atoi( Info_ValueForKey( info, "g_needpass") );
+	servernodeptr->humanclients = atoi( Info_ValueForKey( info, "g_humanplayers") );
+	servernodeptr->needPass = atoi( Info_ValueForKey( info, "g_needpass") );
 	servernodeptr->maxclients = atoi( Info_ValueForKey( info, "sv_maxclients") );
 	servernodeptr->pingtime   = pingtime;
 	servernodeptr->minPing    = atoi( Info_ValueForKey( info, "minPing") );
 	servernodeptr->maxPing    = atoi( Info_ValueForKey( info, "maxPing") );
 
-	
 	s = Info_ValueForKey( info, "nettype" );
 	for (i=0; ;i++)
 	{
@@ -1757,10 +1765,10 @@ static void ArenaServers_Insert( char* adrstr, char* info, int pingtime )
 	}
 #endif
 	if( *s ) {
-		servernodeptr->gametype = i;//-1;
+		servernodeptr->gametype = i;
 		Q_strncpyz( servernodeptr->gamename, s, sizeof(servernodeptr->gamename) );
 	}
-	else if( g_mainmenu_list && existing && savedGamename[0] ) {
+	else if( g_internet_scan && existing && savedGamename[0] ) {
 		servernodeptr->gametype = i;
 		Q_strncpyz( servernodeptr->gamename, savedGamename, sizeof(servernodeptr->gamename) );
 	}
@@ -1769,16 +1777,13 @@ static void ArenaServers_Insert( char* adrstr, char* info, int pingtime )
 		Q_strncpyz( servernodeptr->gamename, gamenames[i], sizeof(servernodeptr->gamename) );
 	}
 
-	if( g_mainmenu_list ) {
-		if( !MainMenuServers_IsDevotionMod( servernodeptr->gamename ) ) {
-			if( !existing ) {
-				(*g_arenaservers.numservers)--;
-			}
-			return;
+	if( g_internet_scan ) {
+		if( MainMenuServers_IsDevotionMod( servernodeptr->gamename ) ) {
+			MainMenuServers_CacheServer( servernodeptr );
 		}
-
-		MainMenuServers_CacheServer( servernodeptr );
-		ArenaServers_UpdateMainMenuList();
+		if( g_mainmenu_list ) {
+			ArenaServers_UpdateMainMenuList();
+		}
 	}
 }
 
@@ -1901,28 +1906,40 @@ static void ArenaServers_StopRefresh( void )
 		// not currently refreshing
 		return;
 
-	g_arenaservers.refreshservers = qfalse;
+	if (!g_arenaservers.refreshservers)
+		// not currently refreshing
+		return;
 
-	if (g_servertype == UIAS_FAVORITES)
 	{
-		// nonresponsive favorites must be shown
-		ArenaServers_InsertFavorites();
-	}
+		qboolean was_internet = g_internet_scan;
 
-	// final tally
-	if (g_arenaservers.numqueriedservers >= 0)
-	{
-		g_arenaservers.currentping       = *g_arenaservers.numservers;
-		g_arenaservers.numqueriedservers = *g_arenaservers.numservers; 
-	}
+		g_arenaservers.refreshservers = qfalse;
+		g_internet_scan = qfalse;
+
+		if (g_servertype == UIAS_FAVORITES)
+		{
+			// nonresponsive favorites must be shown
+			ArenaServers_InsertFavorites();
+		}
+
+		// final tally
+		if (g_arenaservers.numqueriedservers >= 0)
+		{
+			g_arenaservers.currentping       = *g_arenaservers.numservers;
+			g_arenaservers.numqueriedservers = *g_arenaservers.numservers; 
+		}
 	
-	// sort
-	qsort( g_arenaservers.serverlist, *g_arenaservers.numservers, sizeof( servernode_t ), ArenaServers_Compare);
+		// sort
+		qsort( g_arenaservers.serverlist, *g_arenaservers.numservers, sizeof( servernode_t ), ArenaServers_Compare);
 
-	ArenaServers_UpdateMenu();
+		ArenaServers_UpdateMenu();
 
-	if( g_mainmenu_list ) {
-		MainMenuServers_SaveCache();
+		if( was_internet ) {
+			MainMenuServers_SaveCache();
+			if( g_mainmenu_list ) {
+				ArenaServers_UpdateMainMenuList();
+			}
+		}
 	}
 }
 
@@ -1936,7 +1953,7 @@ static qboolean MainMenuServers_IsMasterDefined( int masterIndex ) {
 	char	masterstr[64];
 	char	cvarname[sizeof( "sv_master5" )];
 
-	if( masterIndex < UIAS_GLOBAL1 || masterIndex > UIAS_GLOBAL5 ) {
+	if( masterIndex < AS_MASTER1 || masterIndex > AS_MASTER_MAX ) {
 		return qfalse;
 	}
 
@@ -1947,76 +1964,77 @@ static qboolean MainMenuServers_IsMasterDefined( int masterIndex ) {
 
 /*
 =================
-MainMenuServers_MergeFromMasterIncremental
+MainMenuServers_AnyMasterDefined
 =================
 */
-static void MainMenuServers_MergeFromMasterIncremental( int masterIndex ) {
+static qboolean MainMenuServers_AnyMasterDefined( void ) {
+	int		m;
+
+	for( m = AS_MASTER1; m <= AS_MASTER_MAX; m++ ) {
+		if( MainMenuServers_IsMasterDefined( m ) ) {
+			return qtrue;
+		}
+	}
+
+	return qfalse;
+}
+
+/*
+=================
+MainMenuServers_MergeFromGlobalIncremental
+
+Copy newly arrived addresses from the engine's combined AS_GLOBAL list.
+ioquake3 dedupes master responses into that list; we still skip addresses
+already present from the devotion cache priority queue.
+=================
+*/
+static void MainMenuServers_MergeFromGlobalIncremental( void ) {
 	int		i;
 	int		count;
 	char	adrstr[MAX_ADDRESSLENGTH];
 
-	count = trap_LAN_GetServerCount( masterIndex );
+	count = trap_LAN_GetServerCount( AS_GLOBAL );
 	if( count < 0 ) {
 		return;
 	}
 
-	if( count < g_mainmenu_master_merged_idx[masterIndex] ) {
-		g_mainmenu_master_merged_idx[masterIndex] = 0;
+	if( count < g_mainmenu_master_merged_idx ) {
+		g_mainmenu_master_merged_idx = 0;
 	}
 
-	for( i = g_mainmenu_master_merged_idx[masterIndex]; i < count; i++ ) {
-		trap_LAN_GetServerAddressString( masterIndex, i, adrstr, MAX_ADDRESSLENGTH );
+	for( i = g_mainmenu_master_merged_idx; i < count; i++ ) {
+		trap_LAN_GetServerAddressString( AS_GLOBAL, i, adrstr, MAX_ADDRESSLENGTH );
 		if( adrstr[0] ) {
 			MainMenuServers_AddDiscoveryAddress( adrstr );
 		}
 	}
 
-	g_mainmenu_master_merged_idx[masterIndex] = count;
+	g_mainmenu_master_merged_idx = count;
 }
 
 /*
 =================
 MainMenuServers_IssueMasterQuery
+
+Ask the engine to query every configured master once (globalservers 0).
 =================
 */
-static void MainMenuServers_IssueMasterQuery( int masterIndex ) {
+static void MainMenuServers_IssueMasterQuery( void ) {
 	char	protocol[32];
 
-	g_mainmenu_master_query_time[masterIndex] = uis.realtime;
-	g_mainmenu_master_query_sent[masterIndex] = qtrue;
-	g_mainmenu_active_query_master = masterIndex;
-	g_mainmenu_master_last_count[masterIndex] = -1;
+	g_mainmenu_master_query_time = uis.realtime;
+	g_mainmenu_master_query_sent = qtrue;
+	g_mainmenu_master_last_count = -1;
+	g_mainmenu_master_merged_idx = 0;
+	g_mainmenu_masters_done = qfalse;
 
 	protocol[0] = '\0';
 	trap_Cvar_VariableStringBuffer( "debug_protocol", protocol, sizeof( protocol ) );
 	if( strlen( protocol ) ) {
-		trap_Cmd_ExecuteText( EXEC_NOW, va( "globalservers %d %s\n", masterIndex - 1, protocol ) );
+		trap_Cmd_ExecuteText( EXEC_NOW, va( "globalservers 0 %s\n", protocol ) );
 	} else {
-		trap_Cmd_ExecuteText( EXEC_NOW, va( "globalservers %d %d\n", masterIndex - 1, (int)trap_Cvar_VariableValue( "protocol" ) ) );
+		trap_Cmd_ExecuteText( EXEC_NOW, va( "globalservers 0 %d\n", (int)trap_Cvar_VariableValue( "protocol" ) ) );
 	}
-}
-
-/*
-=================
-MainMenuServers_AllMastersFinished
-=================
-*/
-static qboolean MainMenuServers_AllMastersFinished( void ) {
-	int			m;
-	qboolean	found;
-
-	found = qfalse;
-	for( m = UIAS_GLOBAL1; m <= UIAS_GLOBAL5; m++ ) {
-		if( !MainMenuServers_IsMasterDefined( m ) ) {
-			continue;
-		}
-		found = qtrue;
-		if( !g_mainmenu_master_done[m] ) {
-			return qfalse;
-		}
-	}
-
-	return found;
 }
 
 /*
@@ -2029,7 +2047,7 @@ static void MainMenuServers_BeginPingPhase( void ) {
 	g_arenaservers.numqueriedservers = g_mainmenu_numaddresses;
 	g_arenaservers.currentping = 0;
 	g_mainmenu_last_ping_time = 0;
-	g_mainmenu_active_query_master = 0;
+	g_mainmenu_masters_done = qtrue;
 
 	if( !g_mainmenu_numaddresses ) {
 		ArenaServers_StopRefresh();
@@ -2042,57 +2060,44 @@ MainMenuServers_PollMasters
 =================
 */
 static void MainMenuServers_PollMasters( void ) {
-	int		m;
 	int		count;
 
-	for( m = UIAS_GLOBAL1; m <= UIAS_GLOBAL5; m++ ) {
-		if( !MainMenuServers_IsMasterDefined( m ) ) {
-			continue;
-		}
-
-		if( g_mainmenu_master_done[m] ) {
-			continue;
-		}
-
-		if( !g_mainmenu_master_query_sent[m] &&
-			uis.realtime - g_mainmenu_scan_start_time > MAINMENU_MASTER_BOOT_MS &&
-			g_mainmenu_active_query_master == 0 ) {
-			MainMenuServers_IssueMasterQuery( m );
-			continue;
-		}
-
-		count = trap_LAN_GetServerCount( m );
-
-		if( count < 0 ) {
-			if( g_mainmenu_master_query_sent[m] &&
-				uis.realtime - g_mainmenu_master_query_time[m] > MAINMENU_MASTER_TIMEOUT_MS ) {
-				g_mainmenu_master_done[m] = qtrue;
-				if( g_mainmenu_active_query_master == m ) {
-					g_mainmenu_active_query_master = 0;
-				}
-			}
-			continue;
-		}
-
-		MainMenuServers_MergeFromMasterIncremental( m );
-
-		if( g_mainmenu_active_query_master == m ) {
-			g_mainmenu_active_query_master = 0;
-		}
-
-		if( count != g_mainmenu_master_last_count[m] ) {
-			g_mainmenu_master_last_count[m] = count;
-			g_mainmenu_master_stable_time[m] = uis.realtime;
-			continue;
-		}
-
-		if( g_mainmenu_master_query_sent[m] &&
-			uis.realtime - g_mainmenu_master_stable_time[m] >= MAINMENU_MASTER_STABLE_MS ) {
-			g_mainmenu_master_done[m] = qtrue;
-		}
+	if( g_mainmenu_masters_done ) {
+		return;
 	}
 
-	if( MainMenuServers_AllMastersFinished() ) {
+	if( !g_mainmenu_master_query_sent &&
+		uis.realtime - g_mainmenu_scan_start_time > MAINMENU_MASTER_BOOT_MS ) {
+		if( !MainMenuServers_AnyMasterDefined() ) {
+			MainMenuServers_BeginPingPhase();
+			return;
+		}
+		MainMenuServers_IssueMasterQuery();
+		return;
+	}
+
+	if( !g_mainmenu_master_query_sent ) {
+		return;
+	}
+
+	count = trap_LAN_GetServerCount( AS_GLOBAL );
+
+	if( count < 0 ) {
+		if( uis.realtime - g_mainmenu_master_query_time > MAINMENU_MASTER_TIMEOUT_MS ) {
+			MainMenuServers_BeginPingPhase();
+		}
+		return;
+	}
+
+	MainMenuServers_MergeFromGlobalIncremental();
+
+	if( count != g_mainmenu_master_last_count ) {
+		g_mainmenu_master_last_count = count;
+		g_mainmenu_master_stable_time = uis.realtime;
+		return;
+	}
+
+	if( uis.realtime - g_mainmenu_master_stable_time >= MAINMENU_MASTER_STABLE_MS ) {
 		MainMenuServers_BeginPingPhase();
 	}
 }
@@ -2111,14 +2116,13 @@ static void MainMenuServers_StartRefresh( void ) {
 
 	memset( g_mainmenu_addresses, 0, sizeof( g_mainmenu_addresses ) );
 	g_mainmenu_numaddresses = 0;
-	g_mainmenu_discovery_addresses = 0;
 	g_mainmenu_last_ping_activity = 0;
-	memset( g_mainmenu_master_last_count, -1, sizeof( g_mainmenu_master_last_count ) );
-	memset( g_mainmenu_master_merged_idx, 0, sizeof( g_mainmenu_master_merged_idx ) );
-	memset( g_mainmenu_master_stable_time, 0, sizeof( g_mainmenu_master_stable_time ) );
-	memset( g_mainmenu_master_query_time, 0, sizeof( g_mainmenu_master_query_time ) );
-	memset( g_mainmenu_master_done, 0, sizeof( g_mainmenu_master_done ) );
-	memset( g_mainmenu_master_query_sent, 0, sizeof( g_mainmenu_master_query_sent ) );
+	g_mainmenu_master_last_count = -1;
+	g_mainmenu_master_merged_idx = 0;
+	g_mainmenu_master_stable_time = 0;
+	g_mainmenu_master_query_time = 0;
+	g_mainmenu_master_query_sent = qfalse;
+	g_mainmenu_masters_done = qfalse;
 	g_mainmenu_cache_written_count = 0;
 
 	for( i = 0; i < MAX_PINGREQUESTS; i++ ) {
@@ -2126,25 +2130,25 @@ static void MainMenuServers_StartRefresh( void ) {
 		trap_LAN_ClearPing( i );
 	}
 
+	g_internet_scan = qtrue;
 	g_arenaservers.refreshservers = qtrue;
 	g_arenaservers.currentping = 0;
 	g_arenaservers.nextpingtime = 0;
 	g_arenaservers.numqueriedservers = 0;
 	g_mainmenu_refresh_phase = MM_REFRESH_MASTERS;
 	g_mainmenu_scan_start_time = uis.realtime;
-	g_mainmenu_active_query_master = 0;
 	g_mainmenu_last_ping_time = 0;
 	g_mainmenu_last_ping_activity = uis.realtime;
 
 	MainMenuServers_AddCachedAddresses();
 
-	ArenaServers_UpdateMainMenuList();
+	if( g_mainmenu_list ) {
+		ArenaServers_UpdateMainMenuList();
+	} else if( g_servertype == UIAS_INTERNET ) {
+		ArenaServers_UpdateMenu();
+	}
 
-	if( !MainMenuServers_IsMasterDefined( UIAS_GLOBAL1 ) &&
-		!MainMenuServers_IsMasterDefined( UIAS_GLOBAL2 ) &&
-		!MainMenuServers_IsMasterDefined( UIAS_GLOBAL3 ) &&
-		!MainMenuServers_IsMasterDefined( UIAS_GLOBAL4 ) &&
-		!MainMenuServers_IsMasterDefined( UIAS_GLOBAL5 ) ) {
+	if( !MainMenuServers_AnyMasterDefined() ) {
 		MainMenuServers_BeginPingPhase();
 	}
 }
@@ -2165,7 +2169,11 @@ static void MainMenuServers_DoRefresh( void ) {
 
 	if( g_mainmenu_refresh_phase == MM_REFRESH_MASTERS ) {
 		MainMenuServers_PollMasters();
-		ArenaServers_UpdateMainMenuList();
+		if( g_mainmenu_list ) {
+			ArenaServers_UpdateMainMenuList();
+		} else if( g_servertype == UIAS_INTERNET ) {
+			ArenaServers_UpdateMenu();
+		}
 		return;
 	}
 
@@ -2233,7 +2241,11 @@ static void MainMenuServers_DoRefresh( void ) {
 	}
 
 	if( uis.realtime - g_mainmenu_last_ping_time < MAINMENU_PING_INTERVAL_MS ) {
-		ArenaServers_UpdateMainMenuList();
+		if( g_mainmenu_list ) {
+			ArenaServers_UpdateMainMenuList();
+		} else if( g_servertype == UIAS_INTERNET ) {
+			ArenaServers_UpdateMenu();
+		}
 		return;
 	}
 
@@ -2265,7 +2277,11 @@ static void MainMenuServers_DoRefresh( void ) {
 		g_mainmenu_last_ping_activity = uis.realtime;
 	}
 
-	ArenaServers_UpdateMainMenuList();
+	if( g_mainmenu_list ) {
+		ArenaServers_UpdateMainMenuList();
+	} else if( g_servertype == UIAS_INTERNET ) {
+		ArenaServers_UpdateMenu();
+	}
 }
 
 /*
@@ -2282,7 +2298,7 @@ static void ArenaServers_DoRefresh( void )
 	char	adrstr[MAX_ADDRESSLENGTH];
 	char	info[MAX_INFO_STRING];
 
-	if( g_mainmenu_list ) {
+	if( g_internet_scan ) {
 		MainMenuServers_DoRefresh();
 		return;
 	}
@@ -2429,9 +2445,16 @@ ArenaServers_StartRefresh
 static void ArenaServers_StartRefresh( void )
 {
 	int		i;
-	char	myargs[32], protocol[32];
 
-	memset( g_arenaservers.serverlist, 0, g_arenaservers.maxservers*sizeof(table_t) );
+	if( g_servertype == UIAS_INTERNET ) {
+		if( g_arenaservers.refreshservers ) {
+			ArenaServers_StopRefresh();
+		}
+		MainMenuServers_StartRefresh();
+		return;
+	}
+
+	memset( g_arenaservers.serverlist, 0, g_arenaservers.maxservers*sizeof(servernode_t) );
 
 	for (i=0; i<MAX_PINGREQUESTS; i++)
 	{
@@ -2439,100 +2462,20 @@ static void ArenaServers_StartRefresh( void )
 		trap_LAN_ClearPing( i );
 	}
 
+	g_internet_scan = qfalse;
 	g_arenaservers.refreshservers    = qtrue;
 	g_arenaservers.currentping       = 0;
 	g_arenaservers.nextpingtime      = 0;
 	*g_arenaservers.numservers       = 0;
 	g_arenaservers.numqueriedservers = 0;
 
-	// allow max 5 seconds for responses
+	/* allow max 5 seconds for responses */
 	g_arenaservers.refreshtime = uis.realtime + 5000;
 
-	// place menu in zeroed state
 	ArenaServers_UpdateMenu();
 
 	if( g_servertype == UIAS_LOCAL ) {
 		trap_Cmd_ExecuteText( EXEC_APPEND, "localservers\n" );
-		return;
-	}
-
-	if( g_servertype >= UIAS_GLOBAL1 && g_servertype <= UIAS_GLOBAL5 ) {
-		switch( g_arenaservers.gametype.curvalue ) {
-		default:
-		case GAMES_ALL:
-			myargs[0] = 0;
-			break;
-
-		case GAMES_FFA:
-			strcpy( myargs, " ffa" );
-			break;
-
-		case GAMES_TEAMPLAY:
-			strcpy( myargs, " team" );
-			break;
-
-		case GAMES_TOURNEY:
-			strcpy( myargs, " tourney" );
-			break;
-
-		case GAMES_CTF:
-			strcpy( myargs, " ctf" );
-			break;
-
-		case GAMES_ELIMINATION:
-			strcpy( myargs, " elimination" );
-			break;
-
-		case GAMES_CTF_ELIMINATION:
-			strcpy( myargs, " ctfelimination" );
-			break;
-
-		case GAMES_LMS:
-			strcpy( myargs, " lms" );
-			break;
-
-#ifdef WITH_DOUBLED_GAMETYPE
-		case GAMES_DOUBLE_D:
-			strcpy( myargs, " dd" );
-			break;
-#endif
-
-#ifdef WITH_DOM_GAMETYPE
-		case GAMES_DOM:
-			strcpy( myargs, " dom" );
-			break;
-#endif
-
-#ifdef WITH_TREASURE_HUNTER_GAMETYPE
-		case GAMES_TH:
-			strcpy( myargs, va(" %d", GT_TREASURE_HUNTER) );
-			break;
-#endif
-
-#ifdef WITH_MULTITOURNAMENT
-		case GAMES_MULTITOURNAMENT:
-			strcpy( myargs, va(" %d", GT_MULTITOURNAMENT) );
-			break;
-#endif
-		}
-
-
-		if (g_emptyservers) {
-			strcat(myargs, " empty");
-		}
-
-		if (g_fullservers) {
-			strcat(myargs, " full");
-		}
-
-		protocol[0] = '\0';
-		trap_Cvar_VariableStringBuffer( "debug_protocol", protocol, sizeof(protocol) );
-		if (strlen(protocol)) {
-			trap_Cmd_ExecuteText( EXEC_APPEND, va( "globalservers %d %s%s\n", g_servertype - 1, protocol, myargs ));
-		}
-		else {
-			trap_Cmd_ExecuteText( EXEC_APPEND, va( "globalservers %d %d%s\n", g_servertype - 1, (int)trap_Cvar_VariableValue( "protocol" ), myargs ) );
-		}
 	}
 }
 
@@ -2576,19 +2519,11 @@ ArenaServers_SetType
 */
 int ArenaServers_SetType( int type )
 {
-	if(type >= UIAS_GLOBAL1 && type <= UIAS_GLOBAL5)
-	{
-		char masterstr[2], cvarname[sizeof("sv_master1")];
-		
-		while(type <= UIAS_GLOBAL5)
-		{
-			Com_sprintf(cvarname, sizeof(cvarname), "sv_master%d", type);
-			trap_Cvar_VariableStringBuffer(cvarname, masterstr, sizeof(masterstr));
-			if(*masterstr)
-				break;
-			
-			type++;
-		}
+	if( type < UIAS_LOCAL ) {
+		type = UIAS_LOCAL;
+	}
+	if( type > UIAS_FAVORITES ) {
+		type = UIAS_FAVORITES;
 	}
 
 	g_servertype = type;
@@ -2602,11 +2537,7 @@ int ArenaServers_SetType( int type )
 		g_arenaservers.maxservers = MAX_LOCALSERVERS;
 		break;
 
-	case UIAS_GLOBAL1:
-	case UIAS_GLOBAL2:
-	case UIAS_GLOBAL3:
-	case UIAS_GLOBAL4:
-	case UIAS_GLOBAL5:
+	case UIAS_INTERNET:
 		g_arenaservers.remove.generic.flags |= (QMF_INACTIVE|QMF_HIDDEN);
 		g_arenaservers.serverlist = g_globalserverlist;
 		g_arenaservers.numservers = &g_numglobalservers;
@@ -2622,13 +2553,25 @@ int ArenaServers_SetType( int type )
 
 	}
 
-	if( !*g_arenaservers.numservers ) {
+	if( type == UIAS_INTERNET ) {
+		if( g_internet_scan ) {
+			ArenaServers_UpdateMenu();
+		} else if( !*g_arenaservers.numservers ) {
+			ArenaServers_StartRefresh();
+		} else {
+			g_arenaservers.currentping       = *g_arenaservers.numservers;
+			g_arenaservers.numqueriedservers = *g_arenaservers.numservers;
+			ArenaServers_UpdateMenu();
+			strcpy( g_arenaservers.status.string, "hit refresh to update" );
+		}
+	} else if( g_internet_scan ) {
+		/* Keep shared internet scan running; don't steal the ping queue. */
+		ArenaServers_UpdateMenu();
+	} else if( !*g_arenaservers.numservers ) {
 		ArenaServers_StartRefresh();
-	}
-	else {
-		// avoid slow operation, use existing results
+	} else {
 		g_arenaservers.currentping       = *g_arenaservers.numservers;
-		g_arenaservers.numqueriedservers = *g_arenaservers.numservers; 
+		g_arenaservers.numqueriedservers = *g_arenaservers.numservers;
 		ArenaServers_UpdateMenu();
 		strcpy(g_arenaservers.status.string,"hit refresh to update");
 	}
@@ -2711,7 +2654,6 @@ static void ArenaServers_Event( void* ptr, int event ) {
 		break;
 
 	case ID_BACK:
-		ArenaServers_StopRefresh();
 		ArenaServers_SaveChanges();
 		UI_PopMenu();
 		break;
@@ -2773,7 +2715,6 @@ static sfxHandle_t ArenaServers_MenuKey( int key ) {
 	}
 
 	if( key == K_MOUSE2 || key == K_ESCAPE ) {
-		ArenaServers_StopRefresh();
 		ArenaServers_SaveChanges();
 	}
         
@@ -2798,11 +2739,41 @@ ArenaServers_MenuInit
 static void ArenaServers_MenuInit( void ) {
 	int			i;
 	int			y;
-	int			value;
 	static char	statusbuffer[MAX_STATUSLENGTH];
+	qboolean	saved_refresh;
+	qboolean	saved_internet;
+	int			saved_currentping;
+	int			saved_nextpingtime;
+	int			saved_numqueried;
+	int			saved_refreshtime;
+	int			saved_phase;
+	pinglist_t	saved_pinglist[MAX_PINGREQUESTS];
 
-	// zero set all our globals
+	/* Preserve in-flight shared internet scan across menu rebuild. */
+	saved_refresh = g_arenaservers.refreshservers;
+	saved_internet = g_internet_scan;
+	saved_currentping = g_arenaservers.currentping;
+	saved_nextpingtime = g_arenaservers.nextpingtime;
+	saved_numqueried = g_arenaservers.numqueriedservers;
+	saved_refreshtime = g_arenaservers.refreshtime;
+	saved_phase = g_mainmenu_refresh_phase;
+	memcpy( saved_pinglist, g_arenaservers.pinglist, sizeof( saved_pinglist ) );
+
+	/* zero set all our globals */
 	memset( &g_arenaservers, 0 ,sizeof(arenaservers_t) );
+
+	if( saved_internet || saved_refresh ) {
+		g_arenaservers.refreshservers = saved_refresh;
+		g_internet_scan = saved_internet;
+		g_arenaservers.currentping = saved_currentping;
+		g_arenaservers.nextpingtime = saved_nextpingtime;
+		g_arenaservers.numqueriedservers = saved_numqueried;
+		g_arenaservers.refreshtime = saved_refreshtime;
+		g_mainmenu_refresh_phase = saved_phase;
+		memcpy( g_arenaservers.pinglist, saved_pinglist, sizeof( saved_pinglist ) );
+	} else {
+		g_internet_scan = qfalse;
+	}
 
 	ArenaServers_Cache();
 
@@ -3058,12 +3029,16 @@ static void ArenaServers_MenuInit( void ) {
 	
 	ArenaServers_LoadFavorites();
 
-	g_servertype = Com_Clamp( 0, 3, ui_browserMaster.integer );
-	// hack to get rid of MPlayer stuff
-	value = g_servertype;
-	if (value >= 1)
-		value--;
-	g_arenaservers.master.curvalue = value;
+	/* Migrate legacy ui_browserMaster values (old 1-5 internet tabs, 6 favorites). */
+	g_servertype = ui_browserMaster.integer;
+	if( g_servertype >= 6 ) {
+		g_servertype = UIAS_FAVORITES;
+	} else if( g_servertype >= 1 ) {
+		g_servertype = UIAS_INTERNET;
+	} else {
+		g_servertype = UIAS_LOCAL;
+	}
+	g_arenaservers.master.curvalue = g_servertype;
 
 	g_gametype = Com_Clamp( 0, 12, ui_browserGameType.integer );
 	g_arenaservers.gametype.curvalue = g_gametype;
@@ -3085,7 +3060,7 @@ static void ArenaServers_MenuInit( void ) {
 
         g_arenaservers.filter.field.buffer[0] = '\0';
 
-	// force to initial state and refresh
+	/* Attach to shared internet results / in-flight scan when possible. */
 	g_arenaservers.master.curvalue = g_servertype = ArenaServers_SetType(g_servertype);
 
 	trap_Cvar_Register(NULL, "debug_protocol", "", 0 );
@@ -3148,20 +3123,18 @@ void UI_MainMenuServers_Begin( menulist_s *list, menubitmap_s *mappic ) {
 	g_onlyhumans = 1;
 	g_hideprivate = 0;
 
-	g_arenaservers.serverlist = g_mainmenu_serverlist;
-	g_arenaservers.numservers = &g_mainmenu_numservers;
+	g_arenaservers.serverlist = g_globalserverlist;
+	g_arenaservers.numservers = &g_numglobalservers;
 	g_arenaservers.maxservers = MAX_GLOBALSERVERS;
 
-	if( g_arenaservers.refreshservers ) {
-		ArenaServers_StopRefresh();
+	if( !g_internet_scan ) {
+		if( g_numglobalservers == 0 ) {
+			MainMenuServers_LoadCache();
+		}
+		MainMenuServers_StartRefresh();
 	}
 
-	memset( g_mainmenu_serverlist, 0, g_arenaservers.maxservers * sizeof( servernode_t ) );
-	g_mainmenu_numservers = 0;
-	MainMenuServers_LoadCache();
 	ArenaServers_UpdateMainMenuList();
-
-	MainMenuServers_StartRefresh();
 }
 
 /*
@@ -3190,13 +3163,9 @@ void UI_MainMenuServers_Resume( menulist_s *list, menubitmap_s *mappic ) {
 	g_onlyhumans = 1;
 	g_hideprivate = 0;
 
-	g_arenaservers.serverlist = g_mainmenu_serverlist;
-	g_arenaservers.numservers = &g_mainmenu_numservers;
+	g_arenaservers.serverlist = g_globalserverlist;
+	g_arenaservers.numservers = &g_numglobalservers;
 	g_arenaservers.maxservers = MAX_GLOBALSERVERS;
-
-	if( g_arenaservers.refreshservers ) {
-		ArenaServers_StopRefresh();
-	}
 
 	ArenaServers_UpdateMainMenuList();
 }
@@ -3219,22 +3188,10 @@ UI_MainMenuServers_End
 =================
 */
 void UI_MainMenuServers_End( void ) {
-	if( g_arenaservers.refreshservers && g_mainmenu_list ) {
-		ArenaServers_StopRefresh();
-	}
-
+	/* Detach main-menu view only; keep the shared internet scan running. */
 	g_mainmenu_list = NULL;
 	g_mainmenu_mappic = NULL;
-	g_mainmenu_refresh_phase = 0;
-	g_mainmenu_scan_start_time = 0;
-	g_mainmenu_active_query_master = 0;
-	g_mainmenu_numaddresses = 0;
-	g_mainmenu_discovery_addresses = 0;
-	g_mainmenu_cache_written_count = 0;
-	g_mainmenu_last_ping_activity = 0;
 	g_mainmenu_server_column_focus = qfalse;
-	memset( g_mainmenu_master_done, 0, sizeof( g_mainmenu_master_done ) );
-	memset( g_mainmenu_master_query_sent, 0, sizeof( g_mainmenu_master_query_sent ) );
 }
 
 /*
@@ -3243,7 +3200,7 @@ UI_MainMenuServers_IsRefreshing
 =================
 */
 qboolean UI_MainMenuServers_IsRefreshing( void ) {
-	return g_arenaservers.refreshservers;
+	return g_internet_scan || g_arenaservers.refreshservers;
 }
 
 /*


### PR DESCRIPTION
Menu improvements:
- Main menu split into two columns: Same old menu on the left, list of Devo servers on the right
- 'DEMOS' renamed to 'REPLAYS'
- Multiplayer screen server list parsing has been tweaked and improved:
-- Black text in server names removed (not visible on dark UI background).
-- Server entries de-duplicated so they only show up once.
-- Multiple successive spaces in a server name collapse to a single space.

<img width="1280" height="720" alt="shot-20260803-203756" src="https://github.com/user-attachments/assets/3f415f1d-f3e0-4486-85e4-8f5293a7b76f" />

A bunch of work in the background enables this
- Master server querying and game server polling now begins in the background on the main menu, instead of on the multiplayer screen.
- Scanning persists as you move between screens, rather than being cleared out when you navigate.
- Results returned from multiple masters are built into a singular list, and any overlaps removed. Previous behavior was to show each master server separately, and you could only poll servers from one master at once.
- Devotion servers that are discovered during scanning are cached to disk (`devotion_servers.cache`) so they re-appear immediately on the main menu upon game startup.
- The cached list is fully rewritten at the end of every scan, but persist in the UI, so old/dead/stale servers will drop off across game re-starts, but will persist within a single game session.

Tested on Quake3e and IOQuake3 clients.