### PR TITLE
Parse demo file information for replays menu

### DIFF
--- a/ratoa_gamecode/Makefile
+++ b/ratoa_gamecode/Makefile
@@ -1952,6 +1952,8 @@ Q3UIOBJ_ = \
   $(B)/baseq3/ui/ui_controls2.o \
   $(B)/baseq3/ui/ui_credits.o \
   $(B)/baseq3/ui/ui_demo2.o \
+  $(B)/baseq3/ui/ui_demo_parse.o \
+  $(B)/baseq3/ui/ui_com_stub.o \
   $(B)/baseq3/ui/ui_display.o \
   $(B)/baseq3/ui/ui_firstconnect.o \
   $(B)/baseq3/ui/ui_gameinfo.o \
@@ -1994,7 +1996,9 @@ Q3UIOBJ_ = \
   $(B)/baseq3/ui/ui_votemenu_custom.o \
   \
   $(B)/baseq3/qcommon/q_math.o \
-  $(B)/baseq3/qcommon/q_shared.o
+  $(B)/baseq3/qcommon/q_shared.o \
+  $(B)/baseq3/qcommon/msg.o \
+  $(B)/baseq3/qcommon/huffman.o
 
 Q3UIOBJ = $(Q3UIOBJ_) $(B)/missionpack/ui/ui_syscalls.o
 Q3UIVMOBJ = $(Q3UIOBJ_:%.o=%.asm)

--- a/ratoa_gamecode/code/q3_ui/q3_ui.q3asm
+++ b/ratoa_gamecode/code/q3_ui/q3_ui.q3asm
@@ -8,6 +8,7 @@ ui_cinematics
 ui_connect
 ui_controls2
 ui_demo2
+ui_demo_parse
 ui_mfield
 ui_credits
 ui_menu
@@ -47,5 +48,8 @@ ui_votemenu_map
 ui_votemenu_timelimit
 ..\game\bg_misc
 ..\game\bg_lib
+ui_com_stub
+..\qcommon\msg
+..\qcommon\huffman
 ..\qcommon\q_math
 ..\qcommon\q_shared

--- a/ratoa_gamecode/code/q3_ui/ui_com_stub.c
+++ b/ratoa_gamecode/code/q3_ui/ui_com_stub.c
@@ -1,0 +1,22 @@
+/*
+===========================================================================
+Com_Memset / Com_Memcpy for ui.qvm (msg.c expects these symbols).
+===========================================================================
+*/
+#include "../game/bg_lib.h"
+
+void Com_Memset( void *dest, const int val, size_t count ) {
+	memset( dest, val, count );
+}
+
+void Com_Memcpy( void *dest, const void *src, size_t count ) {
+	memcpy( dest, src, count );
+}
+
+short LittleShort( short l ) {
+	return l;
+}
+
+int LittleLong( int l ) {
+	return l;
+}

--- a/ratoa_gamecode/code/q3_ui/ui_demo2.c
+++ b/ratoa_gamecode/code/q3_ui/ui_demo2.c
@@ -63,20 +63,32 @@ Structured view for autorecord/rec filenames; raw file list fallback.
 #define DEMO_LIST_X			120
 #define DEMO_INFO_CARD_Y		76
 #define DEMO_INFO_CARD_W		400
-#define DEMO_INFO_CARD_H		96
-#define DEMO_INFO_LEVELSHOT_W	128
-#define DEMO_INFO_LEVELSHOT_H	96
-#define DEMO_INFO_TEXT_X		( DEMO_LIST_X + DEMO_INFO_LEVELSHOT_W + 12 )
-#define DEMO_HEADER_Y			176
-#define DEMO_LIST_Y_FANCY		194
-#define DEMO_LIST_VISIBLE_FANCY	11
+#define DEMO_INFO_CARD_MAX_H	168
+#define DEMO_INFO_LEVELSHOT_W	96
+#define DEMO_INFO_LEVELSHOT_H	72
+#define DEMO_INFO_COL_LEFT_X	( DEMO_LIST_X + 4 )
+#define DEMO_INFO_COL_RIGHT_X	( DEMO_LIST_X + DEMO_INFO_CARD_W - 4 )
+#define DEMO_INFO_COL_CENTER_X	( DEMO_LIST_X + DEMO_INFO_CARD_W / 2 )
+#define DEMO_PLAYER_ICON_SZ		24
+#define DEMO_PLAYER_ICON_SZ_DUEL	42
+#define DEMO_PLAYER_DUEL_CHAR_W		21
+#define DEMO_PLAYER_DUEL_CHAR_H		21
+#define DEMO_PLAYER_ROW_H		28
+#define DEMO_PLAYER_ROW_H_DUEL		46
+#define DEMO_PLAYER_DUEL_GAP		6
+#define DEMO_PLAYER_DUEL_BLOCK_H	( DEMO_PLAYER_ICON_SZ_DUEL + DEMO_PLAYER_DUEL_GAP + \
+		DEMO_PLAYER_DUEL_CHAR_H + DEMO_PLAYER_DUEL_GAP + DEMO_PLAYER_DUEL_CHAR_H )
+#define DEMO_PARSE_DEBOUNCE_MS		500
+#define DEMO_HEADER_Y			224
+#define DEMO_LIST_Y_FANCY		240
+#define DEMO_LIST_VISIBLE_FANCY	10
 #define DEMO_LIST_WIDTH_FANCY	54
 
 #define DEMO_LIST_Y_ALL			72
 #define DEMO_LIST_VISIBLE_ALL	22
 #define DEMO_LIST_WIDTH_ALL		51
 
-#define DEMO_STATUS_Y			396
+#define DEMO_STATUS_Y			404
 #define DEMO_STATUS_DURATION_MS	3000
 
 #define DEMO_COL_W_DATETIME	16
@@ -94,33 +106,15 @@ Structured view for autorecord/rec filenames; raw file list fallback.
 #define DEMO_ARROWS_BG_W	48
 #define DEMO_ARROWS_BG_H	96
 
-#define DEMO_OPTS_X			400
 #define DEMO_OPTS_DELAG_Y	424
 #define DEMO_OPTS_BBOX_Y	440
+#define DEMO_MENU_CENTER_X	320
 
 static const char *replayView_items[] = {
 	"Fancy",
 	"All",
 	NULL
 };
-
-typedef enum {
-	DEMO_PARSE_NONE = 0,
-	DEMO_PARSE_AUTORECORD
-} demoParseType_t;
-
-typedef struct {
-	char				filename[MAX_OSPATH];
-	demoParseType_t		parseType;
-	char				date[12];
-	char				time[6];
-	char				server[48];
-	char				gametype[12];
-	char				map[32];
-	char				players[48];
-	int					fileSize;
-	char				label[DEMO_LABEL_SIZE];
-} demoEntry_t;
 
 typedef enum {
 	DEMO_SORT_DATETIME = 0,
@@ -167,12 +161,128 @@ typedef struct {
 	int					lastClickTarget;
 	char				statusMessage[MAX_STRING_CHARS];
 	int					statusTime;
+	int					parseDebounceEntryIdx;
+	int					parseDebounceTime;
+	int					lastSelectedEntryIdx;
 } demos_t;
 
 static demos_t	s_demos;
 
-static void Demos_MenuEvent( void *ptr, int event );
+static demoEntry_t *UI_Demo_GetSelectedEntry( void );
+
+static void UI_Demo_FormatDuration( int ms, char *out, int outSize ) {
+	int	sec;
+	int	min;
+
+	if ( ms <= 0 ) {
+		Q_strncpyz( out, "unknown", outSize );
+		return;
+	}
+
+	sec = ms / 1000;
+	min = sec / 60;
+	sec %= 60;
+	Com_sprintf( out, outSize, "%d:%02d", min, sec );
+}
+
+static void UI_Demo_SelectionChanged( void ) {
+	demoEntry_t	*entry;
+	int			idx;
+
+	if ( s_demos.viewMode.curvalue != 0 ) {
+		UI_Demo_ParseStop();
+		s_demos.parseDebounceEntryIdx = -1;
+		return;
+	}
+
+	if ( s_demos.list.curvalue < 0 ||
+			s_demos.list.curvalue >= s_demos.numViewItems ) {
+		UI_Demo_ParseStop();
+		s_demos.parseDebounceEntryIdx = -1;
+		return;
+	}
+
+	idx = s_demos.viewToEntry[s_demos.list.curvalue];
+	if ( idx < 0 ) {
+		UI_Demo_ParseStop();
+		s_demos.parseDebounceEntryIdx = -1;
+		return;
+	}
+
+	entry = &s_demos.entries[idx];
+	UI_Demo_ParseStop();
+	s_demos.parseDebounceEntryIdx = -1;
+
+	if ( entry->metaState == DEMO_META_DONE ) {
+		return;
+	}
+
+	s_demos.parseDebounceEntryIdx = idx;
+	s_demos.parseDebounceTime = uis.realtime + DEMO_PARSE_DEBOUNCE_MS;
+}
+
+static void UI_Demo_ParseDebounceTick( void ) {
+	demoEntry_t	*entry;
+	int			idx;
+
+	if ( s_demos.parseDebounceEntryIdx < 0 ) {
+		return;
+	}
+
+	if ( uis.realtime < s_demos.parseDebounceTime ) {
+		return;
+	}
+
+	idx = s_demos.parseDebounceEntryIdx;
+	s_demos.parseDebounceEntryIdx = -1;
+
+	if ( s_demos.viewMode.curvalue != 0 ) {
+		return;
+	}
+
+	if ( s_demos.list.curvalue < 0 ||
+			s_demos.list.curvalue >= s_demos.numViewItems ) {
+		return;
+	}
+
+	if ( s_demos.viewToEntry[s_demos.list.curvalue] != idx ) {
+		return;
+	}
+
+	entry = &s_demos.entries[idx];
+	if ( entry->metaState == DEMO_META_DONE ) {
+		return;
+	}
+
+	UI_Demo_ParseBegin( entry );
+}
+
+static void UI_Demo_CheckSelectionChanged( void ) {
+	int		idx;
+
+	if ( s_demos.viewMode.curvalue != 0 ) {
+		if ( s_demos.lastSelectedEntryIdx != -1 ) {
+			s_demos.lastSelectedEntryIdx = -1;
+			UI_Demo_SelectionChanged();
+		}
+		return;
+	}
+
+	if ( s_demos.list.curvalue < 0 ||
+			s_demos.list.curvalue >= s_demos.numViewItems ) {
+		idx = -1;
+	} else {
+		idx = s_demos.viewToEntry[s_demos.list.curvalue];
+	}
+
+	if ( idx != s_demos.lastSelectedEntryIdx ) {
+		s_demos.lastSelectedEntryIdx = idx;
+		UI_Demo_SelectionChanged();
+	}
+}
+
 static void UI_Demo_RebuildList( void );
+static void Demos_MenuEvent( void *ptr, int event );
 static int UI_Demo_CompareParsed( const demoEntry_t *a, const demoEntry_t *b );
 
 static const char *demoGametypeSlugs[] = {
@@ -712,7 +822,7 @@ static qboolean UI_Demo_MapIsAvailable( const char *map ) {
 	return UI_Demo_MapLevelshotExists( map );
 }
 
-static void UI_Demo_DrawLevelshot( int x, int y, const char *mapname ) {
+static void UI_Demo_DrawLevelshot( int x, int y, int w, int h, const char *mapname ) {
 	qhandle_t	shader;
 
 	if ( !mapname || !mapname[0] ) {
@@ -732,7 +842,545 @@ static void UI_Demo_DrawLevelshot( int x, int y, const char *mapname ) {
 		shader = s_demos.unknownMapShader;
 	}
 
-	UI_DrawHandlePic( x, y, DEMO_INFO_LEVELSHOT_W, DEMO_INFO_LEVELSHOT_H, shader );
+	UI_DrawHandlePic( x, y, w, h, shader );
+}
+
+static int UI_Demo_VisibleStrLen( const char *str ) {
+	int		len;
+
+	len = 0;
+	if ( !str ) {
+		return 0;
+	}
+
+	while ( *str ) {
+		if ( Q_IsColorString( str ) ) {
+			str += 2;
+			continue;
+		}
+		len++;
+		str++;
+	}
+
+	return len;
+}
+
+static void UI_Demo_DrawStringCentered( int centerX, int y, const char *str,
+		qboolean smallFont, vec4_t color ) {
+	int		charw;
+	int		style;
+	int		x;
+
+	if ( !str || !str[0] ) {
+		return;
+	}
+
+	if ( smallFont ) {
+		charw = SMALLCHAR_WIDTH;
+		style = UI_LEFT | UI_SMALLFONT;
+	} else {
+		charw = BIGCHAR_WIDTH;
+		style = UI_LEFT;
+	}
+
+	x = centerX - ( UI_Demo_VisibleStrLen( str ) * charw ) / 2;
+	UI_DrawString( x, y, str, style, color );
+}
+
+static void UI_Demo_DrawStringCenteredSized( int centerX, int y, const char *str,
+		int charw, int charh, vec4_t color ) {
+	int		x;
+
+	if ( !str || !str[0] ) {
+		return;
+	}
+
+	x = centerX - ( UI_Demo_VisibleStrLen( str ) * charw ) / 2;
+	UI_DrawStringSized( x, y, str, UI_LEFT, color, charw, charh );
+}
+
+static int UI_Demo_CenteredRadioX( const char *label ) {
+	return DEMO_MENU_CENTER_X +
+			strlen( label ) * ( SMALLCHAR_WIDTH / 2 ) -
+			( SMALLCHAR_WIDTH + 16 + 3 * SMALLCHAR_WIDTH ) / 2;
+}
+
+static qboolean UI_Demo_IsTeamGametype( int gametype ) {
+	if ( gametype < GT_TEAM ) {
+		return qfalse;
+	}
+#ifdef WITH_MULTITOURNAMENT
+	if ( gametype == GT_MULTITOURNAMENT ) {
+		return qfalse;
+	}
+#endif
+	if ( gametype == GT_LMS ) {
+		return qfalse;
+	}
+
+	return qtrue;
+}
+
+static qhandle_t UI_Demo_GetPlayerIcon( demoEntry_t *entry, int clientNum ) {
+	char		model[MAX_QPATH];
+	char		*skin;
+	char		iconName[MAX_QPATH];
+	qhandle_t	shader;
+
+	if ( clientNum < 0 || clientNum >= MAX_CLIENTS ||
+			!entry->metaPlayerModels[clientNum][0] ) {
+		return trap_R_RegisterShaderNoMip( "models/players/sarge/icon_default.tga" );
+	}
+
+	Q_strncpyz( model, entry->metaPlayerModels[clientNum], sizeof( model ) );
+	skin = strchr( model, '/' );
+	if ( skin ) {
+		*skin++ = '\0';
+	} else {
+		skin = "default";
+	}
+
+	Com_sprintf( iconName, sizeof( iconName ),
+			"models/players/%s/icon_%s.tga", model, skin );
+	shader = trap_R_RegisterShaderNoMip( iconName );
+	if ( !shader ) {
+		Com_sprintf( iconName, sizeof( iconName ),
+				"models/players/%s/icon_default.tga", model );
+		shader = trap_R_RegisterShaderNoMip( iconName );
+	}
+	if ( !shader ) {
+		shader = trap_R_RegisterShaderNoMip( "models/players/sarge/icon_default.tga" );
+	}
+
+	return shader;
+}
+
+static void UI_Demo_DrawFightDuelPlayer( int centerX, int y, qhandle_t icon,
+		const char *name, int score, int iconSz ) {
+	char	scoreLine[16];
+	int		rowY;
+
+	rowY = y;
+	UI_DrawHandlePic( centerX - iconSz / 2, rowY, iconSz, iconSz, icon );
+	rowY += iconSz + DEMO_PLAYER_DUEL_GAP;
+	UI_Demo_DrawStringCenteredSized( centerX, rowY, name,
+			DEMO_PLAYER_DUEL_CHAR_W, DEMO_PLAYER_DUEL_CHAR_H, menu_text_color );
+	rowY += DEMO_PLAYER_DUEL_CHAR_H + DEMO_PLAYER_DUEL_GAP;
+	Com_sprintf( scoreLine, sizeof( scoreLine ), "%d", score );
+	UI_Demo_DrawStringCenteredSized( centerX, rowY, scoreLine,
+			DEMO_PLAYER_DUEL_CHAR_W, DEMO_PLAYER_DUEL_CHAR_H, text_color_normal );
+}
+
+static void UI_Demo_DrawFightPlayerRow( int edgeX, int y, qboolean rightAlign,
+		qhandle_t icon, const char *name, int score, int iconSz, qboolean largeText ) {
+	char		scorePart[16];
+	int			gap;
+	int			nameLen;
+	int			charW;
+	int			xIcon;
+	int			xText;
+	int			style;
+
+	if ( !name || !name[0] ) {
+		return;
+	}
+
+	gap = largeText ? 6 : 4;
+	charW = largeText ? BIGCHAR_WIDTH : SMALLCHAR_WIDTH;
+	style = largeText ? UI_LEFT : ( UI_LEFT | UI_SMALLFONT );
+	nameLen = UI_Demo_VisibleStrLen( name );
+	Com_sprintf( scorePart, sizeof( scorePart ), "(%d)", score );
+
+	if ( rightAlign ) {
+		xText = edgeX - ( nameLen + strlen( scorePart ) ) * charW;
+		xIcon = xText - gap - iconSz;
+		UI_DrawHandlePic( xIcon, y, iconSz, iconSz, icon );
+		UI_DrawString( xText, y, name, style, menu_text_color );
+		UI_DrawString( xText + nameLen * charW, y, scorePart,
+				largeText ? UI_LEFT : ( UI_LEFT | UI_SMALLFONT ), text_color_normal );
+	} else {
+		xIcon = edgeX;
+		xText = xIcon + iconSz + gap;
+		UI_DrawHandlePic( xIcon, y, iconSz, iconSz, icon );
+		UI_DrawString( xText, y, name, style, menu_text_color );
+		UI_DrawString( xText + nameLen * charW, y, scorePart,
+				largeText ? UI_LEFT : ( UI_LEFT | UI_SMALLFONT ), text_color_normal );
+	}
+}
+
+static void UI_Demo_DrawFightTeamScore( int edgeX, int y, qboolean rightAlign,
+		int score, vec4_t color, qboolean largeText ) {
+	char	line[16];
+	int		style;
+
+	Com_sprintf( line, sizeof( line ), "%d", score );
+	style = largeText ? ( rightAlign ? UI_RIGHT : UI_LEFT )
+			: ( ( rightAlign ? UI_RIGHT : UI_LEFT ) | UI_SMALLFONT );
+	if ( rightAlign ) {
+		UI_DrawString( edgeX, y, line, style, color );
+	} else {
+		UI_DrawString( edgeX, y, line, style, color );
+	}
+}
+
+typedef struct {
+	int			clientNum;
+	const char	*name;
+} demoFightSlot_t;
+
+static char	s_demoFightFallbackNames[2][MAX_NAME_LENGTH];
+
+static qboolean UI_Demo_IsDuelGametype( int gametype, const char *slug );
+
+static void UI_Demo_BuildFightColumnsProvisional( demoEntry_t *entry, int gametype,
+		demoFightSlot_t *leftSlots, int *leftCount,
+		demoFightSlot_t *rightSlots, int *rightCount ) {
+	int		c;
+	int		duelCount;
+
+	*leftCount = 0;
+	*rightCount = 0;
+
+	if ( UI_Demo_IsTeamGametype( gametype ) ) {
+		for ( c = 0; c < MAX_CLIENTS; c++ ) {
+			if ( !entry->metaPlayerNames[c][0] ) {
+				continue;
+			}
+			if ( entry->metaPlayerTeam[c] == TEAM_SPECTATOR ) {
+				continue;
+			}
+			if ( entry->metaPlayerTeam[c] == TEAM_RED ) {
+				leftSlots[*leftCount].clientNum = c;
+				leftSlots[*leftCount].name = entry->metaPlayerNames[c];
+				(*leftCount)++;
+			} else if ( entry->metaPlayerTeam[c] == TEAM_BLUE ) {
+				rightSlots[*rightCount].clientNum = c;
+				rightSlots[*rightCount].name = entry->metaPlayerNames[c];
+				(*rightCount)++;
+			}
+		}
+		return;
+	}
+
+	if ( UI_Demo_IsDuelGametype( gametype, entry->gametype ) ) {
+		duelCount = 0;
+		for ( c = 0; c < MAX_CLIENTS; c++ ) {
+			if ( !entry->metaPlayerNames[c][0] ) {
+				continue;
+			}
+			if ( entry->metaPlayerTeam[c] == TEAM_SPECTATOR ) {
+				continue;
+			}
+			if ( duelCount == 0 ) {
+				leftSlots[0].clientNum = c;
+				leftSlots[0].name = entry->metaPlayerNames[c];
+				*leftCount = 1;
+			} else if ( duelCount == 1 ) {
+				rightSlots[0].clientNum = c;
+				rightSlots[0].name = entry->metaPlayerNames[c];
+				*rightCount = 1;
+			} else {
+				break;
+			}
+			duelCount++;
+		}
+		return;
+	}
+
+	for ( c = 0; c < MAX_CLIENTS; c++ ) {
+		if ( !entry->metaPlayerNames[c][0] ) {
+			continue;
+		}
+		if ( entry->metaPlayerTeam[c] == TEAM_SPECTATOR ) {
+			continue;
+		}
+		if ( *leftCount <= *rightCount ) {
+			leftSlots[*leftCount].clientNum = c;
+			leftSlots[*leftCount].name = entry->metaPlayerNames[c];
+			(*leftCount)++;
+		} else {
+			rightSlots[*rightCount].clientNum = c;
+			rightSlots[*rightCount].name = entry->metaPlayerNames[c];
+			(*rightCount)++;
+		}
+	}
+}
+
+static qboolean UI_Demo_EntryHasParsedNames( demoEntry_t *entry ) {
+	int		c;
+
+	for ( c = 0; c < MAX_CLIENTS; c++ ) {
+		if ( entry->metaPlayerNames[c][0] ) {
+			return qtrue;
+		}
+	}
+
+	return qfalse;
+}
+
+static void UI_Demo_BuildFightColumns( demoEntry_t *entry, int gametype,
+		demoFightSlot_t *leftSlots, int *leftCount,
+		demoFightSlot_t *rightSlots, int *rightCount,
+		qboolean *showTeamScores, int *leftTeamScore, int *rightTeamScore ) {
+	int		i;
+	int		c;
+	char	source[MAX_STRING_CHARS];
+	char	*vs;
+
+	*leftCount = 0;
+	*rightCount = 0;
+	*showTeamScores = qfalse;
+	*leftTeamScore = 0;
+	*rightTeamScore = 0;
+
+	if ( entry->metaLayoutLocked ) {
+		*showTeamScores = UI_Demo_IsTeamGametype( gametype ) && entry->metaHaveScores;
+		*leftTeamScore = entry->metaScore0;
+		*rightTeamScore = entry->metaScore1;
+
+		for ( i = 0; i < entry->metaNumLeft; i++ ) {
+			c = entry->metaLeftClients[i];
+			if ( c < 0 || c >= MAX_CLIENTS || !entry->metaPlayerNames[c][0] ) {
+				continue;
+			}
+			leftSlots[*leftCount].clientNum = c;
+			leftSlots[*leftCount].name = entry->metaPlayerNames[c];
+			(*leftCount)++;
+		}
+
+		for ( i = 0; i < entry->metaNumRight; i++ ) {
+			c = entry->metaRightClients[i];
+			if ( c < 0 || c >= MAX_CLIENTS || !entry->metaPlayerNames[c][0] ) {
+				continue;
+			}
+			rightSlots[*rightCount].clientNum = c;
+			rightSlots[*rightCount].name = entry->metaPlayerNames[c];
+			(*rightCount)++;
+		}
+		return;
+	}
+
+	if ( UI_Demo_EntryHasParsedNames( entry ) ) {
+		UI_Demo_BuildFightColumnsProvisional( entry, gametype,
+				leftSlots, leftCount, rightSlots, rightCount );
+		return;
+	}
+
+	/* Filename fallback before demo scan has read any player configstrings */
+	if ( UI_Demo_IsDuelGametype( gametype, entry->gametype ) ) {
+		if ( entry->metaPlayers[0] ) {
+			Q_strncpyz( source, entry->metaPlayers, sizeof( source ) );
+		} else if ( entry->players[0] ) {
+			Q_strncpyz( source, entry->players, sizeof( source ) );
+		} else {
+			return;
+		}
+
+		vs = strstr( source, " vs " );
+		if ( vs ) {
+			*vs = '\0';
+			Q_strncpyz( s_demoFightFallbackNames[0], source,
+					sizeof( s_demoFightFallbackNames[0] ) );
+			Q_strncpyz( s_demoFightFallbackNames[1], vs + 4,
+					sizeof( s_demoFightFallbackNames[1] ) );
+			leftSlots[0].clientNum = -1;
+			leftSlots[0].name = s_demoFightFallbackNames[0];
+			rightSlots[0].clientNum = -1;
+			rightSlots[0].name = s_demoFightFallbackNames[1];
+			*leftCount = 1;
+			*rightCount = 1;
+		}
+	}
+}
+
+static int UI_Demo_GetFightPlayerScore( demoEntry_t *entry, int clientNum ) {
+	if ( clientNum < 0 || clientNum >= MAX_CLIENTS ) {
+		return 0;
+	}
+
+	return entry->metaPlayerScores[clientNum];
+}
+
+static void UI_Demo_DrawFightColumn( demoEntry_t *entry, int edgeX, int colCenterX,
+		int y, qboolean rightAlign, const demoFightSlot_t *slots, int count,
+		qboolean showTeamScore, int teamScore, vec4_t teamColor,
+		int iconSz, int rowH, qboolean duelStacked ) {
+	int		i;
+	int		rowY;
+	qhandle_t	icon;
+	int		score;
+
+	rowY = y;
+	if ( showTeamScore ) {
+		if ( duelStacked ) {
+			UI_DrawString( colCenterX, rowY, va( "%d", teamScore ),
+					UI_CENTER, teamColor );
+		} else {
+			UI_Demo_DrawFightTeamScore( edgeX, rowY, rightAlign, teamScore,
+					teamColor, qfalse );
+		}
+		rowY += rowH;
+	}
+
+	for ( i = 0; i < count; i++ ) {
+		if ( slots[i].clientNum >= 0 ) {
+			icon = UI_Demo_GetPlayerIcon( entry, slots[i].clientNum );
+			score = UI_Demo_GetFightPlayerScore( entry, slots[i].clientNum );
+		} else {
+			icon = trap_R_RegisterShaderNoMip( "models/players/sarge/icon_default.tga" );
+			score = 0;
+		}
+
+		if ( duelStacked ) {
+			UI_Demo_DrawFightDuelPlayer( colCenterX, rowY, icon,
+					slots[i].name, score, iconSz );
+			rowY += DEMO_PLAYER_DUEL_BLOCK_H;
+		} else {
+			UI_Demo_DrawFightPlayerRow( edgeX, rowY, rightAlign, icon,
+					slots[i].name, score, iconSz, qfalse );
+			rowY += rowH;
+		}
+	}
+}
+
+static qboolean UI_Demo_IsDuelGametype( int gametype, const char *slug ) {
+	if ( gametype == GT_TOURNAMENT ) {
+		return qtrue;
+	}
+#ifdef WITH_MULTITOURNAMENT
+	if ( gametype == GT_MULTITOURNAMENT ) {
+		return qtrue;
+	}
+#endif
+	if ( slug && !Q_stricmp( slug, "1v1" ) ) {
+		return qtrue;
+	}
+
+	return qfalse;
+}
+
+static void UI_Demo_DrawFightNightCard( demoEntry_t *entry ) {
+	char		mapLong[MAX_QPATH];
+	char		line[MAX_STRING_CHARS];
+	demoFightSlot_t	leftSlots[MAX_CLIENTS];
+	demoFightSlot_t	rightSlots[MAX_CLIENTS];
+	int			leftCount;
+	int			rightCount;
+	qboolean	showTeamScores;
+	int			leftTeamScore;
+	int			rightTeamScore;
+	int			gametype;
+	const char	*colorPrefix;
+	int			cardX;
+	int			cardY;
+	int			cardH;
+	int			centerY;
+	int			sideY;
+	int			leftRows;
+	int			rightRows;
+	int			centerH;
+	int			sideH;
+	int			levelshotX;
+	int			levelshotY;
+	int			blockH;
+	int			blockTop;
+	qboolean	isDuel;
+	int			iconSz;
+	int			rowH;
+	int			leftCenterX;
+	int			rightCenterX;
+
+	gametype = UI_Demo_SlugToGametype( entry->gametype );
+	isDuel = UI_Demo_IsDuelGametype( gametype, entry->gametype );
+	iconSz = isDuel ? DEMO_PLAYER_ICON_SZ_DUEL : DEMO_PLAYER_ICON_SZ;
+	rowH = isDuel ? DEMO_PLAYER_ROW_H_DUEL : DEMO_PLAYER_ROW_H;
+	leftCenterX = ( DEMO_INFO_COL_LEFT_X +
+			DEMO_INFO_COL_CENTER_X - DEMO_INFO_LEVELSHOT_W / 2 ) / 2;
+	rightCenterX = ( DEMO_INFO_COL_CENTER_X + DEMO_INFO_LEVELSHOT_W / 2 +
+			DEMO_INFO_COL_RIGHT_X ) / 2;
+
+	UI_Demo_BuildFightColumns( entry, gametype, leftSlots, &leftCount,
+			rightSlots, &rightCount, &showTeamScores,
+			&leftTeamScore, &rightTeamScore );
+
+	if ( isDuel ) {
+		sideH = 0;
+		if ( leftCount > 0 || rightCount > 0 ) {
+			sideH = DEMO_PLAYER_DUEL_BLOCK_H;
+		}
+		if ( showTeamScores ) {
+			sideH += rowH;
+		}
+	} else {
+		leftRows = leftCount + ( showTeamScores ? 1 : 0 );
+		rightRows = rightCount + ( showTeamScores ? 1 : 0 );
+		sideH = ( leftRows > rightRows ? leftRows : rightRows ) * rowH;
+	}
+
+	centerH = SMALLCHAR_HEIGHT + 4 + DEMO_INFO_LEVELSHOT_H + 4 +
+			SMALLCHAR_HEIGHT + SMALLCHAR_HEIGHT;
+
+	cardH = sideH > centerH ? sideH : centerH;
+	cardH += 12;
+	if ( cardH > DEMO_INFO_CARD_MAX_H ) {
+		cardH = DEMO_INFO_CARD_MAX_H;
+	}
+
+	blockH = sideH > centerH ? sideH : centerH;
+	blockTop = DEMO_INFO_CARD_Y + ( cardH - blockH ) / 2;
+
+	cardX = DEMO_LIST_X - 4;
+	cardY = DEMO_INFO_CARD_Y - 4;
+	UI_FillRect( cardX, cardY, DEMO_INFO_CARD_W, cardH + 8, listbar_color );
+	UI_DrawRect( cardX, cardY, DEMO_INFO_CARD_W, cardH + 8, color_white );
+
+	centerY = blockTop + ( blockH - centerH ) / 2;
+	colorPrefix = ( gametype >= 0 )
+			? UI_Demo_GametypeColor( gametype ) : S_COLOR_WHITE;
+	Com_sprintf( line, sizeof( line ), "%s%s",
+			colorPrefix, UI_Demo_ExpandedGametype( entry->gametype ) );
+	UI_Demo_DrawStringCentered( DEMO_INFO_COL_CENTER_X, centerY, line,
+			qtrue, menu_text_color );
+	centerY += SMALLCHAR_HEIGHT + 4;
+
+	levelshotX = DEMO_INFO_COL_CENTER_X - DEMO_INFO_LEVELSHOT_W / 2;
+	levelshotY = centerY;
+	UI_Demo_DrawLevelshot( levelshotX, levelshotY,
+			DEMO_INFO_LEVELSHOT_W, DEMO_INFO_LEVELSHOT_H, entry->map );
+	centerY += DEMO_INFO_LEVELSHOT_H + 4;
+
+	mapLong[0] = '\0';
+	UI_Demo_GetMapLongName( entry->map, mapLong, sizeof( mapLong ) );
+	if ( mapLong[0] ) {
+		UI_DrawString( DEMO_INFO_COL_CENTER_X, centerY, mapLong,
+				UI_CENTER | UI_SMALLFONT, menu_text_color );
+	} else {
+		Q_strncpyz( line, entry->map, sizeof( line ) );
+		Q_strupr( line );
+		UI_DrawString( DEMO_INFO_COL_CENTER_X, centerY, line,
+				UI_CENTER | UI_SMALLFONT, menu_text_color );
+	}
+	centerY += SMALLCHAR_HEIGHT;
+
+	if ( entry->metaState == DEMO_META_DONE && entry->metaDurationMs > 0 ) {
+		UI_Demo_FormatDuration( entry->metaDurationMs, line, sizeof( line ) );
+		UI_Demo_DrawStringCentered( DEMO_INFO_COL_CENTER_X, centerY, line,
+				qtrue, text_color_normal );
+	} else if ( entry->metaState == DEMO_META_DONE ) {
+		UI_Demo_DrawStringCentered( DEMO_INFO_COL_CENTER_X, centerY, "unknown",
+				qtrue, text_color_normal );
+	} else {
+		UI_Demo_DrawStringCentered( DEMO_INFO_COL_CENTER_X, centerY,
+				"scanning...", qtrue, text_color_normal );
+	}
+
+	sideY = blockTop + ( blockH - sideH ) / 2;
+	UI_Demo_DrawFightColumn( entry, DEMO_INFO_COL_LEFT_X, leftCenterX, sideY,
+			qfalse, leftSlots, leftCount, showTeamScores, leftTeamScore,
+			color_red, iconSz, rowH, isDuel );
+	UI_Demo_DrawFightColumn( entry, DEMO_INFO_COL_RIGHT_X, rightCenterX, sideY,
+			qtrue, rightSlots, rightCount, showTeamScores, rightTeamScore,
+			color_blue, iconSz, rowH, isDuel );
 }
 
 static void UI_Demo_FormatFileSize( int bytes, char *out, int outSize ) {
@@ -839,8 +1487,6 @@ static int UI_Demo_ListMouseRow( void ) {
 
 static void UI_Demo_DrawInfoCard( void ) {
 	demoEntry_t	*entry;
-	char		mapLong[MAX_QPATH];
-	char		line[MAX_STRING_CHARS];
 	char		sizeText[32];
 	int			x;
 	int			y;
@@ -854,66 +1500,24 @@ static void UI_Demo_DrawInfoCard( void ) {
 		return;
 	}
 
+	if ( entry->parseType == DEMO_PARSE_AUTORECORD ) {
+		UI_Demo_DrawFightNightCard( entry );
+		return;
+	}
+
 	x = DEMO_LIST_X - 4;
 	y = DEMO_INFO_CARD_Y - 4;
-	UI_FillRect( x, y, DEMO_INFO_CARD_W, DEMO_INFO_CARD_H + 8, listbar_color );
-	UI_DrawRect( x, y, DEMO_INFO_CARD_W, DEMO_INFO_CARD_H + 8, color_white );
+	UI_FillRect( x, y, DEMO_INFO_CARD_W, DEMO_INFO_CARD_MAX_H + 8, listbar_color );
+	UI_DrawRect( x, y, DEMO_INFO_CARD_W, DEMO_INFO_CARD_MAX_H + 8, color_white );
 
-	if ( entry->parseType == DEMO_PARSE_AUTORECORD ) {
-		UI_Demo_DrawLevelshot( DEMO_LIST_X, DEMO_INFO_CARD_Y, entry->map );
+	x = DEMO_INFO_COL_LEFT_X;
+	y = DEMO_INFO_CARD_Y;
 
-		x = DEMO_INFO_TEXT_X;
-		y = DEMO_INFO_CARD_Y;
+	UI_Demo_DrawCardRow( x, y, "File: ", entry->filename );
+	y += SMALLCHAR_HEIGHT;
 
-		Com_sprintf( line, sizeof( line ), "%s %s", entry->date, entry->time );
-		UI_Demo_DrawCardRow( x, y, "Date/Time: ", line );
-		y += SMALLCHAR_HEIGHT;
-
-		{
-			int			gametype;
-			const char	*colorPrefix;
-			int			labelWidth;
-
-			gametype = UI_Demo_SlugToGametype( entry->gametype );
-			colorPrefix = ( gametype >= 0 )
-					? UI_Demo_GametypeColor( gametype ) : S_COLOR_WHITE;
-			Com_sprintf( line, sizeof( line ), "%s%s",
-					colorPrefix, UI_Demo_ExpandedGametype( entry->gametype ) );
-			UI_DrawString( x, y, "Gametype: ", UI_LEFT | UI_SMALLFONT, text_color_normal );
-			labelWidth = strlen( "Gametype: " ) * SMALLCHAR_WIDTH;
-			UI_DrawString( x + labelWidth, y, line, UI_LEFT | UI_SMALLFONT, menu_text_color );
-		}
-		y += SMALLCHAR_HEIGHT;
-
-		if ( entry->server[0] ) {
-			UI_Demo_DrawCardRow( x, y, "Server: ", entry->server );
-			y += SMALLCHAR_HEIGHT;
-		}
-
-		mapLong[0] = '\0';
-		UI_Demo_GetMapLongName( entry->map, mapLong, sizeof( mapLong ) );
-		if ( mapLong[0] ) {
-			UI_Demo_DrawCardRow( x, y, "Map: ", mapLong );
-		} else {
-			Q_strncpyz( line, entry->map, sizeof( line ) );
-			Q_strupr( line );
-			UI_Demo_DrawCardRow( x, y, "Map: ", line );
-		}
-		y += SMALLCHAR_HEIGHT;
-
-		if ( entry->players[0] ) {
-			UI_Demo_DrawCardRow( x, y, "Players: ", entry->players );
-		}
-	} else {
-		x = DEMO_INFO_TEXT_X;
-		y = DEMO_INFO_CARD_Y;
-
-		UI_Demo_DrawCardRow( x, y, "File: ", entry->filename );
-		y += SMALLCHAR_HEIGHT;
-
-		UI_Demo_FormatFileSize( entry->fileSize, sizeText, sizeof( sizeText ) );
-		UI_Demo_DrawCardRow( x, y, "Size: ", sizeText );
-	}
+	UI_Demo_FormatFileSize( entry->fileSize, sizeText, sizeof( sizeText ) );
+	UI_Demo_DrawCardRow( x, y, "Size: ", sizeText );
 }
 
 static void UI_Demo_StripExtension( char *name ) {
@@ -986,6 +1590,7 @@ static void UI_Demo_LoadAll( void ) {
 		entry = &s_demos.entries[s_demos.numAll];
 		memset( entry, 0, sizeof( *entry ) );
 
+		Q_strncpyz( entry->fsName, demoname, sizeof( entry->fsName ) );
 		UI_Demo_LoadFileSize( demoname, entry );
 
 		Q_strncpyz( stripped, demoname, sizeof( stripped ) );
@@ -1101,6 +1706,7 @@ static void UI_Demo_RebuildList( void ) {
 	UI_Demo_UpdateSortHeaders();
 	UI_Demo_UpdateReplayOptions();
 	UI_MouseEvent( 0, 0 );
+	UI_Demo_SelectionChanged();
 }
 
 /*
@@ -1109,6 +1715,11 @@ Demos_MenuEvent
 ===============
 */
 static void Demos_MenuEvent( void *ptr, int event ) {
+	if ( event == QM_GOTFOCUS && ((menucommon_s*)ptr)->id == ID_LIST ) {
+		UI_Demo_SelectionChanged();
+		return;
+	}
+
 	if ( event != QM_ACTIVATED ) {
 		return;
 	}
@@ -1118,9 +1729,13 @@ static void Demos_MenuEvent( void *ptr, int event ) {
 		UI_Demo_PlaySelected();
 		break;
 	case ID_BACK:
+		s_demos.parseDebounceEntryIdx = -1;
+		UI_Demo_ParseStop();
 		UI_PopMenu();
 		break;
 	case ID_VIEW:
+		s_demos.parseDebounceEntryIdx = -1;
+		UI_Demo_ParseStop();
 		UI_Demo_RebuildList();
 		break;
 	case ID_SORT_DATETIME:
@@ -1161,7 +1776,7 @@ static sfxHandle_t UI_DemosMenu_Key( int key ) {
 	if ( key == K_MOUSE1 && s_demos.playable ) {
 		if ( s_demos.viewMode.curvalue == 0 &&
 				UI_CursorInRect( DEMO_LIST_X - 4, DEMO_INFO_CARD_Y - 4,
-				DEMO_INFO_CARD_W, DEMO_INFO_CARD_H + 8 ) ) {
+				DEMO_INFO_CARD_W, DEMO_INFO_CARD_MAX_H + 8 ) ) {
 			if ( UI_Demo_IsDoubleClick( DEMO_CLICK_CARD ) ) {
 				UI_Demo_PlaySelected();
 			}
@@ -1204,6 +1819,9 @@ static void UI_Demo_DrawStatus( void ) {
 }
 
 static void Demos_Draw( void ) {
+	UI_Demo_CheckSelectionChanged();
+	UI_Demo_ParseDebounceTick();
+	UI_Demo_ParseTick();
 	Menu_Draw( &s_demos.menu );
 	UI_Demo_DrawInfoCard();
 	UI_Demo_DrawStatus();
@@ -1245,13 +1863,15 @@ static void Demos_MenuInit( void ) {
 	s_demos.viewMode.generic.flags		= QMF_PULSEIFFOCUS | QMF_SMALLFONT;
 	s_demos.viewMode.generic.callback	= Demos_MenuEvent;
 	s_demos.viewMode.generic.id			= ID_VIEW;
-	s_demos.viewMode.generic.x			= 500;
-	s_demos.viewMode.generic.y			= 48;
+	s_demos.viewMode.generic.x			= DEMO_MENU_CENTER_X;
+	s_demos.viewMode.generic.y			= 52;
 	s_demos.viewMode.itemnames			= replayView_items;
 	s_demos.viewMode.curvalue			= 0;
 
 	s_demos.sortColumn = DEMO_SORT_DATETIME;
 	s_demos.sortDescending = qtrue;
+	s_demos.lastSelectedEntryIdx = -1;
+	s_demos.parseDebounceEntryIdx = -1;
 	UI_Demo_InitSortHeaders();
 
 	s_demos.arrows.generic.type		= MTYPE_BITMAP;
@@ -1308,7 +1928,8 @@ static void Demos_MenuInit( void ) {
 	s_demos.replayDelag.generic.flags		= QMF_PULSEIFFOCUS | QMF_SMALLFONT;
 	s_demos.replayDelag.generic.callback	= Demos_MenuEvent;
 	s_demos.replayDelag.generic.id			= ID_REPLAY_DELAG;
-	s_demos.replayDelag.generic.x			= DEMO_OPTS_X;
+	s_demos.replayDelag.generic.x			=
+			UI_Demo_CenteredRadioX( s_demos.replayDelag.generic.name );
 	s_demos.replayDelag.generic.y			= DEMO_OPTS_DELAG_Y;
 
 	s_demos.drawBBox.generic.type		= MTYPE_RADIOBUTTON;
@@ -1316,7 +1937,8 @@ static void Demos_MenuInit( void ) {
 	s_demos.drawBBox.generic.flags		= QMF_PULSEIFFOCUS | QMF_SMALLFONT;
 	s_demos.drawBBox.generic.callback	= Demos_MenuEvent;
 	s_demos.drawBBox.generic.id			= ID_DRAW_BBOX;
-	s_demos.drawBBox.generic.x			= DEMO_OPTS_X;
+	s_demos.drawBBox.generic.x			=
+			UI_Demo_CenteredRadioX( s_demos.drawBBox.generic.name );
 	s_demos.drawBBox.generic.y			= DEMO_OPTS_BBOX_Y;
 
 	s_demos.list.generic.type		= MTYPE_SCROLLLIST;

--- a/ratoa_gamecode/code/q3_ui/ui_demo_parse.c
+++ b/ratoa_gamecode/code/q3_ui/ui_demo_parse.c
@@ -1,0 +1,773 @@
+/*
+===========================================================================
+Cooperative demo-file scanner for Fancy replays info card enrichment.
+Parses one selected demo per frame using an adaptive time budget (same poll
+model as server lists).
+===========================================================================
+*/
+
+#include "ui_local.h"
+#include "../qcommon/msg_qvm.h"
+
+#define DEMO_PARSE_MAX_ARGS			512
+
+#define DEMO_PARSE_TARGET_FRAME_MS	16
+#define DEMO_PARSE_BUDGET_MIN_MS	1
+#define DEMO_PARSE_BUDGET_MAX_MS	10
+#define DEMO_PARSE_BUDGET_DEFAULT_MS	4
+#define DEMO_PARSE_BUDGET_STEP_MS	1
+#define DEMO_PARSE_MAX_BLOCKS_PER_TICK	64
+#define DEMO_PARSE_ADAPT_INTERVAL		4
+#define DEMO_PARSE_FRAME_SLOW_MS		20
+#define DEMO_PARSE_FRAME_WARN_MS		18
+
+typedef struct {
+	fileHandle_t	fh;
+	demoEntry_t		*entry;
+	int				fileSize;
+	int				bytesRead;
+	int				blocksThisTick;
+	int				budgetMs;
+	int				adaptCooldown;
+	qboolean		active;
+} demoParseCtx_t;
+
+static demoParseCtx_t	s_demoParse;
+
+static void UI_Demo_ParseCloseFile( void ) {
+	if ( s_demoParse.fh ) {
+		trap_FS_FCloseFile( s_demoParse.fh );
+		s_demoParse.fh = 0;
+	}
+}
+
+void UI_Demo_ParseStop( void ) {
+	UI_Demo_ParseCloseFile();
+	s_demoParse.entry = NULL;
+	s_demoParse.active = qfalse;
+	s_demoParse.blocksThisTick = 0;
+	s_demoParse.adaptCooldown = 0;
+}
+
+static void UI_Demo_ParseAdaptBudget( int parseMs ) {
+	if ( s_demoParse.adaptCooldown > 0 ) {
+		s_demoParse.adaptCooldown--;
+		return;
+	}
+
+	s_demoParse.adaptCooldown = DEMO_PARSE_ADAPT_INTERVAL;
+
+	if ( uis.frametime > DEMO_PARSE_FRAME_SLOW_MS || parseMs > s_demoParse.budgetMs + 2 ) {
+		s_demoParse.budgetMs -= DEMO_PARSE_BUDGET_STEP_MS * 2;
+	} else if ( uis.frametime > DEMO_PARSE_FRAME_WARN_MS ) {
+		s_demoParse.budgetMs -= DEMO_PARSE_BUDGET_STEP_MS;
+	} else if ( uis.frametime < DEMO_PARSE_TARGET_FRAME_MS - 4 &&
+			parseMs >= s_demoParse.budgetMs - 1 ) {
+		s_demoParse.budgetMs += DEMO_PARSE_BUDGET_STEP_MS;
+	}
+
+	if ( s_demoParse.budgetMs < DEMO_PARSE_BUDGET_MIN_MS ) {
+		s_demoParse.budgetMs = DEMO_PARSE_BUDGET_MIN_MS;
+	}
+	if ( s_demoParse.budgetMs > DEMO_PARSE_BUDGET_MAX_MS ) {
+		s_demoParse.budgetMs = DEMO_PARSE_BUDGET_MAX_MS;
+	}
+}
+
+static void UI_Demo_ParseResetEntryMeta( demoEntry_t *entry ) {
+	int		i;
+
+	entry->metaState = DEMO_META_NONE;
+	entry->metaDurationMs = 0;
+	entry->metaScores[0] = '\0';
+	entry->metaPlayers[0] = '\0';
+	entry->metaFirstServerTime = 0;
+	entry->metaLastServerTime = 0;
+	entry->metaScore0 = 0;
+	entry->metaScore1 = 0;
+	entry->metaHaveScores = qfalse;
+	entry->metaNumOrderedPlayers = 0;
+	Com_Memset( entry->metaPlayerScores, 0, sizeof( entry->metaPlayerScores ) );
+	Com_Memset( entry->metaPlayerOrder, 0, sizeof( entry->metaPlayerOrder ) );
+	Com_Memset( entry->metaPlayerModels, 0, sizeof( entry->metaPlayerModels ) );
+	Com_Memset( entry->metaLeftClients, 0, sizeof( entry->metaLeftClients ) );
+	Com_Memset( entry->metaRightClients, 0, sizeof( entry->metaRightClients ) );
+	entry->metaNumLeft = 0;
+	entry->metaNumRight = 0;
+	entry->metaLayoutLocked = qfalse;
+	Com_Memset( entry->metaPlayerNames, 0, sizeof( entry->metaPlayerNames ) );
+	for ( i = 0; i < MAX_CLIENTS; i++ ) {
+		entry->metaPlayerTeam[i] = TEAM_FREE;
+	}
+}
+
+static qboolean UI_Demo_ParseIsTeamSlug( const char *slug ) {
+	if ( !slug || !slug[0] ) {
+		return qfalse;
+	}
+
+	if ( !Q_stricmp( slug, "tdm" ) || !Q_stricmp( slug, "ctf" ) ||
+			!Q_stricmp( slug, "1fctf" ) || !Q_stricmp( slug, "ctfe" ) ||
+			!Q_stricmp( slug, "elim" ) || !Q_stricmp( slug, "obelisk" ) ||
+			!Q_stricmp( slug, "harv" ) || !Q_stricmp( slug, "harvester" ) ||
+			!Q_stricmp( slug, "dom" ) || !Q_stricmp( slug, "dd" ) ||
+			!Q_stricmp( slug, "th" ) ) {
+		return qtrue;
+	}
+
+	return qfalse;
+}
+
+static qboolean UI_Demo_ParseIsDuelSlug( const char *slug ) {
+	if ( !slug || !slug[0] ) {
+		return qfalse;
+	}
+
+	if ( !Q_stricmp( slug, "1v1" ) ) {
+		return qtrue;
+	}
+#ifdef WITH_MULTITOURNAMENT
+	if ( !Q_stricmp( slug, "game" ) ) {
+		return qtrue;
+	}
+#endif
+
+	return qfalse;
+}
+
+static void UI_Demo_ParseEstablishLayout( demoEntry_t *entry ) {
+	int		c;
+	int		duelCount;
+
+	if ( entry->metaLayoutLocked ) {
+		return;
+	}
+
+	entry->metaNumLeft = 0;
+	entry->metaNumRight = 0;
+
+	if ( UI_Demo_ParseIsTeamSlug( entry->gametype ) ) {
+		for ( c = 0; c < MAX_CLIENTS; c++ ) {
+			if ( !entry->metaPlayerNames[c][0] ) {
+				continue;
+			}
+			if ( entry->metaPlayerTeam[c] == TEAM_SPECTATOR ) {
+				continue;
+			}
+			if ( entry->metaPlayerTeam[c] == TEAM_RED ) {
+				entry->metaLeftClients[entry->metaNumLeft] = c;
+				entry->metaNumLeft++;
+			} else if ( entry->metaPlayerTeam[c] == TEAM_BLUE ) {
+				entry->metaRightClients[entry->metaNumRight] = c;
+				entry->metaNumRight++;
+			}
+		}
+		entry->metaLayoutLocked = qtrue;
+		return;
+	}
+
+	if ( UI_Demo_ParseIsDuelSlug( entry->gametype ) ) {
+		duelCount = 0;
+		for ( c = 0; c < MAX_CLIENTS; c++ ) {
+			if ( !entry->metaPlayerNames[c][0] ) {
+				continue;
+			}
+			if ( entry->metaPlayerTeam[c] == TEAM_SPECTATOR ) {
+				continue;
+			}
+			if ( duelCount == 0 ) {
+				entry->metaLeftClients[0] = c;
+				entry->metaNumLeft = 1;
+			} else if ( duelCount == 1 ) {
+				entry->metaRightClients[0] = c;
+				entry->metaNumRight = 1;
+			} else {
+				break;
+			}
+			duelCount++;
+		}
+		entry->metaLayoutLocked = qtrue;
+		return;
+	}
+
+	/* FFA: alternate left/right in client slot order */
+	for ( c = 0; c < MAX_CLIENTS; c++ ) {
+		if ( !entry->metaPlayerNames[c][0] ) {
+			continue;
+		}
+		if ( entry->metaPlayerTeam[c] == TEAM_SPECTATOR ) {
+			continue;
+		}
+		if ( entry->metaNumLeft <= entry->metaNumRight ) {
+			entry->metaLeftClients[entry->metaNumLeft] = c;
+			entry->metaNumLeft++;
+		} else {
+			entry->metaRightClients[entry->metaNumRight] = c;
+			entry->metaNumRight++;
+		}
+	}
+
+	entry->metaLayoutLocked = qtrue;
+}
+
+static qboolean UI_Demo_ParseScoresWouldRegress( demoEntry_t *entry, int score0, int score1 ) {
+	if ( !entry->metaHaveScores ) {
+		return qfalse;
+	}
+
+	if ( entry->metaScore0 > 0 && score0 == 0 ) {
+		return qtrue;
+	}
+	if ( entry->metaScore1 > 0 && score1 == 0 ) {
+		return qtrue;
+	}
+	if ( entry->metaScore0 + entry->metaScore1 > 0 && score0 + score1 == 0 ) {
+		return qtrue;
+	}
+
+	return qfalse;
+}
+
+static void UI_Demo_ParseApplyTeamScores( demoEntry_t *entry, int score0, int score1 ) {
+	if ( UI_Demo_ParseScoresWouldRegress( entry, score0, score1 ) ) {
+		return;
+	}
+
+	entry->metaScore0 = score0;
+	entry->metaScore1 = score1;
+	entry->metaHaveScores = qtrue;
+
+	if ( score1 != 0 || score0 != score1 ) {
+		Com_sprintf( entry->metaScores, sizeof( entry->metaScores ),
+				"%d - %d", score0, score1 );
+	} else {
+		Com_sprintf( entry->metaScores, sizeof( entry->metaScores ),
+				"%d", score0 );
+	}
+}
+
+static void UI_Demo_ParseBuildPlayersFromSlots( demoEntry_t *entry ) {
+	int		i;
+	int		count;
+	char	name[MAX_NAME_LENGTH];
+	char	info[MAX_STRING_CHARS];
+	char	*n;
+
+	count = 0;
+	entry->metaPlayers[0] = '\0';
+
+	for ( i = 0; i < MAX_CLIENTS; i++ ) {
+		if ( !entry->metaPlayerNames[i][0] ) {
+			continue;
+		}
+
+		Q_strncpyz( name, entry->metaPlayerNames[i], sizeof( name ) );
+
+		if ( count == 0 ) {
+			Q_strncpyz( entry->metaPlayers, name, sizeof( entry->metaPlayers ) );
+		} else if ( count == 1 && !strchr( entry->metaPlayers, ',' ) ) {
+			Q_strncpyz( info, entry->metaPlayers, sizeof( info ) );
+			Com_sprintf( entry->metaPlayers, sizeof( entry->metaPlayers ),
+					"%s vs %s", info, name );
+		} else {
+			Q_strncpyz( info, entry->metaPlayers, sizeof( info ) );
+			Com_sprintf( entry->metaPlayers, sizeof( entry->metaPlayers ),
+					"%s, %s", info, name );
+		}
+		count++;
+	}
+}
+
+static void UI_Demo_ParseBuildDisplayStrings( demoEntry_t *entry ) {
+	int		i;
+	int		c;
+	int		score;
+	int		count;
+	char	scorePart[16];
+	char	info[MAX_STRING_CHARS];
+
+	entry->metaPlayers[0] = '\0';
+	entry->metaScores[0] = '\0';
+
+	count = entry->metaNumOrderedPlayers;
+	if ( count <= 0 ) {
+		UI_Demo_ParseBuildPlayersFromSlots( entry );
+		return;
+	}
+
+	for ( i = 0; i < count; i++ ) {
+		c = entry->metaPlayerOrder[i];
+		if ( c < 0 || c >= MAX_CLIENTS ) {
+			continue;
+		}
+		if ( !entry->metaPlayerNames[c][0] ) {
+			continue;
+		}
+
+		score = entry->metaPlayerScores[c];
+		Com_sprintf( scorePart, sizeof( scorePart ), "%d", score );
+
+		if ( entry->metaPlayers[0] ) {
+			if ( count == 2 && i == 1 ) {
+				Q_strncpyz( info, entry->metaPlayers, sizeof( info ) );
+				Com_sprintf( entry->metaPlayers, sizeof( entry->metaPlayers ),
+						"%s vs %s", info, entry->metaPlayerNames[c] );
+			} else {
+				Q_strncpyz( info, entry->metaPlayers, sizeof( info ) );
+				Com_sprintf( entry->metaPlayers, sizeof( entry->metaPlayers ),
+						"%s, %s", info, entry->metaPlayerNames[c] );
+			}
+		} else {
+			Q_strncpyz( entry->metaPlayers, entry->metaPlayerNames[c],
+					sizeof( entry->metaPlayers ) );
+		}
+
+		if ( entry->metaScores[0] ) {
+			if ( count == 2 && i == 1 ) {
+				Q_strncpyz( info, entry->metaScores, sizeof( info ) );
+				Com_sprintf( entry->metaScores, sizeof( entry->metaScores ),
+						"%s - %s", info, scorePart );
+			} else {
+				Q_strncpyz( info, entry->metaScores, sizeof( info ) );
+				Com_sprintf( entry->metaScores, sizeof( entry->metaScores ),
+						"%s, %s", info, scorePart );
+			}
+		} else {
+			Q_strncpyz( entry->metaScores, scorePart, sizeof( entry->metaScores ) );
+		}
+	}
+}
+
+static qboolean UI_Demo_ParsePlayerScoresWouldRegress( demoEntry_t *entry, int numScores,
+		int firstArg, int stride, int argc, char *argv[] ) {
+	int		i;
+	int		c;
+	int		score;
+	int		oldSum;
+	int		newSum;
+
+	if ( !entry->metaHaveScores ) {
+		return qfalse;
+	}
+
+	oldSum = 0;
+	newSum = 0;
+	for ( i = 0; i < MAX_CLIENTS; i++ ) {
+		oldSum += entry->metaPlayerScores[i];
+	}
+
+	for ( i = 0; i < numScores; i++ ) {
+		int	base = firstArg + i * stride;
+
+		if ( base + 1 >= argc ) {
+			break;
+		}
+
+		c = atoi( argv[base] );
+		score = atoi( argv[base + 1] );
+		newSum += score;
+
+		if ( c >= 0 && c < MAX_CLIENTS &&
+				entry->metaPlayerScores[c] > 0 && score == 0 ) {
+			return qtrue;
+		}
+	}
+
+	if ( oldSum > 0 && newSum == 0 ) {
+		return qtrue;
+	}
+
+	return qfalse;
+}
+
+static void UI_Demo_ParseApplyPlayerScoresFromArgv( demoEntry_t *entry, int numScores,
+		int firstArg, int stride, int argc, char *argv[], qboolean preserveTeamScores ) {
+	int		i;
+	int		c;
+	int		score;
+	int		base;
+
+	if ( firstArg + 2 > argc ) {
+		return;
+	}
+
+	if ( UI_Demo_ParsePlayerScoresWouldRegress( entry, numScores,
+			firstArg, stride, argc, argv ) ) {
+		return;
+	}
+
+	for ( i = 0; i < numScores; i++ ) {
+		base = firstArg + i * stride;
+		if ( base + 1 >= argc ) {
+			break;
+		}
+
+		c = atoi( argv[base] );
+		score = atoi( argv[base + 1] );
+
+		if ( c < 0 || c >= MAX_CLIENTS ) {
+			continue;
+		}
+
+		entry->metaPlayerScores[c] = score;
+	}
+
+	entry->metaHaveScores = qtrue;
+	if ( !preserveTeamScores ) {
+		entry->metaScore0 = 0;
+		entry->metaScore1 = 0;
+	}
+	UI_Demo_ParseBuildDisplayStrings( entry );
+}
+
+static void UI_Demo_ParseApplyPlayerConfigstring( demoEntry_t *entry, int clientNum,
+		const char *cs ) {
+	const char	*n;
+
+	if ( clientNum < 0 || clientNum >= MAX_CLIENTS || !cs || !cs[0] ) {
+		return;
+	}
+
+	n = Info_ValueForKey( cs, "n" );
+	if ( !n || !n[0] ) {
+		return;
+	}
+
+	Q_strncpyz( entry->metaPlayerNames[clientNum], n,
+			sizeof( entry->metaPlayerNames[clientNum] ) );
+
+	{
+		const char	*model;
+		const char	*teamStr;
+
+		model = Info_ValueForKey( cs, "model" );
+		if ( model && model[0] ) {
+			Q_strncpyz( entry->metaPlayerModels[clientNum], model,
+					sizeof( entry->metaPlayerModels[clientNum] ) );
+		}
+
+		teamStr = Info_ValueForKey( cs, "t" );
+		if ( teamStr && teamStr[0] ) {
+			entry->metaPlayerTeam[clientNum] = atoi( teamStr );
+		} else {
+			entry->metaPlayerTeam[clientNum] = TEAM_FREE;
+		}
+	}
+
+	if ( entry->metaNumOrderedPlayers > 0 ) {
+		UI_Demo_ParseBuildDisplayStrings( entry );
+	} else {
+		UI_Demo_ParseBuildPlayersFromSlots( entry );
+	}
+}
+
+static int UI_Demo_ParseSplitArgs( char *cmdLine, char *argv[], int maxArgs ) {
+	int		count;
+	char	*scan;
+
+	count = 0;
+	scan = cmdLine;
+
+	while ( count < maxArgs ) {
+		while ( *scan == ' ' ) {
+			scan++;
+		}
+		if ( !*scan ) {
+			break;
+		}
+		argv[count++] = scan;
+		while ( *scan && *scan != ' ' ) {
+			scan++;
+		}
+		if ( *scan ) {
+			*scan = '\0';
+			scan++;
+		}
+	}
+
+	return count;
+}
+
+static void UI_Demo_ParseScoresFromArgv( demoEntry_t *entry, int argc, char *argv[] ) {
+	int		numScores;
+	int		team0;
+	int		team1;
+
+	if ( argc < 4 ) {
+		return;
+	}
+
+	if ( !Q_stricmp( argv[0], "ratscores1" ) ) {
+		if ( argc < 5 ) {
+			return;
+		}
+		numScores = atoi( argv[2] );
+		team0 = atoi( argv[3] );
+		team1 = atoi( argv[4] );
+	} else if ( !Q_stricmp( argv[0], "scores" ) || !Q_stricmp( argv[0], "ratscores" ) ) {
+		numScores = atoi( argv[1] );
+		team0 = atoi( argv[2] );
+		team1 = atoi( argv[3] );
+	} else {
+		return;
+	}
+
+	if ( numScores <= 0 || numScores > MAX_CLIENTS ) {
+		return;
+	}
+
+	if ( team0 != 0 || team1 != 0 ) {
+		UI_Demo_ParseApplyTeamScores( entry, team0, team1 );
+	}
+
+	/* Per-player scores in scoreboard sort order */
+	if ( !Q_stricmp( argv[0], "ratscores1" ) ) {
+		UI_Demo_ParseApplyPlayerScoresFromArgv( entry, numScores, 8, 17, argc, argv,
+				team0 != 0 || team1 != 0 );
+		return;
+	}
+
+	if ( !Q_stricmp( argv[0], "ratscores" ) ) {
+		UI_Demo_ParseApplyPlayerScoresFromArgv( entry, numScores, 5, 21, argc, argv,
+				team0 != 0 || team1 != 0 );
+		return;
+	}
+
+	if ( !Q_stricmp( argv[0], "scores" ) ) {
+		UI_Demo_ParseApplyPlayerScoresFromArgv( entry, numScores, 5, 15, argc, argv,
+				team0 != 0 || team1 != 0 );
+	}
+}
+
+static void UI_Demo_ParseServerCommand( demoEntry_t *entry, const char *cmd ) {
+	char		buf[MAX_STRING_CHARS];
+	char		*argv[DEMO_PARSE_MAX_ARGS];
+	int			argc;
+
+	if ( !cmd || !cmd[0] ) {
+		return;
+	}
+
+	Q_strncpyz( buf, cmd, sizeof( buf ) );
+	argc = UI_Demo_ParseSplitArgs( buf, argv, DEMO_PARSE_MAX_ARGS );
+	if ( argc <= 0 ) {
+		return;
+	}
+
+	if ( !Q_stricmp( argv[0], "ratscores1" ) ||
+			!Q_stricmp( argv[0], "ratscores" ) ||
+			!Q_stricmp( argv[0], "scores" ) ) {
+		UI_Demo_ParseScoresFromArgv( entry, argc, argv );
+	}
+}
+
+static void UI_Demo_ParseTrackServerTime( demoEntry_t *entry, int serverTime ) {
+	if ( entry->metaFirstServerTime == 0 ) {
+		entry->metaFirstServerTime = serverTime;
+	}
+	if ( serverTime > entry->metaLastServerTime ) {
+		entry->metaLastServerTime = serverTime;
+	}
+	if ( entry->metaLastServerTime > entry->metaFirstServerTime ) {
+		entry->metaDurationMs = entry->metaLastServerTime - entry->metaFirstServerTime;
+	}
+}
+
+static void UI_Demo_ParseGamestate( msg_t *msg, demoEntry_t *entry ) {
+	int				cmd;
+	int				idx;
+	char			*s;
+
+	MSG_ReadLong( msg );
+
+	while ( msg->readcount < msg->cursize ) {
+		cmd = MSG_ReadByte( msg );
+		if ( cmd < 0 ) {
+			break;
+		}
+		if ( cmd == svc_EOF ) {
+			break;
+		}
+
+		if ( cmd == svc_configstring ) {
+			idx = MSG_ReadShort( msg );
+			s = MSG_ReadBigString( msg );
+			if ( idx >= CS_PLAYERS && idx < CS_PLAYERS + MAX_CLIENTS ) {
+				UI_Demo_ParseApplyPlayerConfigstring( entry,
+						idx - CS_PLAYERS, s );
+			}
+		} else {
+			break;
+		}
+	}
+
+	if ( msg->readcount + 8 <= msg->cursize ) {
+		MSG_ReadLong( msg );
+		MSG_ReadLong( msg );
+	}
+
+	UI_Demo_ParseEstablishLayout( entry );
+}
+
+static void UI_Demo_ParseServerMessage( msg_t *msg, demoEntry_t *entry ) {
+	int		cmd;
+
+	if ( msg->cursize <= 0 ) {
+		return;
+	}
+
+	MSG_Bitstream( msg );
+	MSG_ReadLong( msg );
+
+	while ( 1 ) {
+		if ( msg->readcount > msg->cursize ) {
+			break;
+		}
+
+		cmd = MSG_ReadByte( msg );
+		if ( cmd < 0 ) {
+			break;
+		}
+		if ( cmd == svc_EOF ) {
+			break;
+		}
+
+		switch ( cmd ) {
+		case svc_nop:
+			break;
+		case svc_serverCommand:
+			MSG_ReadLong( msg );
+			UI_Demo_ParseServerCommand( entry, MSG_ReadString( msg ) );
+			break;
+		case svc_gamestate:
+			UI_Demo_ParseGamestate( msg, entry );
+			break;
+		case svc_snapshot:
+			if ( msg->readcount + 4 <= msg->cursize ) {
+				UI_Demo_ParseTrackServerTime( entry, MSG_ReadLong( msg ) );
+			}
+			return;
+		case svc_download:
+			{
+				int dlSize = MSG_ReadShort( msg );
+				if ( dlSize < 0 || msg->readcount + dlSize > msg->cursize ) {
+					return;
+				}
+				msg->readcount += dlSize;
+			}
+			break;
+		default:
+			return;
+		}
+	}
+}
+
+static qboolean UI_Demo_ParseReadBlock( demoEntry_t *entry ) {
+	msg_t		msg;
+	byte		msgData[MAX_MSGLEN];
+	int			seq;
+	int			len;
+
+	if ( s_demoParse.bytesRead + 8 > s_demoParse.fileSize ) {
+		return qfalse;
+	}
+
+	trap_FS_Read( &seq, 4, s_demoParse.fh );
+	s_demoParse.bytesRead += 4;
+	seq = LittleLong( seq );
+
+	trap_FS_Read( &len, 4, s_demoParse.fh );
+	s_demoParse.bytesRead += 4;
+	len = LittleLong( len );
+
+	if ( len == -1 || seq == -1 ) {
+		return qfalse;
+	}
+
+	if ( len <= 0 || len > MAX_MSGLEN ) {
+		return qfalse;
+	}
+
+	if ( s_demoParse.bytesRead + len > s_demoParse.fileSize ) {
+		return qfalse;
+	}
+
+	MSG_Init( &msg, msgData, sizeof( msgData ) );
+	msg.cursize = len;
+
+	trap_FS_Read( msg.data, len, s_demoParse.fh );
+	s_demoParse.bytesRead += len;
+
+	UI_Demo_ParseServerMessage( &msg, entry );
+	return qtrue;
+}
+
+void UI_Demo_ParseBegin( demoEntry_t *entry ) {
+	char		path[MAX_OSPATH];
+	int			size;
+
+	UI_Demo_ParseStop();
+
+	if ( !entry || !entry->fsName[0] ) {
+		return;
+	}
+
+	if ( s_demoParse.active && s_demoParse.entry == entry ) {
+		return;
+	}
+
+	if ( entry->metaState == DEMO_META_DONE ) {
+		return;
+	}
+
+	Com_sprintf( path, sizeof( path ), "demos/%s", entry->fsName );
+	size = trap_FS_FOpenFile( path, &s_demoParse.fh, FS_READ );
+	if ( size <= 0 || !s_demoParse.fh ) {
+		entry->metaState = DEMO_META_ERROR;
+		UI_Demo_ParseCloseFile();
+		return;
+	}
+
+	s_demoParse.fileSize = size;
+	s_demoParse.bytesRead = 0;
+
+	UI_Demo_ParseResetEntryMeta( entry );
+	entry->metaState = DEMO_META_LOADING;
+
+	s_demoParse.entry = entry;
+	s_demoParse.active = qtrue;
+	s_demoParse.blocksThisTick = 0;
+	s_demoParse.budgetMs = DEMO_PARSE_BUDGET_DEFAULT_MS;
+	s_demoParse.adaptCooldown = 0;
+}
+
+void UI_Demo_ParseTick( void ) {
+	int		startMs;
+	int		deadlineMs;
+	int		parseMs;
+	int		i;
+
+	if ( !s_demoParse.active || !s_demoParse.entry || !s_demoParse.fh ) {
+		return;
+	}
+
+	s_demoParse.blocksThisTick = 0;
+	startMs = trap_Milliseconds();
+	deadlineMs = startMs + s_demoParse.budgetMs;
+
+	for ( i = 0; i < DEMO_PARSE_MAX_BLOCKS_PER_TICK; i++ ) {
+		if ( i > 0 && trap_Milliseconds() >= deadlineMs ) {
+			break;
+		}
+
+		if ( !UI_Demo_ParseReadBlock( s_demoParse.entry ) ) {
+			s_demoParse.entry->metaState = DEMO_META_DONE;
+			UI_Demo_ParseStop();
+			return;
+		}
+		s_demoParse.blocksThisTick++;
+	}
+
+	parseMs = trap_Milliseconds() - startMs;
+	UI_Demo_ParseAdaptBudget( parseMs );
+}

--- a/ratoa_gamecode/code/q3_ui/ui_local.h
+++ b/ratoa_gamecode/code/q3_ui/ui_local.h
@@ -340,10 +340,60 @@ extern void UI_ControlsMenu( void );
 extern void Controls_Cache( void );
 
 //
-// ui_demo2.c
+// ui_demo2.c / ui_demo_parse.c
 //
+typedef enum {
+	DEMO_PARSE_NONE = 0,
+	DEMO_PARSE_AUTORECORD
+} demoParseType_t;
+
+typedef enum {
+	DEMO_META_NONE = 0,
+	DEMO_META_LOADING,
+	DEMO_META_DONE,
+	DEMO_META_ERROR
+} demoMetaState_t;
+
+typedef struct {
+	char				filename[MAX_OSPATH];
+	char				fsName[MAX_OSPATH];
+	demoParseType_t		parseType;
+	char				date[12];
+	char				time[6];
+	char				server[48];
+	char				gametype[12];
+	char				map[32];
+	char				players[48];
+	int					fileSize;
+	char				label[80];
+	demoMetaState_t		metaState;
+	int					metaDurationMs;
+	char				metaScores[256];
+	char				metaPlayers[256];
+	char				metaPlayerNames[MAX_CLIENTS][MAX_NAME_LENGTH];
+	char				metaPlayerModels[MAX_CLIENTS][MAX_QPATH];
+	int					metaPlayerTeam[MAX_CLIENTS];
+	int					metaPlayerScores[MAX_CLIENTS];
+	int					metaPlayerOrder[MAX_CLIENTS];
+	int					metaNumOrderedPlayers;
+	int					metaFirstServerTime;
+	int					metaLastServerTime;
+	int					metaScore0;
+	int					metaScore1;
+	qboolean			metaHaveScores;
+	int					metaLeftClients[MAX_CLIENTS];
+	int					metaNumLeft;
+	int					metaRightClients[MAX_CLIENTS];
+	int					metaNumRight;
+	qboolean			metaLayoutLocked;
+} demoEntry_t;
+
 extern void UI_DemosMenu( void );
 extern void Demos_Cache( void );
+extern void UI_Demo_ParseStop( void );
+extern void UI_Demo_ParseBegin( demoEntry_t *entry );
+extern void UI_Demo_ParseTick( void );
+
 
 //
 // ui_challenges.c

--- a/ratoa_gamecode/code/qcommon/huffman.c
+++ b/ratoa_gamecode/code/qcommon/huffman.c
@@ -1,0 +1,444 @@
+/*
+===========================================================================
+Copyright (C) 1999-2005 Id Software, Inc.
+
+This file is part of Quake III Arena source code.
+
+Quake III Arena source code is free software; you can redistribute it
+and/or modify it under the terms of the GNU General Public License as
+published by the Free Software Foundation; either version 2 of the License,
+or (at your option) any later version.
+
+Quake III Arena source code is distributed in the hope that it will be
+useful, but WITHOUT ANY WARRANTY; without even the implied warranty of
+MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+GNU General Public License for more details.
+
+You should have received a copy of the GNU General Public License
+along with Foobar; if not, write to the Free Software
+Foundation, Inc., 51 Franklin St, Fifth Floor, Boston, MA  02110-1301  USA
+===========================================================================
+*/
+
+/* This is based on the Adaptive Huffman algorithm described in Sayood's Data
+ * Compression book.  The ranks are not actually stored, but implicitly defined
+ * by the location of a node within a doubly-linked list */
+
+#include "../game/q_shared.h"
+#ifdef Q3_VM
+#include "msg_qvm.h"
+#else
+#include "qcommon.h"
+#endif
+
+static int			bloc = 0;
+
+void	Huff_putBit( int bit, byte *fout, int *offset) {
+	bloc = *offset;
+	if ((bloc&7) == 0) {
+		fout[(bloc>>3)] = 0;
+	}
+	fout[(bloc>>3)] |= bit << (bloc&7);
+	bloc++;
+	*offset = bloc;
+}
+
+int		Huff_getBit( byte *fin, int *offset) {
+	int t;
+	bloc = *offset;
+	t = (fin[(bloc>>3)] >> (bloc&7)) & 0x1;
+	bloc++;
+	*offset = bloc;
+	return t;
+}
+
+/* Add a bit to the output file (buffered) */
+static void add_bit (char bit, byte *fout) {
+	if ((bloc&7) == 0) {
+		fout[(bloc>>3)] = 0;
+	}
+	fout[(bloc>>3)] |= bit << (bloc&7);
+	bloc++;
+}
+
+/* Receive one bit from the input file (buffered) */
+static int get_bit (byte *fin) {
+	int t;
+	t = (fin[(bloc>>3)] >> (bloc&7)) & 0x1;
+	bloc++;
+	return t;
+}
+
+static node_t **get_ppnode(huff_t* huff) {
+	node_t **tppnode;
+	if (!huff->freelist) {
+		return &(huff->nodePtrs[huff->blocPtrs++]);
+	} else {
+		tppnode = huff->freelist;
+		huff->freelist = (node_t **)*tppnode;
+		return tppnode;
+	}
+}
+
+static void free_ppnode(huff_t* huff, node_t **ppnode) {
+	*ppnode = (node_t *)huff->freelist;
+	huff->freelist = ppnode;
+}
+
+/* Swap the location of these two nodes in the tree */
+static void swap (huff_t* huff, node_t *node1, node_t *node2) { 
+	node_t *par1, *par2;
+
+	par1 = node1->parent;
+	par2 = node2->parent;
+
+	if (par1) {
+		if (par1->left == node1) {
+			par1->left = node2;
+		} else {
+	      par1->right = node2;
+		}
+	} else {
+		huff->tree = node2;
+	}
+
+	if (par2) {
+		if (par2->left == node2) {
+			par2->left = node1;
+		} else {
+			par2->right = node1;
+		}
+	} else {
+		huff->tree = node1;
+	}
+  
+	node1->parent = par2;
+	node2->parent = par1;
+}
+
+/* Swap these two nodes in the linked list (update ranks) */
+static void swaplist(node_t *node1, node_t *node2) {
+	node_t *par1;
+
+	par1 = node1->next;
+	node1->next = node2->next;
+	node2->next = par1;
+
+	par1 = node1->prev;
+	node1->prev = node2->prev;
+	node2->prev = par1;
+
+	if (node1->next == node1) {
+		node1->next = node2;
+	}
+	if (node2->next == node2) {
+		node2->next = node1;
+	}
+	if (node1->next) {
+		node1->next->prev = node1;
+	}
+	if (node2->next) {
+		node2->next->prev = node2;
+	}
+	if (node1->prev) {
+		node1->prev->next = node1;
+	}
+	if (node2->prev) {
+		node2->prev->next = node2;
+	}
+}
+
+/* Do the increments */
+static void increment(huff_t* huff, node_t *node) {
+	node_t *lnode;
+
+	if (!node) {
+		return;
+	}
+
+	if (node->next != NULL && node->next->weight == node->weight) {
+	    lnode = *node->head;
+		if (lnode != node->parent) {
+			swap(huff, lnode, node);
+		}
+		swaplist(lnode, node);
+	}
+	if (node->prev && node->prev->weight == node->weight) {
+		*node->head = node->prev;
+	} else {
+	    *node->head = NULL;
+		free_ppnode(huff, node->head);
+	}
+	node->weight++;
+	if (node->next && node->next->weight == node->weight) {
+		node->head = node->next->head;
+	} else { 
+		node->head = get_ppnode(huff);
+		*node->head = node;
+	}
+	if (node->parent) {
+		increment(huff, node->parent);
+		if (node->prev == node->parent) {
+			swaplist(node, node->parent);
+			if (*node->head == node) {
+				*node->head = node->parent;
+			}
+		}
+	}
+}
+
+void Huff_addRef(huff_t* huff, byte ch) {
+	node_t *tnode, *tnode2;
+	if (huff->loc[ch] == NULL) { /* if this is the first transmission of this node */
+		tnode = &(huff->nodeList[huff->blocNode++]);
+		tnode2 = &(huff->nodeList[huff->blocNode++]);
+
+		tnode2->symbol = INTERNAL_NODE;
+		tnode2->weight = 1;
+		tnode2->next = huff->lhead->next;
+		if (huff->lhead->next) {
+			huff->lhead->next->prev = tnode2;
+			if (huff->lhead->next->weight == 1) {
+				tnode2->head = huff->lhead->next->head;
+			} else {
+				tnode2->head = get_ppnode(huff);
+				*tnode2->head = tnode2;
+			}
+		} else {
+			tnode2->head = get_ppnode(huff);
+			*tnode2->head = tnode2;
+		}
+		huff->lhead->next = tnode2;
+		tnode2->prev = huff->lhead;
+ 
+		tnode->symbol = ch;
+		tnode->weight = 1;
+		tnode->next = huff->lhead->next;
+		if (huff->lhead->next) {
+			huff->lhead->next->prev = tnode;
+			if (huff->lhead->next->weight == 1) {
+				tnode->head = huff->lhead->next->head;
+			} else {
+				/* this should never happen */
+				tnode->head = get_ppnode(huff);
+				*tnode->head = tnode2;
+		    }
+		} else {
+			/* this should never happen */
+			tnode->head = get_ppnode(huff);
+			*tnode->head = tnode;
+		}
+		huff->lhead->next = tnode;
+		tnode->prev = huff->lhead;
+		tnode->left = tnode->right = NULL;
+ 
+		if (huff->lhead->parent) {
+			if (huff->lhead->parent->left == huff->lhead) { /* lhead is guaranteed to by the NYT */
+				huff->lhead->parent->left = tnode2;
+			} else {
+				huff->lhead->parent->right = tnode2;
+			}
+		} else {
+			huff->tree = tnode2; 
+		}
+ 
+		tnode2->right = tnode;
+		tnode2->left = huff->lhead;
+ 
+		tnode2->parent = huff->lhead->parent;
+		huff->lhead->parent = tnode->parent = tnode2;
+     
+		huff->loc[ch] = tnode;
+ 
+		increment(huff, tnode2->parent);
+	} else {
+		increment(huff, huff->loc[ch]);
+	}
+}
+
+/* Get a symbol */
+int Huff_Receive (node_t *node, int *ch, byte *fin) {
+	while (node && node->symbol == INTERNAL_NODE) {
+		if (get_bit(fin)) {
+			node = node->right;
+		} else {
+			node = node->left;
+		}
+	}
+	if (!node) {
+		return 0;
+//		Com_Error(ERR_DROP, "Illegal tree!\n");
+	}
+	return (*ch = node->symbol);
+}
+
+/* Get a symbol */
+void Huff_offsetReceive (node_t *node, int *ch, byte *fin, int *offset) {
+	bloc = *offset;
+	while (node && node->symbol == INTERNAL_NODE) {
+		if (get_bit(fin)) {
+			node = node->right;
+		} else {
+			node = node->left;
+		}
+	}
+	if (!node) {
+		*ch = 0;
+		return;
+//		Com_Error(ERR_DROP, "Illegal tree!\n");
+	}
+	*ch = node->symbol;
+	*offset = bloc;
+}
+
+/* Send the prefix code for this node */
+static void send(node_t *node, node_t *child, byte *fout) {
+	if (node->parent) {
+		send(node->parent, node, fout);
+	}
+	if (child) {
+		if (node->right == child) {
+			add_bit(1, fout);
+		} else {
+			add_bit(0, fout);
+		}
+	}
+}
+
+/* Send a symbol */
+void Huff_transmit (huff_t *huff, int ch, byte *fout) {
+	int i;
+	if (huff->loc[ch] == NULL) { 
+		/* node_t hasn't been transmitted, send a NYT, then the symbol */
+		Huff_transmit(huff, NYT, fout);
+		for (i = 7; i >= 0; i--) {
+			add_bit((char)((ch >> i) & 0x1), fout);
+		}
+	} else {
+		send(huff->loc[ch], NULL, fout);
+	}
+}
+
+void Huff_offsetTransmit (huff_t *huff, int ch, byte *fout, int *offset) {
+	bloc = *offset;
+	send(huff->loc[ch], NULL, fout);
+	*offset = bloc;
+}
+
+#ifndef Q3_VM
+void Huff_Decompress(msg_t *mbuf, int offset) {
+	int			ch, cch, i, j, size;
+	byte		seq[65536];
+	byte*		buffer;
+	huff_t		huff;
+
+	size = mbuf->cursize - offset;
+	buffer = mbuf->data + offset;
+
+	if ( size <= 0 ) {
+		return;
+	}
+
+	Com_Memset(&huff, 0, sizeof(huff_t));
+	// Initialize the tree & list with the NYT node 
+	huff.tree = huff.lhead = huff.ltail = huff.loc[NYT] = &(huff.nodeList[huff.blocNode++]);
+	huff.tree->symbol = NYT;
+	huff.tree->weight = 0;
+	huff.lhead->next = huff.lhead->prev = NULL;
+	huff.tree->parent = huff.tree->left = huff.tree->right = NULL;
+
+	cch = buffer[0]*256 + buffer[1];
+	// don't overflow with bad messages
+	if ( cch > mbuf->maxsize - offset ) {
+		cch = mbuf->maxsize - offset;
+	}
+	bloc = 16;
+
+	for ( j = 0; j < cch; j++ ) {
+		ch = 0;
+		// don't overflow reading from the messages
+		// FIXME: would it be better to have a overflow check in get_bit ?
+		if ( (bloc >> 3) > size ) {
+			seq[j] = 0;
+			break;
+		}
+		Huff_Receive(huff.tree, &ch, buffer);				/* Get a character */
+		if ( ch == NYT ) {								/* We got a NYT, get the symbol associated with it */
+			ch = 0;
+			for ( i = 0; i < 8; i++ ) {
+				ch = (ch<<1) + get_bit(buffer);
+			}
+		}
+    
+		seq[j] = ch;									/* Write symbol */
+
+		Huff_addRef(&huff, (byte)ch);								/* Increment node */
+	}
+	mbuf->cursize = cch + offset;
+	Com_Memcpy(mbuf->data + offset, seq, cch);
+}
+
+extern 	int oldsize;
+
+void Huff_Compress(msg_t *mbuf, int offset) {
+	int			i, ch, size;
+	byte		seq[65536];
+	byte*		buffer;
+	huff_t		huff;
+
+	size = mbuf->cursize - offset;
+	buffer = mbuf->data+ + offset;
+
+	if (size<=0) {
+		return;
+	}
+
+	Com_Memset(&huff, 0, sizeof(huff_t));
+	// Add the NYT (not yet transmitted) node into the tree/list */
+	huff.tree = huff.lhead = huff.loc[NYT] =  &(huff.nodeList[huff.blocNode++]);
+	huff.tree->symbol = NYT;
+	huff.tree->weight = 0;
+	huff.lhead->next = huff.lhead->prev = NULL;
+	huff.tree->parent = huff.tree->left = huff.tree->right = NULL;
+	huff.loc[NYT] = huff.tree;
+
+	seq[0] = (size>>8);
+	seq[1] = size&0xff;
+
+	bloc = 16;
+
+	for (i=0; i<size; i++ ) {
+		ch = buffer[i];
+		Huff_transmit(&huff, ch, seq);						/* Transmit symbol */
+		Huff_addRef(&huff, (byte)ch);								/* Do update */
+	}
+
+	bloc += 8;												// next byte
+
+	mbuf->cursize = (bloc>>3) + offset;
+	Com_Memcpy(mbuf->data+offset, seq, (bloc>>3));
+}
+
+#endif /* !Q3_VM */
+
+void Huff_Init(huffman_t *huff) {
+
+	Com_Memset(&huff->compressor, 0, sizeof(huff_t));
+	Com_Memset(&huff->decompressor, 0, sizeof(huff_t));
+
+	// Initialize the tree & list with the NYT node 
+	huff->decompressor.tree = huff->decompressor.lhead = huff->decompressor.ltail = huff->decompressor.loc[NYT] = &(huff->decompressor.nodeList[huff->decompressor.blocNode++]);
+	huff->decompressor.tree->symbol = NYT;
+	huff->decompressor.tree->weight = 0;
+	huff->decompressor.lhead->next = huff->decompressor.lhead->prev = NULL;
+	huff->decompressor.tree->parent = huff->decompressor.tree->left = huff->decompressor.tree->right = NULL;
+
+	// Add the NYT (not yet transmitted) node into the tree/list */
+	huff->compressor.tree = huff->compressor.lhead = huff->compressor.loc[NYT] =  &(huff->compressor.nodeList[huff->compressor.blocNode++]);
+	huff->compressor.tree->symbol = NYT;
+	huff->compressor.tree->weight = 0;
+	huff->compressor.lhead->next = huff->compressor.lhead->prev = NULL;
+	huff->compressor.tree->parent = huff->compressor.tree->left = huff->compressor.tree->right = NULL;
+	huff->compressor.loc[NYT] = huff->compressor.tree;
+}
+

--- a/ratoa_gamecode/code/qcommon/msg.c
+++ b/ratoa_gamecode/code/qcommon/msg.c
@@ -1,0 +1,1770 @@
+/*
+===========================================================================
+Copyright (C) 1999-2005 Id Software, Inc.
+
+This file is part of Quake III Arena source code.
+
+Quake III Arena source code is free software; you can redistribute it
+and/or modify it under the terms of the GNU General Public License as
+published by the Free Software Foundation; either version 2 of the License,
+or (at your option) any later version.
+
+Quake III Arena source code is distributed in the hope that it will be
+useful, but WITHOUT ANY WARRANTY; without even the implied warranty of
+MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+GNU General Public License for more details.
+
+You should have received a copy of the GNU General Public License
+along with Foobar; if not, write to the Free Software
+Foundation, Inc., 51 Franklin St, Fifth Floor, Boston, MA  02110-1301  USA
+===========================================================================
+*/
+#include "../game/q_shared.h"
+#ifdef Q3_VM
+#include "msg_qvm.h"
+#define assert(x) ((void)0)
+#else
+#include "qcommon.h"
+#endif
+
+static huffman_t		msgHuff;
+
+static qboolean			msgInit = qfalse;
+
+int pcount[256];
+
+/*
+==============================================================================
+
+			MESSAGE IO FUNCTIONS
+
+Handles byte ordering and avoids alignment errors
+==============================================================================
+*/
+
+int oldsize = 0;
+
+void MSG_initHuffman();
+
+void MSG_Init( msg_t *buf, byte *data, int length ) {
+	if (!msgInit) {
+		MSG_initHuffman();
+	}
+	Com_Memset (buf, 0, sizeof(*buf));
+	buf->data = data;
+	buf->maxsize = length;
+}
+
+void MSG_InitOOB( msg_t *buf, byte *data, int length ) {
+	if (!msgInit) {
+		MSG_initHuffman();
+	}
+	Com_Memset (buf, 0, sizeof(*buf));
+	buf->data = data;
+	buf->maxsize = length;
+	buf->oob = qtrue;
+}
+
+void MSG_Clear( msg_t *buf ) {
+	buf->cursize = 0;
+	buf->overflowed = qfalse;
+	buf->bit = 0;					//<- in bits
+}
+
+
+void MSG_Bitstream( msg_t *buf ) {
+	buf->oob = qfalse;
+}
+
+void MSG_BeginReading( msg_t *msg ) {
+	msg->readcount = 0;
+	msg->bit = 0;
+	msg->oob = qfalse;
+}
+
+void MSG_BeginReadingOOB( msg_t *msg ) {
+	msg->readcount = 0;
+	msg->bit = 0;
+	msg->oob = qtrue;
+}
+
+void MSG_Copy(msg_t *buf, byte *data, int length, msg_t *src)
+{
+	if (length<src->cursize) {
+		Com_Error( ERR_DROP, "MSG_Copy: can't copy into a smaller msg_t buffer");
+	}
+	Com_Memcpy(buf, src, sizeof(msg_t));
+	buf->data = data;
+	Com_Memcpy(buf->data, src->data, src->cursize);
+}
+
+/*
+=============================================================================
+
+bit functions
+  
+=============================================================================
+*/
+
+#ifndef Q3_VM
+int	overflows;
+
+// negative bit values include signs
+void MSG_WriteBits( msg_t *msg, int value, int bits ) {
+	int	i;
+//	FILE*	fp;
+
+	oldsize += bits;
+
+	// this isn't an exact overflow check, but close enough
+	if ( msg->maxsize - msg->cursize < 4 ) {
+		msg->overflowed = qtrue;
+		return;
+	}
+
+	if ( bits == 0 || bits < -31 || bits > 32 ) {
+		Com_Error( ERR_DROP, "MSG_WriteBits: bad bits %i", bits );
+	}
+
+	// check for overflows
+	if ( bits != 32 ) {
+		if ( bits > 0 ) {
+			if ( value > ( ( 1 << bits ) - 1 ) || value < 0 ) {
+				overflows++;
+			}
+		} else {
+			int	r;
+
+			r = 1 << (bits-1);
+
+			if ( value >  r - 1 || value < -r ) {
+				overflows++;
+			}
+		}
+	}
+	if ( bits < 0 ) {
+		bits = -bits;
+	}
+	if (msg->oob) {
+		if (bits==8) {
+			msg->data[msg->cursize] = value;
+			msg->cursize += 1;
+			msg->bit += 8;
+		} else if (bits==16) {
+			unsigned short *sp = (unsigned short *)&msg->data[msg->cursize];
+			*sp = LittleShort(value);
+			msg->cursize += 2;
+			msg->bit += 16;
+		} else if (bits==32) {
+			unsigned int *ip = (unsigned int *)&msg->data[msg->cursize];
+			*ip = LittleLong(value);
+			msg->cursize += 4;
+			msg->bit += 8;
+		} else {
+			Com_Error(ERR_DROP, "can't read %d bits\n", bits);
+		}
+	} else {
+//		fp = fopen("c:\\netchan.bin", "a");
+		value &= (0xffffffff>>(32-bits));
+		if (bits&7) {
+			int nbits;
+			nbits = bits&7;
+			for(i=0;i<nbits;i++) {
+				Huff_putBit((value&1), msg->data, &msg->bit);
+				value = (value>>1);
+			}
+			bits = bits - nbits;
+		}
+		if (bits) {
+			for(i=0;i<bits;i+=8) {
+//				fwrite(bp, 1, 1, fp);
+				Huff_offsetTransmit (&msgHuff.compressor, (value&0xff), msg->data, &msg->bit);
+				value = (value>>8);
+			}
+		}
+		msg->cursize = (msg->bit>>3)+1;
+//		fclose(fp);
+	}
+}
+
+#endif /* !Q3_VM */
+
+int MSG_ReadBits( msg_t *msg, int bits ) {
+	int			value;
+	int			get;
+	qboolean	sgn;
+	int			i, nbits;
+//	FILE*	fp;
+
+	value = 0;
+
+	if ( bits < 0 ) {
+		bits = -bits;
+		sgn = qtrue;
+	} else {
+		sgn = qfalse;
+	}
+
+	if (msg->oob) {
+		if (bits==8) {
+			value = msg->data[msg->readcount];
+			msg->readcount += 1;
+			msg->bit += 8;
+		} else if (bits==16) {
+			unsigned short *sp = (unsigned short *)&msg->data[msg->readcount];
+			value = LittleShort(*sp);
+			msg->readcount += 2;
+			msg->bit += 16;
+		} else if (bits==32) {
+			unsigned int *ip = (unsigned int *)&msg->data[msg->readcount];
+			value = LittleLong(*ip);
+			msg->readcount += 4;
+			msg->bit += 32;
+		} else {
+			Com_Error(ERR_DROP, "can't read %d bits\n", bits);
+		}
+	} else {
+		nbits = 0;
+		if (bits&7) {
+			nbits = bits&7;
+			for(i=0;i<nbits;i++) {
+				value |= (Huff_getBit(msg->data, &msg->bit)<<i);
+			}
+			bits = bits - nbits;
+		}
+		if (bits) {
+//			fp = fopen("c:\\netchan.bin", "a");
+			for(i=0;i<bits;i+=8) {
+				Huff_offsetReceive (msgHuff.decompressor.tree, &get, msg->data, &msg->bit);
+//				fwrite(&get, 1, 1, fp);
+				value |= (get<<(i+nbits));
+			}
+//			fclose(fp);
+		}
+		msg->readcount = (msg->bit>>3)+1;
+	}
+	if ( sgn ) {
+		if ( value & ( 1 << ( bits - 1 ) ) ) {
+			value |= -1 ^ ( ( 1 << bits ) - 1 );
+		}
+	}
+
+	return value;
+}
+
+
+
+//================================================================================
+
+#ifndef Q3_VM
+//
+// writing functions
+//
+
+void MSG_WriteChar( msg_t *sb, int c ) {
+#ifdef PARANOID
+	if (c < -128 || c > 127)
+		Com_Error (ERR_FATAL, "MSG_WriteChar: range error");
+#endif
+
+	MSG_WriteBits( sb, c, 8 );
+}
+
+void MSG_WriteByte( msg_t *sb, int c ) {
+#ifdef PARANOID
+	if (c < 0 || c > 255)
+		Com_Error (ERR_FATAL, "MSG_WriteByte: range error");
+#endif
+
+	MSG_WriteBits( sb, c, 8 );
+}
+
+void MSG_WriteData( msg_t *buf, const void *data, int length ) {
+	int i;
+	for(i=0;i<length;i++) {
+		MSG_WriteByte(buf, ((byte *)data)[i]);
+	}
+}
+
+void MSG_WriteShort( msg_t *sb, int c ) {
+#ifdef PARANOID
+	if (c < ((short)0x8000) || c > (short)0x7fff)
+		Com_Error (ERR_FATAL, "MSG_WriteShort: range error");
+#endif
+
+	MSG_WriteBits( sb, c, 16 );
+}
+
+void MSG_WriteLong( msg_t *sb, int c ) {
+	MSG_WriteBits( sb, c, 32 );
+}
+
+void MSG_WriteFloat( msg_t *sb, float f ) {
+	union {
+		float	f;
+		int	l;
+	} dat;
+	
+	dat.f = f;
+	MSG_WriteBits( sb, dat.l, 32 );
+}
+
+void MSG_WriteString( msg_t *sb, const char *s ) {
+	if ( !s ) {
+		MSG_WriteData (sb, "", 1);
+	} else {
+		int		l,i;
+		char	string[MAX_STRING_CHARS];
+
+		l = strlen( s );
+		if ( l >= MAX_STRING_CHARS ) {
+			Com_Printf( "MSG_WriteString: MAX_STRING_CHARS" );
+			MSG_WriteData (sb, "", 1);
+			return;
+		}
+		Q_strncpyz( string, s, sizeof( string ) );
+
+		// get rid of 0xff chars, because old clients don't like them
+		for ( i = 0 ; i < l ; i++ ) {
+			if ( ((byte *)string)[i] > 127 ) {
+				string[i] = '.';
+			}
+		}
+
+		MSG_WriteData (sb, string, l+1);
+	}
+}
+
+void MSG_WriteBigString( msg_t *sb, const char *s ) {
+	if ( !s ) {
+		MSG_WriteData (sb, "", 1);
+	} else {
+		int		l,i;
+		char	string[BIG_INFO_STRING];
+
+		l = strlen( s );
+		if ( l >= BIG_INFO_STRING ) {
+			Com_Printf( "MSG_WriteString: BIG_INFO_STRING" );
+			MSG_WriteData (sb, "", 1);
+			return;
+		}
+		Q_strncpyz( string, s, sizeof( string ) );
+
+		// get rid of 0xff chars, because old clients don't like them
+		for ( i = 0 ; i < l ; i++ ) {
+			if ( ((byte *)string)[i] > 127 ) {
+				string[i] = '.';
+			}
+		}
+
+		MSG_WriteData (sb, string, l+1);
+	}
+}
+
+void MSG_WriteAngle( msg_t *sb, float f ) {
+	MSG_WriteByte (sb, (int)(f*256/360) & 255);
+}
+
+void MSG_WriteAngle16( msg_t *sb, float f ) {
+	MSG_WriteShort (sb, ANGLE2SHORT(f));
+}
+
+#endif /* !Q3_VM */
+
+//============================================================
+
+//
+// reading functions
+//
+
+// returns -1 if no more characters are available
+int MSG_ReadChar (msg_t *msg ) {
+	int	c;
+	
+	c = (signed char)MSG_ReadBits( msg, 8 );
+	if ( msg->readcount > msg->cursize ) {
+		c = -1;
+	}	
+	
+	return c;
+}
+
+int MSG_ReadByte( msg_t *msg ) {
+	int	c;
+	
+	c = (unsigned char)MSG_ReadBits( msg, 8 );
+	if ( msg->readcount > msg->cursize ) {
+		c = -1;
+	}	
+	return c;
+}
+
+int MSG_ReadShort( msg_t *msg ) {
+	int	c;
+	
+	c = (short)MSG_ReadBits( msg, 16 );
+	if ( msg->readcount > msg->cursize ) {
+		c = -1;
+	}	
+
+	return c;
+}
+
+int MSG_ReadLong( msg_t *msg ) {
+	int	c;
+	
+	c = MSG_ReadBits( msg, 32 );
+	if ( msg->readcount > msg->cursize ) {
+		c = -1;
+	}	
+	
+	return c;
+}
+
+float MSG_ReadFloat( msg_t *msg ) {
+	union {
+		byte	b[4];
+		float	f;
+		int	l;
+	} dat;
+	
+	dat.l = MSG_ReadBits( msg, 32 );
+	if ( msg->readcount > msg->cursize ) {
+		dat.f = -1;
+	}	
+	
+	return dat.f;	
+}
+
+char *MSG_ReadString( msg_t *msg ) {
+	static char	string[MAX_STRING_CHARS];
+	int		l,c;
+	
+	l = 0;
+	do {
+		c = MSG_ReadByte(msg);		// use ReadByte so -1 is out of bounds
+		if ( c == -1 || c == 0 ) {
+			break;
+		}
+		// translate all fmt spec to avoid crash bugs
+		if ( c == '%' ) {
+			c = '.';
+		}
+		// don't allow higher ascii values
+		if ( c > 127 ) {
+			c = '.';
+		}
+
+		string[l] = c;
+		l++;
+	} while (l < sizeof(string)-1);
+	
+	string[l] = 0;
+	
+	return string;
+}
+
+char *MSG_ReadBigString( msg_t *msg ) {
+	static char	string[BIG_INFO_STRING];
+	int		l,c;
+	
+	l = 0;
+	do {
+		c = MSG_ReadByte(msg);		// use ReadByte so -1 is out of bounds
+		if ( c == -1 || c == 0 ) {
+			break;
+		}
+		// translate all fmt spec to avoid crash bugs
+		if ( c == '%' ) {
+			c = '.';
+		}
+
+		string[l] = c;
+		l++;
+	} while (l < sizeof(string)-1);
+	
+	string[l] = 0;
+	
+	return string;
+}
+
+char *MSG_ReadStringLine( msg_t *msg ) {
+	static char	string[MAX_STRING_CHARS];
+	int		l,c;
+
+	l = 0;
+	do {
+		c = MSG_ReadByte(msg);		// use ReadByte so -1 is out of bounds
+		if (c == -1 || c == 0 || c == '\n') {
+			break;
+		}
+		// translate all fmt spec to avoid crash bugs
+		if ( c == '%' ) {
+			c = '.';
+		}
+		string[l] = c;
+		l++;
+	} while (l < sizeof(string)-1);
+	
+	string[l] = 0;
+	
+	return string;
+}
+
+float MSG_ReadAngle16( msg_t *msg ) {
+	return SHORT2ANGLE(MSG_ReadShort(msg));
+}
+
+void MSG_ReadData( msg_t *msg, void *data, int len ) {
+	int		i;
+
+	for (i=0 ; i<len ; i++) {
+		((byte *)data)[i] = MSG_ReadByte (msg);
+	}
+}
+
+
+#ifndef Q3_VM
+/*
+=============================================================================
+
+delta functions
+  
+=============================================================================
+*/
+
+extern cvar_t *cl_shownet;
+
+#define	LOG(x) if( cl_shownet->integer == 4 ) { Com_Printf("%s ", x ); };
+
+void MSG_WriteDelta( msg_t *msg, int oldV, int newV, int bits ) {
+	if ( oldV == newV ) {
+		MSG_WriteBits( msg, 0, 1 );
+		return;
+	}
+	MSG_WriteBits( msg, 1, 1 );
+	MSG_WriteBits( msg, newV, bits );
+}
+
+int	MSG_ReadDelta( msg_t *msg, int oldV, int bits ) {
+	if ( MSG_ReadBits( msg, 1 ) ) {
+		return MSG_ReadBits( msg, bits );
+	}
+	return oldV;
+}
+
+void MSG_WriteDeltaFloat( msg_t *msg, float oldV, float newV ) {
+	if ( oldV == newV ) {
+		MSG_WriteBits( msg, 0, 1 );
+		return;
+	}
+	MSG_WriteBits( msg, 1, 1 );
+	MSG_WriteBits( msg, *(int *)&newV, 32 );
+}
+
+float MSG_ReadDeltaFloat( msg_t *msg, float oldV ) {
+	if ( MSG_ReadBits( msg, 1 ) ) {
+		float	newV;
+
+		*(int *)&newV = MSG_ReadBits( msg, 32 );
+		return newV;
+	}
+	return oldV;
+}
+
+/*
+=============================================================================
+
+delta functions with keys
+  
+=============================================================================
+*/
+
+int kbitmask[32] = {
+	0x00000001, 0x00000003, 0x00000007, 0x0000000F,
+	0x0000001F,	0x0000003F,	0x0000007F,	0x000000FF,
+	0x000001FF,	0x000003FF,	0x000007FF,	0x00000FFF,
+	0x00001FFF,	0x00003FFF,	0x00007FFF,	0x0000FFFF,
+	0x0001FFFF,	0x0003FFFF,	0x0007FFFF,	0x000FFFFF,
+	0x001FFFFf,	0x003FFFFF,	0x007FFFFF,	0x00FFFFFF,
+	0x01FFFFFF,	0x03FFFFFF,	0x07FFFFFF,	0x0FFFFFFF,
+	0x1FFFFFFF,	0x3FFFFFFF,	0x7FFFFFFF,	0xFFFFFFFF,
+};
+
+void MSG_WriteDeltaKey( msg_t *msg, int key, int oldV, int newV, int bits ) {
+	if ( oldV == newV ) {
+		MSG_WriteBits( msg, 0, 1 );
+		return;
+	}
+	MSG_WriteBits( msg, 1, 1 );
+	MSG_WriteBits( msg, newV ^ key, bits );
+}
+
+int	MSG_ReadDeltaKey( msg_t *msg, int key, int oldV, int bits ) {
+	if ( MSG_ReadBits( msg, 1 ) ) {
+		return MSG_ReadBits( msg, bits ) ^ (key & kbitmask[bits]);
+	}
+	return oldV;
+}
+
+void MSG_WriteDeltaKeyFloat( msg_t *msg, int key, float oldV, float newV ) {
+	if ( oldV == newV ) {
+		MSG_WriteBits( msg, 0, 1 );
+		return;
+	}
+	MSG_WriteBits( msg, 1, 1 );
+	MSG_WriteBits( msg, (*(int *)&newV) ^ key, 32 );
+}
+
+float MSG_ReadDeltaKeyFloat( msg_t *msg, int key, float oldV ) {
+	if ( MSG_ReadBits( msg, 1 ) ) {
+		float	newV;
+
+		*(int *)&newV = MSG_ReadBits( msg, 32 ) ^ key;
+		return newV;
+	}
+	return oldV;
+}
+
+
+/*
+============================================================================
+
+usercmd_t communication
+
+============================================================================
+*/
+
+// ms is allways sent, the others are optional
+#define	CM_ANGLE1 	(1<<0)
+#define	CM_ANGLE2 	(1<<1)
+#define	CM_ANGLE3 	(1<<2)
+#define	CM_FORWARD	(1<<3)
+#define	CM_SIDE		(1<<4)
+#define	CM_UP		(1<<5)
+#define	CM_BUTTONS	(1<<6)
+#define CM_WEAPON	(1<<7)
+
+/*
+=====================
+MSG_WriteDeltaUsercmd
+=====================
+*/
+void MSG_WriteDeltaUsercmd( msg_t *msg, usercmd_t *from, usercmd_t *to ) {
+	if ( to->serverTime - from->serverTime < 256 ) {
+		MSG_WriteBits( msg, 1, 1 );
+		MSG_WriteBits( msg, to->serverTime - from->serverTime, 8 );
+	} else {
+		MSG_WriteBits( msg, 0, 1 );
+		MSG_WriteBits( msg, to->serverTime, 32 );
+	}
+	MSG_WriteDelta( msg, from->angles[0], to->angles[0], 16 );
+	MSG_WriteDelta( msg, from->angles[1], to->angles[1], 16 );
+	MSG_WriteDelta( msg, from->angles[2], to->angles[2], 16 );
+	MSG_WriteDelta( msg, from->forwardmove, to->forwardmove, 8 );
+	MSG_WriteDelta( msg, from->rightmove, to->rightmove, 8 );
+	MSG_WriteDelta( msg, from->upmove, to->upmove, 8 );
+	MSG_WriteDelta( msg, from->buttons, to->buttons, 16 );
+	MSG_WriteDelta( msg, from->weapon, to->weapon, 8 );
+}
+
+
+/*
+=====================
+MSG_ReadDeltaUsercmd
+=====================
+*/
+void MSG_ReadDeltaUsercmd( msg_t *msg, usercmd_t *from, usercmd_t *to ) {
+	if ( MSG_ReadBits( msg, 1 ) ) {
+		to->serverTime = from->serverTime + MSG_ReadBits( msg, 8 );
+	} else {
+		to->serverTime = MSG_ReadBits( msg, 32 );
+	}
+	to->angles[0] = MSG_ReadDelta( msg, from->angles[0], 16);
+	to->angles[1] = MSG_ReadDelta( msg, from->angles[1], 16);
+	to->angles[2] = MSG_ReadDelta( msg, from->angles[2], 16);
+	to->forwardmove = MSG_ReadDelta( msg, from->forwardmove, 8);
+	to->rightmove = MSG_ReadDelta( msg, from->rightmove, 8);
+	to->upmove = MSG_ReadDelta( msg, from->upmove, 8);
+	to->buttons = MSG_ReadDelta( msg, from->buttons, 16);
+	to->weapon = MSG_ReadDelta( msg, from->weapon, 8);
+}
+
+/*
+=====================
+MSG_WriteDeltaUsercmd
+=====================
+*/
+void MSG_WriteDeltaUsercmdKey( msg_t *msg, int key, usercmd_t *from, usercmd_t *to ) {
+	if ( to->serverTime - from->serverTime < 256 ) {
+		MSG_WriteBits( msg, 1, 1 );
+		MSG_WriteBits( msg, to->serverTime - from->serverTime, 8 );
+	} else {
+		MSG_WriteBits( msg, 0, 1 );
+		MSG_WriteBits( msg, to->serverTime, 32 );
+	}
+	if (from->angles[0] == to->angles[0] &&
+		from->angles[1] == to->angles[1] &&
+		from->angles[2] == to->angles[2] &&
+		from->forwardmove == to->forwardmove &&
+		from->rightmove == to->rightmove &&
+		from->upmove == to->upmove &&
+		from->buttons == to->buttons &&
+		from->weapon == to->weapon) {
+			MSG_WriteBits( msg, 0, 1 );				// no change
+			oldsize += 7;
+			return;
+	}
+	key ^= to->serverTime;
+	MSG_WriteBits( msg, 1, 1 );
+	MSG_WriteDeltaKey( msg, key, from->angles[0], to->angles[0], 16 );
+	MSG_WriteDeltaKey( msg, key, from->angles[1], to->angles[1], 16 );
+	MSG_WriteDeltaKey( msg, key, from->angles[2], to->angles[2], 16 );
+	MSG_WriteDeltaKey( msg, key, from->forwardmove, to->forwardmove, 8 );
+	MSG_WriteDeltaKey( msg, key, from->rightmove, to->rightmove, 8 );
+	MSG_WriteDeltaKey( msg, key, from->upmove, to->upmove, 8 );
+	MSG_WriteDeltaKey( msg, key, from->buttons, to->buttons, 16 );
+	MSG_WriteDeltaKey( msg, key, from->weapon, to->weapon, 8 );
+}
+
+
+/*
+=====================
+MSG_ReadDeltaUsercmd
+=====================
+*/
+void MSG_ReadDeltaUsercmdKey( msg_t *msg, int key, usercmd_t *from, usercmd_t *to ) {
+	if ( MSG_ReadBits( msg, 1 ) ) {
+		to->serverTime = from->serverTime + MSG_ReadBits( msg, 8 );
+	} else {
+		to->serverTime = MSG_ReadBits( msg, 32 );
+	}
+	if ( MSG_ReadBits( msg, 1 ) ) {
+		key ^= to->serverTime;
+		to->angles[0] = MSG_ReadDeltaKey( msg, key, from->angles[0], 16);
+		to->angles[1] = MSG_ReadDeltaKey( msg, key, from->angles[1], 16);
+		to->angles[2] = MSG_ReadDeltaKey( msg, key, from->angles[2], 16);
+		to->forwardmove = MSG_ReadDeltaKey( msg, key, from->forwardmove, 8);
+		to->rightmove = MSG_ReadDeltaKey( msg, key, from->rightmove, 8);
+		to->upmove = MSG_ReadDeltaKey( msg, key, from->upmove, 8);
+		to->buttons = MSG_ReadDeltaKey( msg, key, from->buttons, 16);
+		to->weapon = MSG_ReadDeltaKey( msg, key, from->weapon, 8);
+	} else {
+		to->angles[0] = from->angles[0];
+		to->angles[1] = from->angles[1];
+		to->angles[2] = from->angles[2];
+		to->forwardmove = from->forwardmove;
+		to->rightmove = from->rightmove;
+		to->upmove = from->upmove;
+		to->buttons = from->buttons;
+		to->weapon = from->weapon;
+	}
+}
+
+/*
+=============================================================================
+
+entityState_t communication
+  
+=============================================================================
+*/
+
+/*
+=================
+MSG_ReportChangeVectors_f
+
+Prints out a table from the current statistics for copying to code
+=================
+*/
+void MSG_ReportChangeVectors_f( void ) {
+	int i;
+	for(i=0;i<256;i++) {
+		if (pcount[i]) {
+			Com_Printf("%d used %d\n", i, pcount[i]);
+		}
+	}
+}
+
+typedef struct {
+	char	*name;
+	int		offset;
+	int		bits;		// 0 = float
+} netField_t;
+
+// using the stringizing operator to save typing...
+#define	NETF(x) #x,(int)&((entityState_t*)0)->x
+
+netField_t	entityStateFields[] = 
+{
+{ NETF(pos.trTime), 32 },
+{ NETF(pos.trBase[0]), 0 },
+{ NETF(pos.trBase[1]), 0 },
+{ NETF(pos.trDelta[0]), 0 },
+{ NETF(pos.trDelta[1]), 0 },
+{ NETF(pos.trBase[2]), 0 },
+{ NETF(apos.trBase[1]), 0 },
+{ NETF(pos.trDelta[2]), 0 },
+{ NETF(apos.trBase[0]), 0 },
+{ NETF(event), 10 },
+{ NETF(angles2[1]), 0 },
+{ NETF(eType), 8 },
+{ NETF(torsoAnim), 8 },
+{ NETF(eventParm), 8 },
+{ NETF(legsAnim), 8 },
+{ NETF(groundEntityNum), GENTITYNUM_BITS },
+{ NETF(pos.trType), 8 },
+{ NETF(eFlags), 19 },
+{ NETF(otherEntityNum), GENTITYNUM_BITS },
+{ NETF(weapon), 8 },
+{ NETF(clientNum), 8 },
+{ NETF(angles[1]), 0 },
+{ NETF(pos.trDuration), 32 },
+{ NETF(apos.trType), 8 },
+{ NETF(origin[0]), 0 },
+{ NETF(origin[1]), 0 },
+{ NETF(origin[2]), 0 },
+{ NETF(solid), 24 },
+{ NETF(powerups), 16 },
+{ NETF(modelindex), 8 },
+{ NETF(otherEntityNum2), GENTITYNUM_BITS },
+{ NETF(loopSound), 8 },
+{ NETF(generic1), 8 },
+{ NETF(origin2[2]), 0 },
+{ NETF(origin2[0]), 0 },
+{ NETF(origin2[1]), 0 },
+{ NETF(modelindex2), 8 },
+{ NETF(angles[0]), 0 },
+{ NETF(time), 32 },
+{ NETF(apos.trTime), 32 },
+{ NETF(apos.trDuration), 32 },
+{ NETF(apos.trBase[2]), 0 },
+{ NETF(apos.trDelta[0]), 0 },
+{ NETF(apos.trDelta[1]), 0 },
+{ NETF(apos.trDelta[2]), 0 },
+{ NETF(time2), 32 },
+{ NETF(angles[2]), 0 },
+{ NETF(angles2[0]), 0 },
+{ NETF(angles2[2]), 0 },
+{ NETF(constantLight), 32 },
+{ NETF(frame), 16 }
+};
+
+
+// if (int)f == f and (int)f + ( 1<<(FLOAT_INT_BITS-1) ) < ( 1 << FLOAT_INT_BITS )
+// the float will be sent with FLOAT_INT_BITS, otherwise all 32 bits will be sent
+#define	FLOAT_INT_BITS	13
+#define	FLOAT_INT_BIAS	(1<<(FLOAT_INT_BITS-1))
+
+/*
+==================
+MSG_WriteDeltaEntity
+
+Writes part of a packetentities message, including the entity number.
+Can delta from either a baseline or a previous packet_entity
+If to is NULL, a remove entity update will be sent
+If force is not set, then nothing at all will be generated if the entity is
+identical, under the assumption that the in-order delta code will catch it.
+==================
+*/
+void MSG_WriteDeltaEntity( msg_t *msg, struct entityState_s *from, struct entityState_s *to, 
+						   qboolean force ) {
+	int			i, lc;
+	int			numFields;
+	netField_t	*field;
+	int			trunc;
+	float		fullFloat;
+	int			*fromF, *toF;
+
+	numFields = sizeof(entityStateFields)/sizeof(entityStateFields[0]);
+
+	// all fields should be 32 bits to avoid any compiler packing issues
+	// the "number" field is not part of the field list
+	// if this assert fails, someone added a field to the entityState_t
+	// struct without updating the message fields
+	assert( numFields + 1 == sizeof( *from )/4 );
+
+	// a NULL to is a delta remove message
+	if ( to == NULL ) {
+		if ( from == NULL ) {
+			return;
+		}
+		MSG_WriteBits( msg, from->number, GENTITYNUM_BITS );
+		MSG_WriteBits( msg, 1, 1 );
+		return;
+	}
+
+	if ( to->number < 0 || to->number >= MAX_GENTITIES ) {
+		Com_Error (ERR_FATAL, "MSG_WriteDeltaEntity: Bad entity number: %i", to->number );
+	}
+
+	lc = 0;
+	// build the change vector as bytes so it is endien independent
+	for ( i = 0, field = entityStateFields ; i < numFields ; i++, field++ ) {
+		fromF = (int *)( (byte *)from + field->offset );
+		toF = (int *)( (byte *)to + field->offset );
+		if ( *fromF != *toF ) {
+			lc = i+1;
+		}
+	}
+
+	if ( lc == 0 ) {
+		// nothing at all changed
+		if ( !force ) {
+			return;		// nothing at all
+		}
+		// write two bits for no change
+		MSG_WriteBits( msg, to->number, GENTITYNUM_BITS );
+		MSG_WriteBits( msg, 0, 1 );		// not removed
+		MSG_WriteBits( msg, 0, 1 );		// no delta
+		return;
+	}
+
+	MSG_WriteBits( msg, to->number, GENTITYNUM_BITS );
+	MSG_WriteBits( msg, 0, 1 );			// not removed
+	MSG_WriteBits( msg, 1, 1 );			// we have a delta
+
+	MSG_WriteByte( msg, lc );	// # of changes
+
+	oldsize += numFields;
+
+	for ( i = 0, field = entityStateFields ; i < lc ; i++, field++ ) {
+		fromF = (int *)( (byte *)from + field->offset );
+		toF = (int *)( (byte *)to + field->offset );
+
+		if ( *fromF == *toF ) {
+			MSG_WriteBits( msg, 0, 1 );	// no change
+			continue;
+		}
+
+		MSG_WriteBits( msg, 1, 1 );	// changed
+
+		if ( field->bits == 0 ) {
+			// float
+			fullFloat = *(float *)toF;
+			trunc = (int)fullFloat;
+
+			if (fullFloat == 0.0f) {
+					MSG_WriteBits( msg, 0, 1 );
+					oldsize += FLOAT_INT_BITS;
+			} else {
+				MSG_WriteBits( msg, 1, 1 );
+				if ( trunc == fullFloat && trunc + FLOAT_INT_BIAS >= 0 && 
+					trunc + FLOAT_INT_BIAS < ( 1 << FLOAT_INT_BITS ) ) {
+					// send as small integer
+					MSG_WriteBits( msg, 0, 1 );
+					MSG_WriteBits( msg, trunc + FLOAT_INT_BIAS, FLOAT_INT_BITS );
+				} else {
+					// send as full floating point value
+					MSG_WriteBits( msg, 1, 1 );
+					MSG_WriteBits( msg, *toF, 32 );
+				}
+			}
+		} else {
+			if (*toF == 0) {
+				MSG_WriteBits( msg, 0, 1 );
+			} else {
+				MSG_WriteBits( msg, 1, 1 );
+				// integer
+				MSG_WriteBits( msg, *toF, field->bits );
+			}
+		}
+	}
+}
+
+/*
+==================
+MSG_ReadDeltaEntity
+
+The entity number has already been read from the message, which
+is how the from state is identified.
+
+If the delta removes the entity, entityState_t->number will be set to MAX_GENTITIES-1
+
+Can go from either a baseline or a previous packet_entity
+==================
+*/
+extern	cvar_t	*cl_shownet;
+
+void MSG_ReadDeltaEntity( msg_t *msg, entityState_t *from, entityState_t *to, 
+						 int number) {
+	int			i, lc;
+	int			numFields;
+	netField_t	*field;
+	int			*fromF, *toF;
+	int			print;
+	int			trunc;
+	int			startBit, endBit;
+
+	if ( number < 0 || number >= MAX_GENTITIES) {
+		Com_Error( ERR_DROP, "Bad delta entity number: %i", number );
+	}
+
+	if ( msg->bit == 0 ) {
+		startBit = msg->readcount * 8 - GENTITYNUM_BITS;
+	} else {
+		startBit = ( msg->readcount - 1 ) * 8 + msg->bit - GENTITYNUM_BITS;
+	}
+
+	// check for a remove
+	if ( MSG_ReadBits( msg, 1 ) == 1 ) {
+		Com_Memset( to, 0, sizeof( *to ) );	
+		to->number = MAX_GENTITIES - 1;
+		if ( cl_shownet->integer >= 2 || cl_shownet->integer == -1 ) {
+			Com_Printf( "%3i: #%-3i remove\n", msg->readcount, number );
+		}
+		return;
+	}
+
+	// check for no delta
+	if ( MSG_ReadBits( msg, 1 ) == 0 ) {
+		*to = *from;
+		to->number = number;
+		return;
+	}
+
+	numFields = sizeof(entityStateFields)/sizeof(entityStateFields[0]);
+	lc = MSG_ReadByte(msg);
+
+	// shownet 2/3 will interleave with other printed info, -1 will
+	// just print the delta records`
+	if ( cl_shownet->integer >= 2 || cl_shownet->integer == -1 ) {
+		print = 1;
+		Com_Printf( "%3i: #%-3i ", msg->readcount, to->number );
+	} else {
+		print = 0;
+	}
+
+	to->number = number;
+
+	for ( i = 0, field = entityStateFields ; i < lc ; i++, field++ ) {
+		fromF = (int *)( (byte *)from + field->offset );
+		toF = (int *)( (byte *)to + field->offset );
+
+		if ( ! MSG_ReadBits( msg, 1 ) ) {
+			// no change
+			*toF = *fromF;
+		} else {
+			if ( field->bits == 0 ) {
+				// float
+				if ( MSG_ReadBits( msg, 1 ) == 0 ) {
+						*(float *)toF = 0.0f; 
+				} else {
+					if ( MSG_ReadBits( msg, 1 ) == 0 ) {
+						// integral float
+						trunc = MSG_ReadBits( msg, FLOAT_INT_BITS );
+						// bias to allow equal parts positive and negative
+						trunc -= FLOAT_INT_BIAS;
+						*(float *)toF = trunc; 
+						if ( print ) {
+							Com_Printf( "%s:%i ", field->name, trunc );
+						}
+					} else {
+						// full floating point value
+						*toF = MSG_ReadBits( msg, 32 );
+						if ( print ) {
+							Com_Printf( "%s:%f ", field->name, *(float *)toF );
+						}
+					}
+				}
+			} else {
+				if ( MSG_ReadBits( msg, 1 ) == 0 ) {
+					*toF = 0;
+				} else {
+					// integer
+					*toF = MSG_ReadBits( msg, field->bits );
+					if ( print ) {
+						Com_Printf( "%s:%i ", field->name, *toF );
+					}
+				}
+			}
+//			pcount[i]++;
+		}
+	}
+	for ( i = lc, field = &entityStateFields[lc] ; i < numFields ; i++, field++ ) {
+		fromF = (int *)( (byte *)from + field->offset );
+		toF = (int *)( (byte *)to + field->offset );
+		// no change
+		*toF = *fromF;
+	}
+
+	if ( print ) {
+		if ( msg->bit == 0 ) {
+			endBit = msg->readcount * 8 - GENTITYNUM_BITS;
+		} else {
+			endBit = ( msg->readcount - 1 ) * 8 + msg->bit - GENTITYNUM_BITS;
+		}
+		Com_Printf( " (%i bits)\n", endBit - startBit  );
+	}
+}
+
+
+/*
+============================================================================
+
+plyer_state_t communication
+
+============================================================================
+*/
+
+// using the stringizing operator to save typing...
+#define	PSF(x) #x,(int)&((playerState_t*)0)->x
+
+netField_t	playerStateFields[] = 
+{
+{ PSF(commandTime), 32 },				
+{ PSF(origin[0]), 0 },
+{ PSF(origin[1]), 0 },
+{ PSF(bobCycle), 8 },
+{ PSF(velocity[0]), 0 },
+{ PSF(velocity[1]), 0 },
+{ PSF(viewangles[1]), 0 },
+{ PSF(viewangles[0]), 0 },
+{ PSF(weaponTime), -16 },
+{ PSF(origin[2]), 0 },
+{ PSF(velocity[2]), 0 },
+{ PSF(legsTimer), 8 },
+{ PSF(pm_time), -16 },
+{ PSF(eventSequence), 16 },
+{ PSF(torsoAnim), 8 },
+{ PSF(movementDir), 4 },
+{ PSF(events[0]), 8 },
+{ PSF(legsAnim), 8 },
+{ PSF(events[1]), 8 },
+{ PSF(pm_flags), 16 },
+{ PSF(groundEntityNum), GENTITYNUM_BITS },
+{ PSF(weaponstate), 4 },
+{ PSF(eFlags), 16 },
+{ PSF(externalEvent), 10 },
+{ PSF(gravity), 16 },
+{ PSF(speed), 16 },
+{ PSF(delta_angles[1]), 16 },
+{ PSF(externalEventParm), 8 },
+{ PSF(viewheight), -8 },
+{ PSF(damageEvent), 8 },
+{ PSF(damageYaw), 8 },
+{ PSF(damagePitch), 8 },
+{ PSF(damageCount), 8 },
+{ PSF(generic1), 8 },
+{ PSF(pm_type), 8 },					
+{ PSF(delta_angles[0]), 16 },
+{ PSF(delta_angles[2]), 16 },
+{ PSF(torsoTimer), 12 },
+{ PSF(eventParms[0]), 8 },
+{ PSF(eventParms[1]), 8 },
+{ PSF(clientNum), 8 },
+{ PSF(weapon), 5 },
+{ PSF(viewangles[2]), 0 },
+{ PSF(grapplePoint[0]), 0 },
+{ PSF(grapplePoint[1]), 0 },
+{ PSF(grapplePoint[2]), 0 },
+{ PSF(jumppad_ent), 10 },
+{ PSF(loopSound), 16 }
+};
+
+/*
+=============
+MSG_WriteDeltaPlayerstate
+
+=============
+*/
+void MSG_WriteDeltaPlayerstate( msg_t *msg, struct playerState_s *from, struct playerState_s *to ) {
+	int				i;
+	playerState_t	dummy;
+	int				statsbits;
+	int				persistantbits;
+	int				ammobits;
+	int				powerupbits;
+	int				numFields;
+	int				c;
+	netField_t		*field;
+	int				*fromF, *toF;
+	float			fullFloat;
+	int				trunc, lc;
+
+	if (!from) {
+		from = &dummy;
+		Com_Memset (&dummy, 0, sizeof(dummy));
+	}
+
+	c = msg->cursize;
+
+	numFields = sizeof( playerStateFields ) / sizeof( playerStateFields[0] );
+
+	lc = 0;
+	for ( i = 0, field = playerStateFields ; i < numFields ; i++, field++ ) {
+		fromF = (int *)( (byte *)from + field->offset );
+		toF = (int *)( (byte *)to + field->offset );
+		if ( *fromF != *toF ) {
+			lc = i+1;
+		}
+	}
+
+	MSG_WriteByte( msg, lc );	// # of changes
+
+	oldsize += numFields - lc;
+
+	for ( i = 0, field = playerStateFields ; i < lc ; i++, field++ ) {
+		fromF = (int *)( (byte *)from + field->offset );
+		toF = (int *)( (byte *)to + field->offset );
+
+		if ( *fromF == *toF ) {
+			MSG_WriteBits( msg, 0, 1 );	// no change
+			continue;
+		}
+
+		MSG_WriteBits( msg, 1, 1 );	// changed
+//		pcount[i]++;
+
+		if ( field->bits == 0 ) {
+			// float
+			fullFloat = *(float *)toF;
+			trunc = (int)fullFloat;
+
+			if ( trunc == fullFloat && trunc + FLOAT_INT_BIAS >= 0 && 
+				trunc + FLOAT_INT_BIAS < ( 1 << FLOAT_INT_BITS ) ) {
+				// send as small integer
+				MSG_WriteBits( msg, 0, 1 );
+				MSG_WriteBits( msg, trunc + FLOAT_INT_BIAS, FLOAT_INT_BITS );
+			} else {
+				// send as full floating point value
+				MSG_WriteBits( msg, 1, 1 );
+				MSG_WriteBits( msg, *toF, 32 );
+			}
+		} else {
+			// integer
+			MSG_WriteBits( msg, *toF, field->bits );
+		}
+	}
+	c = msg->cursize - c;
+
+
+	//
+	// send the arrays
+	//
+	statsbits = 0;
+	for (i=0 ; i<16 ; i++) {
+		if (to->stats[i] != from->stats[i]) {
+			statsbits |= 1<<i;
+		}
+	}
+	persistantbits = 0;
+	for (i=0 ; i<16 ; i++) {
+		if (to->persistant[i] != from->persistant[i]) {
+			persistantbits |= 1<<i;
+		}
+	}
+	ammobits = 0;
+	for (i=0 ; i<16 ; i++) {
+		if (to->ammo[i] != from->ammo[i]) {
+			ammobits |= 1<<i;
+		}
+	}
+	powerupbits = 0;
+	for (i=0 ; i<16 ; i++) {
+		if (to->powerups[i] != from->powerups[i]) {
+			powerupbits |= 1<<i;
+		}
+	}
+
+	if (!statsbits && !persistantbits && !ammobits && !powerupbits) {
+		MSG_WriteBits( msg, 0, 1 );	// no change
+		oldsize += 4;
+		return;
+	}
+	MSG_WriteBits( msg, 1, 1 );	// changed
+
+	if ( statsbits ) {
+		MSG_WriteBits( msg, 1, 1 );	// changed
+		MSG_WriteShort( msg, statsbits );
+		for (i=0 ; i<16 ; i++)
+			if (statsbits & (1<<i) )
+				MSG_WriteShort (msg, to->stats[i]);
+	} else {
+		MSG_WriteBits( msg, 0, 1 );	// no change
+	}
+
+
+	if ( persistantbits ) {
+		MSG_WriteBits( msg, 1, 1 );	// changed
+		MSG_WriteShort( msg, persistantbits );
+		for (i=0 ; i<16 ; i++)
+			if (persistantbits & (1<<i) )
+				MSG_WriteShort (msg, to->persistant[i]);
+	} else {
+		MSG_WriteBits( msg, 0, 1 );	// no change
+	}
+
+
+	if ( ammobits ) {
+		MSG_WriteBits( msg, 1, 1 );	// changed
+		MSG_WriteShort( msg, ammobits );
+		for (i=0 ; i<16 ; i++)
+			if (ammobits & (1<<i) )
+				MSG_WriteShort (msg, to->ammo[i]);
+	} else {
+		MSG_WriteBits( msg, 0, 1 );	// no change
+	}
+
+
+	if ( powerupbits ) {
+		MSG_WriteBits( msg, 1, 1 );	// changed
+		MSG_WriteShort( msg, powerupbits );
+		for (i=0 ; i<16 ; i++)
+			if (powerupbits & (1<<i) )
+				MSG_WriteLong( msg, to->powerups[i] );
+	} else {
+		MSG_WriteBits( msg, 0, 1 );	// no change
+	}
+}
+
+
+/*
+===================
+MSG_ReadDeltaPlayerstate
+===================
+*/
+void MSG_ReadDeltaPlayerstate (msg_t *msg, playerState_t *from, playerState_t *to ) {
+	int			i, lc;
+	int			bits;
+	netField_t	*field;
+	int			numFields;
+	int			startBit, endBit;
+	int			print;
+	int			*fromF, *toF;
+	int			trunc;
+	playerState_t	dummy;
+
+	if ( !from ) {
+		from = &dummy;
+		Com_Memset( &dummy, 0, sizeof( dummy ) );
+	}
+	*to = *from;
+
+	if ( msg->bit == 0 ) {
+		startBit = msg->readcount * 8 - GENTITYNUM_BITS;
+	} else {
+		startBit = ( msg->readcount - 1 ) * 8 + msg->bit - GENTITYNUM_BITS;
+	}
+
+	// shownet 2/3 will interleave with other printed info, -2 will
+	// just print the delta records
+	if ( cl_shownet->integer >= 2 || cl_shownet->integer == -2 ) {
+		print = 1;
+		Com_Printf( "%3i: playerstate ", msg->readcount );
+	} else {
+		print = 0;
+	}
+
+	numFields = sizeof( playerStateFields ) / sizeof( playerStateFields[0] );
+	lc = MSG_ReadByte(msg);
+
+	for ( i = 0, field = playerStateFields ; i < lc ; i++, field++ ) {
+		fromF = (int *)( (byte *)from + field->offset );
+		toF = (int *)( (byte *)to + field->offset );
+
+		if ( ! MSG_ReadBits( msg, 1 ) ) {
+			// no change
+			*toF = *fromF;
+		} else {
+			if ( field->bits == 0 ) {
+				// float
+				if ( MSG_ReadBits( msg, 1 ) == 0 ) {
+					// integral float
+					trunc = MSG_ReadBits( msg, FLOAT_INT_BITS );
+					// bias to allow equal parts positive and negative
+					trunc -= FLOAT_INT_BIAS;
+					*(float *)toF = trunc; 
+					if ( print ) {
+						Com_Printf( "%s:%i ", field->name, trunc );
+					}
+				} else {
+					// full floating point value
+					*toF = MSG_ReadBits( msg, 32 );
+					if ( print ) {
+						Com_Printf( "%s:%f ", field->name, *(float *)toF );
+					}
+				}
+			} else {
+				// integer
+				*toF = MSG_ReadBits( msg, field->bits );
+				if ( print ) {
+					Com_Printf( "%s:%i ", field->name, *toF );
+				}
+			}
+		}
+	}
+	for ( i=lc,field = &playerStateFields[lc];i<numFields; i++, field++) {
+		fromF = (int *)( (byte *)from + field->offset );
+		toF = (int *)( (byte *)to + field->offset );
+		// no change
+		*toF = *fromF;
+	}
+
+
+	// read the arrays
+	if (MSG_ReadBits( msg, 1 ) ) {
+		// parse stats
+		if ( MSG_ReadBits( msg, 1 ) ) {
+			LOG("PS_STATS");
+			bits = MSG_ReadShort (msg);
+			for (i=0 ; i<16 ; i++) {
+				if (bits & (1<<i) ) {
+					to->stats[i] = MSG_ReadShort(msg);
+				}
+			}
+		}
+
+		// parse persistant stats
+		if ( MSG_ReadBits( msg, 1 ) ) {
+			LOG("PS_PERSISTANT");
+			bits = MSG_ReadShort (msg);
+			for (i=0 ; i<16 ; i++) {
+				if (bits & (1<<i) ) {
+					to->persistant[i] = MSG_ReadShort(msg);
+				}
+			}
+		}
+
+		// parse ammo
+		if ( MSG_ReadBits( msg, 1 ) ) {
+			LOG("PS_AMMO");
+			bits = MSG_ReadShort (msg);
+			for (i=0 ; i<16 ; i++) {
+				if (bits & (1<<i) ) {
+					to->ammo[i] = MSG_ReadShort(msg);
+				}
+			}
+		}
+
+		// parse powerups
+		if ( MSG_ReadBits( msg, 1 ) ) {
+			LOG("PS_POWERUPS");
+			bits = MSG_ReadShort (msg);
+			for (i=0 ; i<16 ; i++) {
+				if (bits & (1<<i) ) {
+					to->powerups[i] = MSG_ReadLong(msg);
+				}
+			}
+		}
+	}
+
+	if ( print ) {
+		if ( msg->bit == 0 ) {
+			endBit = msg->readcount * 8 - GENTITYNUM_BITS;
+		} else {
+			endBit = ( msg->readcount - 1 ) * 8 + msg->bit - GENTITYNUM_BITS;
+		}
+		Com_Printf( " (%i bits)\n", endBit - startBit  );
+	}
+}
+
+#endif /* !Q3_VM */
+
+int msg_hData[256] = {
+250315,			// 0
+41193,			// 1
+6292,			// 2
+7106,			// 3
+3730,			// 4
+3750,			// 5
+6110,			// 6
+23283,			// 7
+33317,			// 8
+6950,			// 9
+7838,			// 10
+9714,			// 11
+9257,			// 12
+17259,			// 13
+3949,			// 14
+1778,			// 15
+8288,			// 16
+1604,			// 17
+1590,			// 18
+1663,			// 19
+1100,			// 20
+1213,			// 21
+1238,			// 22
+1134,			// 23
+1749,			// 24
+1059,			// 25
+1246,			// 26
+1149,			// 27
+1273,			// 28
+4486,			// 29
+2805,			// 30
+3472,			// 31
+21819,			// 32
+1159,			// 33
+1670,			// 34
+1066,			// 35
+1043,			// 36
+1012,			// 37
+1053,			// 38
+1070,			// 39
+1726,			// 40
+888,			// 41
+1180,			// 42
+850,			// 43
+960,			// 44
+780,			// 45
+1752,			// 46
+3296,			// 47
+10630,			// 48
+4514,			// 49
+5881,			// 50
+2685,			// 51
+4650,			// 52
+3837,			// 53
+2093,			// 54
+1867,			// 55
+2584,			// 56
+1949,			// 57
+1972,			// 58
+940,			// 59
+1134,			// 60
+1788,			// 61
+1670,			// 62
+1206,			// 63
+5719,			// 64
+6128,			// 65
+7222,			// 66
+6654,			// 67
+3710,			// 68
+3795,			// 69
+1492,			// 70
+1524,			// 71
+2215,			// 72
+1140,			// 73
+1355,			// 74
+971,			// 75
+2180,			// 76
+1248,			// 77
+1328,			// 78
+1195,			// 79
+1770,			// 80
+1078,			// 81
+1264,			// 82
+1266,			// 83
+1168,			// 84
+965,			// 85
+1155,			// 86
+1186,			// 87
+1347,			// 88
+1228,			// 89
+1529,			// 90
+1600,			// 91
+2617,			// 92
+2048,			// 93
+2546,			// 94
+3275,			// 95
+2410,			// 96
+3585,			// 97
+2504,			// 98
+2800,			// 99
+2675,			// 100
+6146,			// 101
+3663,			// 102
+2840,			// 103
+14253,			// 104
+3164,			// 105
+2221,			// 106
+1687,			// 107
+3208,			// 108
+2739,			// 109
+3512,			// 110
+4796,			// 111
+4091,			// 112
+3515,			// 113
+5288,			// 114
+4016,			// 115
+7937,			// 116
+6031,			// 117
+5360,			// 118
+3924,			// 119
+4892,			// 120
+3743,			// 121
+4566,			// 122
+4807,			// 123
+5852,			// 124
+6400,			// 125
+6225,			// 126
+8291,			// 127
+23243,			// 128
+7838,			// 129
+7073,			// 130
+8935,			// 131
+5437,			// 132
+4483,			// 133
+3641,			// 134
+5256,			// 135
+5312,			// 136
+5328,			// 137
+5370,			// 138
+3492,			// 139
+2458,			// 140
+1694,			// 141
+1821,			// 142
+2121,			// 143
+1916,			// 144
+1149,			// 145
+1516,			// 146
+1367,			// 147
+1236,			// 148
+1029,			// 149
+1258,			// 150
+1104,			// 151
+1245,			// 152
+1006,			// 153
+1149,			// 154
+1025,			// 155
+1241,			// 156
+952,			// 157
+1287,			// 158
+997,			// 159
+1713,			// 160
+1009,			// 161
+1187,			// 162
+879,			// 163
+1099,			// 164
+929,			// 165
+1078,			// 166
+951,			// 167
+1656,			// 168
+930,			// 169
+1153,			// 170
+1030,			// 171
+1262,			// 172
+1062,			// 173
+1214,			// 174
+1060,			// 175
+1621,			// 176
+930,			// 177
+1106,			// 178
+912,			// 179
+1034,			// 180
+892,			// 181
+1158,			// 182
+990,			// 183
+1175,			// 184
+850,			// 185
+1121,			// 186
+903,			// 187
+1087,			// 188
+920,			// 189
+1144,			// 190
+1056,			// 191
+3462,			// 192
+2240,			// 193
+4397,			// 194
+12136,			// 195
+7758,			// 196
+1345,			// 197
+1307,			// 198
+3278,			// 199
+1950,			// 200
+886,			// 201
+1023,			// 202
+1112,			// 203
+1077,			// 204
+1042,			// 205
+1061,			// 206
+1071,			// 207
+1484,			// 208
+1001,			// 209
+1096,			// 210
+915,			// 211
+1052,			// 212
+995,			// 213
+1070,			// 214
+876,			// 215
+1111,			// 216
+851,			// 217
+1059,			// 218
+805,			// 219
+1112,			// 220
+923,			// 221
+1103,			// 222
+817,			// 223
+1899,			// 224
+1872,			// 225
+976,			// 226
+841,			// 227
+1127,			// 228
+956,			// 229
+1159,			// 230
+950,			// 231
+7791,			// 232
+954,			// 233
+1289,			// 234
+933,			// 235
+1127,			// 236
+3207,			// 237
+1020,			// 238
+927,			// 239
+1355,			// 240
+768,			// 241
+1040,			// 242
+745,			// 243
+952,			// 244
+805,			// 245
+1073,			// 246
+740,			// 247
+1013,			// 248
+805,			// 249
+1008,			// 250
+796,			// 251
+996,			// 252
+1057,			// 253
+11457,			// 254
+13504,			// 255
+};
+
+void MSG_initHuffman() {
+	int i,j;
+
+	msgInit = qtrue;
+	Huff_Init(&msgHuff);
+	for(i=0;i<256;i++) {
+		for (j=0;j<msg_hData[i];j++) {
+			Huff_addRef(&msgHuff.compressor,	(byte)i);			// Do update
+			Huff_addRef(&msgHuff.decompressor,	(byte)i);			// Do update
+		}
+	}
+}
+
+/*
+void MSG_NUinitHuffman() {
+	byte	*data;
+	int		size, i, ch;
+	int		array[256];
+
+	msgInit = qtrue;
+
+	Huff_Init(&msgHuff);
+	// load it in
+	size = FS_ReadFile( "netchan/netchan.bin", (void **)&data );
+
+	for(i=0;i<256;i++) {
+		array[i] = 0;
+	}
+	for(i=0;i<size;i++) {
+		ch = data[i];
+		Huff_addRef(&msgHuff.compressor,	ch);			// Do update
+		Huff_addRef(&msgHuff.decompressor,	ch);			// Do update
+		array[ch]++;
+	}
+	Com_Printf("msg_hData {\n");
+	for(i=0;i<256;i++) {
+		if (array[i] == 0) {
+			Huff_addRef(&msgHuff.compressor,	i);			// Do update
+			Huff_addRef(&msgHuff.decompressor,	i);			// Do update
+		}
+		Com_Printf("%d,			// %d\n", array[i], i);
+	}
+	Com_Printf("};\n");
+	FS_FreeFile( data );
+	Cbuf_AddText( "condump dump.txt\n" );
+}
+*/
+
+//===========================================================================

--- a/ratoa_gamecode/code/qcommon/msg_qvm.h
+++ b/ratoa_gamecode/code/qcommon/msg_qvm.h
@@ -1,0 +1,84 @@
+/*
+===========================================================================
+Minimal message/Huffman API for QVM modules (ui.qvm) without full qcommon.h.
+===========================================================================
+*/
+#ifndef MSG_QVM_H
+#define MSG_QVM_H
+
+#define	MAX_MSGLEN				16384
+
+typedef struct {
+	qboolean	allowoverflow;
+	qboolean	overflowed;
+	qboolean	oob;
+	byte	*data;
+	int		maxsize;
+	int		cursize;
+	int		readcount;
+	int		bit;
+} msg_t;
+
+enum svc_ops_e {
+	svc_bad,
+	svc_nop,
+	svc_gamestate,
+	svc_configstring,
+	svc_baseline,
+	svc_serverCommand,
+	svc_download,
+	svc_snapshot,
+	svc_EOF,
+	svc_extension,
+	svc_voip
+};
+
+void MSG_Init( msg_t *buf, byte *data, int length );
+void MSG_Bitstream( msg_t *buf );
+
+int		MSG_ReadBits( msg_t *msg, int bits );
+int		MSG_ReadChar( msg_t *sb );
+int		MSG_ReadByte( msg_t *sb );
+int		MSG_ReadShort( msg_t *sb );
+int		MSG_ReadLong( msg_t *sb );
+char	*MSG_ReadString( msg_t *sb );
+char	*MSG_ReadBigString( msg_t *sb );
+void	MSG_ReadData( msg_t *sb, void *buffer, int size );
+
+#define NYT HMAX
+#define INTERNAL_NODE (HMAX+1)
+#define HMAX 256
+
+typedef struct nodetype {
+	struct	nodetype *left, *right, *parent;
+	struct	nodetype *next, *prev;
+	struct	nodetype **head;
+	int		weight;
+	int		symbol;
+} node_t;
+
+typedef struct {
+	int			blocNode;
+	int			blocPtrs;
+	node_t*		tree;
+	node_t*		lhead;
+	node_t*		ltail;
+	node_t*		loc[HMAX+1];
+	node_t**	freelist;
+	node_t		nodeList[768];
+	node_t*		nodePtrs[768];
+} huff_t;
+
+typedef struct {
+	huff_t		compressor;
+	huff_t		decompressor;
+} huffman_t;
+
+void	Huff_Init( huffman_t *huff );
+void	Huff_addRef( huff_t *huff, byte ch );
+int		Huff_Receive( node_t *node, int *ch, byte *fin );
+void	Huff_offsetReceive( node_t *node, int *ch, byte *fin, int *offset );
+void	Huff_putBit( int bit, byte *fout, int *offset );
+int		Huff_getBit( byte *fin, int *offset );
+
+#endif /* MSG_QVM_H */

--- a/ratoa_gamecode/code/qcommon/qcommon.h
+++ b/ratoa_gamecode/code/qcommon/qcommon.h
@@ -23,7 +23,9 @@ Foundation, Inc., 51 Franklin St, Fifth Floor, Boston, MA  02110-1301  USA
 #ifndef _QCOMMON_H_
 #define _QCOMMON_H_
 
+#ifndef Q3_VM
 #include "../qcommon/cm_public.h"
+#endif
 
 //Ignore __attribute__ on non-gcc platforms
 #ifndef __GNUC__
@@ -304,6 +306,7 @@ enum clc_ops_e {
 	clc_voip,   // not wrapped in USE_VOIP, so this value is reserved.
 };
 
+#ifndef Q3_VM
 /*
 ==============================================================
 
@@ -365,6 +368,7 @@ static ID_INLINE float _vmf(intptr_t x)
 }
 #define	VMF(x)	_vmf(args[x])
 
+#endif /* !Q3_VM */
 
 /*
 ==============================================================

--- a/ratoa_gamecode/windows_scripts/q3_ui.q3asm
+++ b/ratoa_gamecode/windows_scripts/q3_ui.q3asm
@@ -8,6 +8,7 @@ ui_connect
 ui_controls2
 ui_challenges
 ui_demo2
+ui_demo_parse
 ui_mfield
 ui_credits
 ui_menu
@@ -49,5 +50,8 @@ ui_votemenu_map
 ui_votemenu_timelimit
 bg_misc
 bg_lib
+ui_com_stub
+msg
+huffman
 q_math
 q_shared

--- a/ratoa_gamecode/windows_scripts/windows_compile_q3_ui.bat
+++ b/ratoa_gamecode/windows_scripts/windows_compile_q3_ui.bat
@@ -27,6 +27,8 @@ cd windows\build\q3_ui
 %cc%  ../../../code/q3_ui/ui_controls2.c
 %cc%  ../../../code/q3_ui/ui_credits.c
 %cc%  ../../../code/q3_ui/ui_demo2.c
+%cc%  ../../../code/q3_ui/ui_demo_parse.c
+%cc%  ../../../code/q3_ui/ui_com_stub.c
 %cc%  ../../../code/q3_ui/ui_display.c
 %cc%  ../../../code/q3_ui/ui_firstconnect.c
 %cc%  ../../../code/q3_ui/ui_gameinfo.c
@@ -80,6 +82,8 @@ copy  ..\..\..\code\ui\ui_syscalls.asm ..
 
 %cc%  ../../../code/qcommon/q_math.c
 %cc%  ../../../code/qcommon/q_shared.c
+%cc%  ../../../code/qcommon/msg.c
+%cc%  ../../../code/qcommon/huffman.c
 
 q3asm -f ../q3_ui
 


### PR DESCRIPTION
Replays menu now parses the selected demo file for game information.
- Chunked file scan performed across many render frames (because no multi-thread in QVM)
- Reads in player names, scores, model, game time, updating the information in top card area as scan progresses
- Scan adapts to host machine performance. If frame times are being impacted, scanning slows. If not, scan speed increases.
- Tweaked card layout so 1v1 has larger player info areas, but larger games can still fit more players on screen.

Tested on IOQuake3 and Quake3e clients.

Limits on number of demo files still apply - 128 on the 'Full' view so whatever portion of that can be parsed by 'Fancy' will be visible there. But there is a secondary cap on total filenames length of 8192 bytes, it's possible to run out on that even earlier with many very long demo filenames.

<img width="1280" height="720" alt="devo_replays_menu3" src="https://github.com/user-attachments/assets/dce87486-d39a-4304-a9ce-98e59078b9dd" />
<img width="1280" height="720" alt="devo_replays_menu2" src="https://github.com/user-attachments/assets/f4258236-1d81-42e2-afcc-4b1de934024e" />