### PR TITLE
SuperHUD

### DIFF
--- a/docs/CLIENT-COMMANDS.md
+++ b/docs/CLIENT-COMMANDS.md
@@ -34,6 +34,10 @@ Here's an exhaustive listing of valid client console commands for the Devotion m
 | `god` | Server | Vanilla | — | Toggle god mode (cheat). |
 | `help` | Server | RatMod | — | Show MOTD/help text (same as `motd`). |
 | `hud` | Local | RatMod | <0-2> | Apply HUD preset 0=Q3, 1=futuristic, 2=legacy RatMod; runs `vid_restart`. |
+| `reloadHUD` | Local | Devotion | | Reload the SuperHUD file named by `ch_file`. |
+| `hud_hide` | Local | Devotion | <element> | Hide a SuperHUD element (adds to `ch_hiddenElements`). |
+| `hud_show` | Local | Devotion | <element> | Show a previously hidden SuperHUD element. |
+| `sh_dumpHud` | Local | Devotion | | Debug: print loaded SuperHUD element slots. |
 | `kill` | Server | Vanilla | — | Suicide. |
 | `levelshot` | Server | Vanilla | — | Capture levelshot (cheat). |
 | `loaddeferred` | Local | Vanilla | — | Load deferred player models. |

--- a/docs/CLIENT-CVARS.md
+++ b/docs/CLIENT-CVARS.md
@@ -21,6 +21,8 @@ Client-side variables registered by the **cgame** module (`cg_*`, plus related n
 | `cg_altScoreboardAccuracy` | Devotion | `1` | 0 or 1 | When `1`, shows weapon accuracy on the RatMod scoreboard. |
 | `cg_altStatusbar` | Devotion | `0` | 0 or 1 | Health/armor/ammo HUD layout: `0` classic, other values select RatMod status bar styles. |
 | `cg_altStatusbarOldNumbers` | Devotion | `0` | 0 or 1 | When `1`, uses the older number style on the alternate status bar. |
+| `ch_file` | Devotion | `""` | string | SuperHUD config basename under `hud/` (without `.cfg`). Empty disables SuperHUD. See [SUPERHUD.md](SUPERHUD.md). |
+| `ch_hiddenElements` | Devotion | `""` | string | Space-separated SuperHUD element names to hide (`hud_hide` / `hud_show` update this). |
 | `cg_alwaysWeaponBar` | RatMod | `1` | 0 or 1 | When `1`, keeps the weapon bar visible at all times instead of only while switching. |
 | `cg_animspeed` | Vanilla | `1` | 0 or 1 | Player animation playback speed (`1` = normal). Mostly a debug option. |
 | `cg_announcer` | RatMod | `quake3` | string or numeric (see default) | Announcer voice pack for match callouts (e.g. `quake3`). |

--- a/docs/CLIENT.md
+++ b/docs/CLIENT.md
@@ -29,3 +29,13 @@ hud 0                            // Legacy RatMod HUD
 hud 1                            // Futuristic HUD
 hud 2                            // Quake 3 HUD (default)
 ```
+
+### SuperHUD (CPMA-style configs)
+
+Opt-in scripted HUD. Place `.cfg` files in `devotion/hud/` and select with `ch_file` (no `.cfg` suffix). When active, SuperHUD replaces overlapping legacy status/FPS/timer/chat widgets. See [SUPERHUD.md](SUPERHUD.md).
+
+```
+seta ch_file "devotion_default"
+reloadHUD
+sh_dumpHud                       // debug loaded elements
+```

--- a/docs/SUPERHUD.md
+++ b/docs/SUPERHUD.md
@@ -1,0 +1,64 @@
+# SuperHUD (Devotion)
+
+Opt-in CPMA-compatible scripted HUD. When `ch_file` is set to a HUD name (without `.cfg`), Devotion loads `hud/<name>.cfg` and draws that layout instead of the overlapping legacy HUD widgets.
+
+## Quick start
+
+```
+seta ch_file "devotion_default"
+reloadHUD
+```
+
+Place custom configs in `devotion/hud/` (filesystem or PK3). Do **not** `exec` them.
+
+| Command / cvar | Purpose |
+|----------------|---------|
+| `ch_file` | HUD basename under `hud/` (empty = SuperHUD off) |
+| `reloadHUD` | Reload current `ch_file` |
+| `hud_hide <element>` / `hud_show <element>` | Toggle element visibility |
+| `ch_hiddenElements` | Space-separated list of hidden elements |
+| `sh_dumpHud` | Debug: print loaded element slots |
+
+## Compat matrix
+
+### Commands
+
+| Command | Status |
+|---------|--------|
+| `rect`, `color` (RGBA / `T` / `E`), `bgcolor`, `fill` | MVP |
+| `fontsize` (1 or 2 args), `textalign`, `text`, `textstyle`, `time`, `fade` | MVP |
+| `image`, `font`, `monospace`, `doublebar` | MVP |
+| `alignh`, `alignv`, `direction`, `margins`, `textoffset`, `imagetc` | Stub / ignore |
+| `model`, `angles`, `offset`, `visflags`, `itteam` | Out of scope |
+
+### Elements
+
+| Element | Status |
+|---------|--------|
+| `!DEFAULT`, Pre/PostDecorate (pool), StatusBar_* | MVP |
+| FPS, GameTime, Score_OWN/NME/Limit, GameType, WarmupInfo | MVP |
+| AmmoMessage, ItemPickup, ItemPickupIcon, FragMessage | MVP |
+| AttackerIcon/Name, FollowMessage, SpecMessage, RankMessage | MVP |
+| NetGraph, NetGraphPing, PlayerSpeed, PowerUp1–4 Icon/Time | MVP |
+| FlagStatus_OWN/NME, TargetName/Status, Chat1–8, Team1–8 | MVP |
+| VoteMessageWorld (`VoteMessage` alias), WeaponList, Console | MVP |
+| ItemTimers*, KeyDown/Up_*, WeaponSelection*, RecordingDemo | Stub |
+| MultiView, PowerUp5–8, TeamCount_*, TeamIcon_* | Stub |
+| MODEL decorations | Out of scope |
+
+Unknown tokens warn once and are skipped so community CPMA configs still partially load.
+
+## Legacy HUD interaction
+
+When SuperHUD is active, Devotion suppresses overlapping legacy draws (status bars, upper-right FPS/timer/ping, lower score corners, team chat, ammo warning, weapon select, holdable/powerup HUD). If `FragMessage` or `RankMessage` is present, the legacy center-print frag overlay is suppressed too. Crosshair, scoreboard, damage indicator, and movement keys remain.
+
+## Reference screenshots
+
+See [superhud-reference/README.md](superhud-reference/README.md) for the visual comparison checklist.
+
+## Known gaps
+
+- CPMA/THREEWAVE/SANSMAN fonts fall back to the ID font.
+- Console element is best-effort (notify area).
+- Item timers, key indicators, and multiview are not implemented.
+- Widescreen uses Devotion’s existing 640×480 virtual scale (may differ slightly from CNQ3+CPMA).

--- a/docs/superhud-reference/README.md
+++ b/docs/superhud-reference/README.md
@@ -1,0 +1,35 @@
+# SuperHUD visual reference checklist
+
+Capture these in CPMA (or CNQ3+CPMA) and in Devotion with the same HUD cfg for side-by-side comparison.
+
+## Fixtures
+
+| Fixture | File | Focus |
+|---------|------|-------|
+| Default | `hud/devotion_default.cfg` | Status strip, scores, FPS, timer |
+| Status-only | `hud/test_status.cfg` | Health/armor/ammo count + bars |
+| Old-style | `hud/test_oldstyle.cfg` | Score_OWN/NME with `color T`/`E` |
+
+## Capture matrix
+
+For each fixture, shoot at **1920×1080** and **1024×768** (4:3):
+
+1. Alive with weapons (health/armor/ammo visible)
+2. Low health (<25) coloring
+3. CTF with flag status (if applicable)
+4. Warmup / waiting for players
+5. Team chat lines present
+
+Store PNGs here as:
+
+```
+cpma_<fixture>_<res>_<scene>.png
+devo_<fixture>_<res>_<scene>.png
+```
+
+## Pass criteria (P0)
+
+- Status numbers roughly match position/size of the cfg `rect` / `fontsize`
+- Scores and timer visible when defined
+- SuperHUD off (`ch_file ""`) leaves RatMod/`\hud` behavior unchanged
+- Loading a stock-style cfg does not abort / spam fatal errors

--- a/ratoa_assets/assets/hud/devotion_default.cfg
+++ b/ratoa_assets/assets/hud/devotion_default.cfg
@@ -1,0 +1,122 @@
+# Devotion default SuperHUD — vanilla-ish layout using MVP elements only
+!DEFAULT
+{
+	color 1 1 1 1
+	bgcolor 0 0 0 0
+	fontsize 12 16
+	textalign L
+	textstyle 1
+	time 3000
+}
+
+PreDecorate
+{
+	rect 0 420 640 60
+	bgcolor 1 1 1 0.25
+	color T
+	fill
+	image "white"
+}
+
+StatusBar_HealthIcon { rect 16 432 32 32; }
+StatusBar_HealthCount { rect 52 432 96 32; fontsize 16 24; textalign L; }
+StatusBar_HealthBar { rect 52 466 96 8; color 1 0 0 0.8; fill; }
+
+StatusBar_ArmorIcon { rect 180 432 32 32; }
+StatusBar_ArmorCount { rect 216 432 96 32; fontsize 16 24; textalign L; }
+StatusBar_ArmorBar { rect 216 466 96 8; color 0 0.6 1 0.8; fill; }
+
+StatusBar_AmmoIcon { rect 340 432 32 32; }
+StatusBar_AmmoCount { rect 376 432 96 32; fontsize 16 24; textalign L; }
+StatusBar_AmmoBar { rect 376 466 96 8; color 1 1 0 0.8; fill; }
+
+FPS { rect 560 8 72 12; fontsize 8 10; textalign R; }
+GameTime { rect 560 22 72 12; fontsize 8 10; textalign R; }
+NetGraphPing { rect 560 36 72 12; fontsize 8 10; textalign R; }
+PlayerSpeed { rect 560 50 72 12; fontsize 8 10; textalign R; }
+
+Score_OWN { rect 8 8 48 20; fontsize 14 18; textalign L; color T; bgcolor 1 1 1 0.35; fill; }
+Score_NME { rect 60 8 48 20; fontsize 14 18; textalign L; color E; bgcolor 1 1 1 0.35; fill; }
+Score_Limit { rect 112 8 48 16; fontsize 10 12; textalign L; }
+
+PowerUp1_Icon { rect 592 80 32 32; }
+PowerUp1_Time { rect 560 88 28 16; fontsize 8 10; textalign R; }
+PowerUp2_Icon { rect 592 116 32 32; }
+PowerUp2_Time { rect 560 124 28 16; fontsize 8 10; textalign R; }
+PowerUp3_Icon { rect 592 152 32 32; }
+PowerUp3_Time { rect 560 160 28 16; fontsize 8 10; textalign R; }
+PowerUp4_Icon { rect 592 188 32 32; }
+PowerUp4_Time { rect 560 196 28 16; fontsize 8 10; textalign R; }
+
+WeaponList
+{
+	rect 320 400 36 14
+	fontsize 8 10
+	textalign C
+	color 0.2 0.2 0.7 0.75
+}
+
+ItemPickupIcon { rect 320 360 32 32; textalign C; time 3000; fade 0 0 0 0; }
+ItemPickup { rect 0 392 640 12; fontsize 8 10; textalign C; time 3000; fade 0 0 0 0; }
+
+AmmoMessage { rect 0 300 640 16; fontsize 10 12; textalign C; color 1 0.2 0.2 1; time 2000; }
+
+AttackerIcon { rect 304 80 32 32; time 5000; fade 0 0 0 0; }
+AttackerName { rect 0 114 640 12; fontsize 8 10; textalign C; time 5000; fade 0 0 0 0; }
+
+FragMessage { rect 0 160 640 16; fontsize 10 12; textalign C; time 3000; fade 0 0 0 0; }
+RankMessage { rect 0 180 640 14; fontsize 8 10; textalign C; time 3000; fade 0 0 0 0; }
+
+WarmupInfo { rect 0 120 640 16; fontsize 12 16; textalign C; }
+GameType { rect 0 100 640 16; fontsize 12 16; textalign C; color 1 1 0.5 1; }
+
+FollowMessage { rect 0 60 640 14; fontsize 10 12; textalign C; }
+SpecMessage { rect 0 60 640 14; fontsize 10 12; textalign C; }
+
+TargetName { rect 0 240 640 12; fontsize 8 10; textalign C; }
+TargetStatus { rect 0 252 640 12; fontsize 8 10; textalign C; }
+
+FlagStatus_OWN { rect 568 400 32 32; color T; bgcolor 1 1 1 1; }
+FlagStatus_NME { rect 528 400 32 32; color E; bgcolor 1 1 1 1; }
+
+VoteMessageWorld { rect 0 200 640 14; fontsize 8 10; textalign C; }
+
+!DEFAULT
+{
+	textalign L
+	fontsize 7 8
+	color 1 1 1 1
+	bgcolor 0 0 0 0.4
+	time 5000
+	fade 0.5 0.5 0.5 0
+	font ID
+}
+
+Chat1 { rect 0 340 320 8; }
+Chat2 { rect 0 348 320 8; }
+Chat3 { rect 0 356 320 8; }
+Chat4 { rect 0 364 320 8; }
+Chat5 { rect 0 372 320 8; }
+Chat6 { rect 0 380 320 8; }
+Chat7 { rect 0 388 320 8; }
+Chat8 { rect 0 396 320 8; }
+
+!DEFAULT
+{
+	textalign R
+	fontsize 7 8
+	monospace
+	bgcolor 0 0 0 0.4
+	color 1 1 1 1
+}
+
+Team1 { rect 0 0 640 8; }
+Team2 { rect 0 8 640 8; }
+Team3 { rect 0 16 640 8; }
+Team4 { rect 0 24 640 8; }
+Team5 { rect 0 32 640 8; }
+Team6 { rect 0 40 640 8; }
+Team7 { rect 0 48 640 8; }
+Team8 { rect 0 56 640 8; }
+
+NetGraph { rect 560 420 72 40; bgcolor 0 0 0 0; color 1 1 1 0.8; }

--- a/ratoa_assets/assets/hud/test_oldstyle.cfg
+++ b/ratoa_assets/assets/hud/test_oldstyle.cfg
@@ -1,0 +1,18 @@
+# Old-school RED/BLUE score boxes (color T / E)
+!DEFAULT
+{
+	color 1 1 1 1
+	fontsize 16 20
+	textalign R
+}
+
+Score_OWN { rect 0 440 64 24; bgcolor 1 1 1 0.5; fill; color T; }
+Score_NME { rect 0 416 64 24; bgcolor 1 1 1 0.5; fill; color E; }
+Score_Limit { rect 0 392 64 20; fontsize 12 16; }
+
+FlagStatus_OWN { rect 608 400 32 32; bgcolor 1 1 1 1; color T; }
+FlagStatus_NME { rect 568 400 32 32; bgcolor 1 1 1 1; color E; }
+
+StatusBar_HealthCount { rect 240 440 80 32; fontsize 20 24; textalign C; }
+StatusBar_ArmorCount { rect 320 440 80 32; fontsize 20 24; textalign C; }
+StatusBar_AmmoCount { rect 160 440 80 32; fontsize 20 24; textalign C; }

--- a/ratoa_assets/assets/hud/test_status.cfg
+++ b/ratoa_assets/assets/hud/test_status.cfg
@@ -1,0 +1,18 @@
+# Minimal status-bar fixture for parse/draw smoke tests
+!DEFAULT
+{
+	color 1 1 1 1
+	fontsize 16 24
+	textalign L
+}
+
+StatusBar_HealthCount { rect 40 420 120 32; }
+StatusBar_ArmorCount { rect 200 420 120 32; }
+StatusBar_AmmoCount { rect 360 420 120 32; }
+
+StatusBar_HealthBar { rect 40 456 120 10; color 1 0 0 1; fill; }
+StatusBar_ArmorBar { rect 200 456 120 10; color 0 0.5 1 1; fill; }
+StatusBar_AmmoBar { rect 360 456 120 10; color 1 1 0 1; fill; }
+
+FPS { rect 8 8 64 12; fontsize 8 10; }
+GameTime { rect 8 24 64 12; fontsize 8 10; }

--- a/ratoa_gamecode/Makefile
+++ b/ratoa_gamecode/Makefile
@@ -1717,6 +1717,7 @@ Q3CGOBJ_ = \
   $(B)/baseq3/cgame/cg_servercmds.o \
   $(B)/baseq3/cgame/cg_snapshot.o \
   $(B)/baseq3/cgame/cg_demo_history.o \
+  $(B)/baseq3/cgame/cg_superhud.o \
   $(B)/baseq3/cgame/cg_unlagged.o \
   $(B)/baseq3/cgame/cg_view.o \
   $(B)/baseq3/cgame/cg_weapons.o \
@@ -1765,6 +1766,7 @@ MPCGOBJ_ = \
   $(B)/missionpack/cgame/cg_servercmds.o \
   $(B)/missionpack/cgame/cg_snapshot.o \
   $(B)/missionpack/cgame/cg_demo_history.o \
+  $(B)/missionpack/cgame/cg_superhud.o \
   $(B)/missionpack/cgame/cg_unlagged.o \
   $(B)/missionpack/cgame/cg_view.o \
   $(B)/missionpack/cgame/cg_weapons.o \

--- a/ratoa_gamecode/code/cgame/cg_consolecmds.c
+++ b/ratoa_gamecode/code/cgame/cg_consolecmds.c
@@ -1442,6 +1442,10 @@ static consoleCommand_t	commands[] = {
         { "hud", CG_HUD_f },
         { "rules", CG_Rules_f },
 		{ "pro", CG_PRO_f},
+		{ "reloadHUD", CG_ReloadHUD_f },
+		{ "hud_hide", CG_HudHide_f },
+		{ "hud_show", CG_HudShow_f },
+		{ "sh_dumpHud", CG_SH_Dump_f },
 //        { "ratversion", CG_RatVersion_f }
 };
 

--- a/ratoa_gamecode/code/cgame/cg_cvar.h
+++ b/ratoa_gamecode/code/cgame/cg_cvar.h
@@ -173,6 +173,8 @@ CG_CVAR( cg_altScoreboard, "cg_altScoreboard", "1", CVAR_ARCHIVE )
 CG_CVAR( cg_altScoreboardAccuracy, "cg_altScoreboardAccuracy", "1", CVAR_ARCHIVE )
 CG_CVAR( cg_altStatusbar, "cg_altStatusbar", "0", CVAR_ARCHIVE )
 CG_CVAR( cg_altStatusbarOldNumbers, "cg_altStatusbarOldNumbers", "0", CVAR_ARCHIVE )
+CG_CVAR( ch_file, "ch_file", "", CVAR_ARCHIVE )
+CG_CVAR( ch_hiddenElements, "ch_hiddenElements", "", CVAR_ARCHIVE )
 
 CG_CVAR( cg_printDuelStats, "cg_printDuelStats", "1", CVAR_ARCHIVE )
 

--- a/ratoa_gamecode/code/cgame/cg_draw.c
+++ b/ratoa_gamecode/code/cgame/cg_draw.c
@@ -6577,12 +6577,16 @@ static void CG_Draw2D(stereoFrame_t stereoFrame)
 		CG_DrawEmptyIndicator();
 		CG_DrawCrosshairNames();
 	} else {
+		qboolean shActive = CG_SH_Active();
+
 		// don't draw any status if dead or the scoreboard is being explicitly shown
 		if ( !cg.showScores && cg.snap->ps.stats[STAT_HEALTH] > 0 ) {
 			CG_DrawZoomScope();
-			// if ((cg_altStatusbar.integer >= 4 && cg_altStatusbar.integer <= 5) && cgs.gametype != GT_HARVESTER && cgs.gametype != GT_TREASURE_HUNTER) {
-			if ((cg_altStatusbar.integer >= 4 && cg_altStatusbar.integer <= 5)) {
-				CG_DrawRatStatusBar4Bg();
+			if ( !shActive ) {
+				// if ((cg_altStatusbar.integer >= 4 && cg_altStatusbar.integer <= 5) && cgs.gametype != GT_HARVESTER && cgs.gametype != GT_TREASURE_HUNTER) {
+				if ((cg_altStatusbar.integer >= 4 && cg_altStatusbar.integer <= 5)) {
+					CG_DrawRatStatusBar4Bg();
+				}
 			}
 			CG_DrawHudDamageIndicator();
 			CG_DrawMovementKeys();
@@ -6593,32 +6597,36 @@ static void CG_Draw2D(stereoFrame_t stereoFrame)
 				CG_DrawTimedMenus();
 			}
 #else
-			// if (cg_altStatusbar.integer && cgs.gametype != GT_HARVESTER && cgs.gametype != GT_TREASURE_HUNTER) {
-			if (cg_altStatusbar.integer) {
-				switch (cg_altStatusbar.integer) {
-					case 4:
-					case 5:
-						CG_DrawRatStatusBar4();
-						break;
-					case 1:
-					case 2:
-						CG_DrawRatStatusBar();
-						break;
-					case 3:
-						CG_DrawRatStatusBar3();
-						break;
-					default:
-						CG_DrawRatStatusBar();
-						break;
+			if ( !shActive ) {
+				// if (cg_altStatusbar.integer && cgs.gametype != GT_HARVESTER && cgs.gametype != GT_TREASURE_HUNTER) {
+				if (cg_altStatusbar.integer) {
+					switch (cg_altStatusbar.integer) {
+						case 4:
+						case 5:
+							CG_DrawRatStatusBar4();
+							break;
+						case 1:
+						case 2:
+							CG_DrawRatStatusBar();
+							break;
+						case 3:
+							CG_DrawRatStatusBar3();
+							break;
+						default:
+							CG_DrawRatStatusBar();
+							break;
+					}
+				} else {
+					CG_DrawStatusBar();
 				}
-			} else {
-				CG_DrawStatusBar();
 			}
 #endif
 
      			CG_DrawThawing(); 
 
-			CG_DrawAmmoWarning();
+			if ( !shActive ) {
+				CG_DrawAmmoWarning();
+			}
 
 			CG_DrawProxWarning();
 			if(stereoFrame == STEREO_CENTER)
@@ -6626,11 +6634,15 @@ static void CG_Draw2D(stereoFrame_t stereoFrame)
 			CG_DrawReloadIndicator();
 			CG_DrawEmptyIndicator();
 			CG_DrawCrosshairNames();
-			CG_DrawWeaponSelect();
+			if ( !shActive || !CG_SH_HasWeaponList() ) {
+				CG_DrawWeaponSelect();
+			}
 
                         #ifndef MISSIONPACK
-			CG_DrawHoldableItem();
-			CG_DrawPersistantPowerup();
+			if ( !shActive ) {
+				CG_DrawHoldableItem();
+				CG_DrawPersistantPowerup();
+			}
 			#endif
 
 			if (cg_drawRewards.integer) {
@@ -6645,32 +6657,48 @@ static void CG_Draw2D(stereoFrame_t stereoFrame)
 	}
 
 #ifndef MISSIONPACK
-	CG_DrawTeamChat();
+	if ( !CG_SH_Active() || !CG_SH_HasChat() ) {
+		CG_DrawTeamChat();
+	}
 #endif
 
 
 	CG_DrawVote();
 	CG_DrawTeamVote();
 
-	CG_DrawLagometer();
-	if (cg_drawFPS.integer == 2) {
-		CG_DrawFPS(0);
-	} else if (cg_drawFPS.integer == 3) {
-		CG_DrawBottomFPS();
+	if ( !CG_SH_Active() || !CG_SH_HasNetGraph() ) {
+		CG_DrawLagometer();
+	}
+	if ( !CG_SH_Active() ) {
+		if (cg_drawFPS.integer == 2) {
+			CG_DrawFPS(0);
+		} else if (cg_drawFPS.integer == 3) {
+			CG_DrawBottomFPS();
+		}
 	}
 
 #ifdef MISSIONPACK
 	if (!cg_paused.integer) {
-		CG_DrawUpperRight(stereoFrame);
+		if ( !CG_SH_Active() ) {
+			CG_DrawUpperRight(stereoFrame);
+		}
 	}
 #else
-	CG_DrawUpperRight(stereoFrame);
+	if ( !CG_SH_Active() ) {
+		CG_DrawUpperRight(stereoFrame);
+	}
 #endif
 
 #ifndef MISSIONPACK
-	CG_DrawLowerRight();
-	CG_DrawLowerLeft();
+	if ( !CG_SH_Active() ) {
+		CG_DrawLowerRight();
+		CG_DrawLowerLeft();
+	}
 #endif
+
+	if ( CG_SH_Active() ) {
+		CG_SH_DrawFrame();
+	}
 
 	//if ( !CG_DrawFollow() ) {
 	//	CG_DrawWarmup();
@@ -6693,7 +6721,9 @@ static void CG_Draw2D(stereoFrame_t stereoFrame)
 		CG_DrawPushNotify();
                 //CG_DrawCenterDDString();
                 //CG_DrawCenter1FctfString();
-		CG_DrawCenterString();
+		if ( !CG_SH_HasCenterMessages() ) {
+			CG_DrawCenterString();
+		}
 
 
 		if ( cgs.clientinfo[cg.clientNum].team != TEAM_SPECTATOR )

--- a/ratoa_gamecode/code/cgame/cg_local.h
+++ b/ratoa_gamecode/code/cgame/cg_local.h
@@ -1792,6 +1792,23 @@ void CG_DrawActiveFrame( int serverTime, stereoFrame_t stereoView, qboolean demo
 
 
 //
+// cg_superhud.c
+//
+void CG_SH_Init( void );
+void CG_SH_Load( void );
+void CG_SH_CheckCvars( void );
+void CG_SH_DrawFrame( void );
+qboolean CG_SH_Active( void );
+qboolean CG_SH_HasWeaponList( void );
+qboolean CG_SH_HasChat( void );
+qboolean CG_SH_HasNetGraph( void );
+qboolean CG_SH_HasCenterMessages( void );
+void CG_ReloadHUD_f( void );
+void CG_SH_Dump_f( void );
+void CG_HudHide_f( void );
+void CG_HudShow_f( void );
+
+//
 // cg_drawtools.c
 //
 void CG_AdjustFrom640( float *x, float *y, float *w, float *h );

--- a/ratoa_gamecode/code/cgame/cg_main.c
+++ b/ratoa_gamecode/code/cgame/cg_main.c
@@ -2656,6 +2656,8 @@ void CG_Init( int serverMessageNum, int serverCommandSequence, int clientNum ) {
 	CG_LoadHudMenu();      // load new hud stuff
 #endif
 
+	CG_SH_Init();
+
 	cg.loading = qfalse;	// future players will be deferred
 
 	CG_InitPMissilles();

--- a/ratoa_gamecode/code/cgame/cg_superhud.c
+++ b/ratoa_gamecode/code/cgame/cg_superhud.c
@@ -1,0 +1,1752 @@
+/*
+===========================================================================
+Devotion SuperHUD — CPMA-compatible scripted HUD (clean-room).
+
+Structural patterns inspired by AfterShock SuperHUD (GPL, Manuel Wiese),
+but dialect and element set follow CPMA SuperHUD documentation.
+===========================================================================
+*/
+
+#include "cg_local.h"
+
+#define SH_MAX_FILE_LEN		32768
+#define SH_MAX_TOKENS		2048
+#define SH_TOKEN_SIZE		64
+#define SH_DECOR_POOL		32
+#define SH_MAX_IMAGE		64
+#define SH_MAX_TEXT			128
+
+typedef enum {
+	SH_TOT_LPAREN,
+	SH_TOT_RPAREN,
+	SH_TOT_WORD,
+	SH_TOT_NUMBER,
+	SH_TOT_NIL
+} shTokenType_t;
+
+typedef struct {
+	char value[SH_TOKEN_SIZE];
+	int type;
+} shToken_t;
+
+typedef enum {
+	SH_FONT_ID = 0,
+	SH_FONT_CPMA,
+	SH_FONT_THREEWAVE,
+	SH_FONT_SANSMAN,
+	SH_FONT_IDBLOCK
+} shFont_t;
+
+typedef enum {
+	SH_ALIGN_L = 0,
+	SH_ALIGN_C = 1,
+	SH_ALIGN_R = 2
+} shAlign_t;
+
+/* Named elements (excluding decor pools). Order is draw priority within content. */
+typedef enum {
+	SH_DEFAULT = 0,
+	SH_AmmoMessage,
+	SH_AttackerIcon,
+	SH_AttackerName,
+	SH_Chat1, SH_Chat2, SH_Chat3, SH_Chat4, SH_Chat5, SH_Chat6, SH_Chat7, SH_Chat8,
+	SH_FlagStatus_OWN,
+	SH_FlagStatus_NME,
+	SH_FollowMessage,
+	SH_FPS,
+	SH_FragMessage,
+	SH_GameTime,
+	SH_GameType,
+	SH_ItemPickup,
+	SH_ItemPickupIcon,
+	SH_NetGraph,
+	SH_NetGraphPing,
+	SH_PlayerSpeed,
+	SH_PowerUp1_Icon, SH_PowerUp2_Icon, SH_PowerUp3_Icon, SH_PowerUp4_Icon,
+	SH_PowerUp1_Time, SH_PowerUp2_Time, SH_PowerUp3_Time, SH_PowerUp4_Time,
+	SH_RankMessage,
+	SH_Score_Limit,
+	SH_Score_NME,
+	SH_Score_OWN,
+	SH_SpecMessage,
+	SH_StatusBar_ArmorBar,
+	SH_StatusBar_ArmorCount,
+	SH_StatusBar_ArmorIcon,
+	SH_StatusBar_AmmoBar,
+	SH_StatusBar_AmmoCount,
+	SH_StatusBar_AmmoIcon,
+	SH_StatusBar_HealthBar,
+	SH_StatusBar_HealthCount,
+	SH_StatusBar_HealthIcon,
+	SH_TargetName,
+	SH_TargetStatus,
+	SH_Team1, SH_Team2, SH_Team3, SH_Team4, SH_Team5, SH_Team6, SH_Team7, SH_Team8,
+	SH_VoteMessageWorld,
+	SH_WarmupInfo,
+	SH_WeaponList,
+	SH_Console,
+	SH_NAMED_MAX,
+
+	/* Stubs / OOS names still accepted by parser */
+	SH_STUB_BEGIN = SH_NAMED_MAX,
+	SH_ItemTimers,
+	SH_KeyIndicator,
+	SH_WeaponSelection,
+	SH_RecordingDemo,
+	SH_MultiView,
+	SH_TeamCount,
+	SH_TeamIcon,
+	SH_PowerUpHigh,
+	SH_STUB_MAX,
+
+	SH_ELEM_COUNT
+} shElemId_t;
+
+typedef struct {
+	qboolean	inuse;
+	qboolean	hidden;
+	qboolean	isStub;
+	float		xpos, ypos, width, height;
+	vec4_t		color;
+	vec4_t		bgcolor;
+	vec4_t		fade;
+	qboolean	hasFade;
+	qboolean	fill;
+	qboolean	monospace;
+	qboolean	doublebar;
+	int			textAlign;
+	int			fontWidth;
+	int			fontHeight;
+	int			textstyle;
+	int			time;
+	int			font;
+	int			teamColor;		/* 0 none, 1 T, 2 E */
+	int			teamBgColor;
+	char		text[SH_MAX_TEXT];
+	char		image[SH_MAX_IMAGE];
+	qhandle_t	imageHandle;
+} shElement_t;
+
+typedef struct {
+	qboolean		active;
+	char			loadedFile[MAX_QPATH];
+	shElement_t		named[SH_NAMED_MAX];
+	shElement_t		preDecor[SH_DECOR_POOL];
+	shElement_t		postDecor[SH_DECOR_POOL];
+	int				preCount;
+	int				postCount;
+	int				chFileModificationCount;
+	char			warnedUnknown[512];
+} shState_t;
+
+static shState_t sh;
+
+/* -------------------------------------------------------------------------- */
+/* Public helpers                                                             */
+/* -------------------------------------------------------------------------- */
+
+qboolean CG_SH_Active( void ) {
+	return sh.active;
+}
+
+static void SH_ClearElement( shElement_t *e ) {
+	memset( e, 0, sizeof( *e ) );
+	e->color[0] = e->color[1] = e->color[2] = e->color[3] = 1.0f;
+	e->fontWidth = 8;
+	e->fontHeight = 8;
+	e->textAlign = SH_ALIGN_L;
+	e->textstyle = 0;
+}
+
+static void SH_ClearAll( void ) {
+	int i;
+
+	memset( &sh, 0, sizeof( sh ) );
+	for ( i = 0; i < SH_NAMED_MAX; i++ ) {
+		SH_ClearElement( &sh.named[i] );
+	}
+	for ( i = 0; i < SH_DECOR_POOL; i++ ) {
+		SH_ClearElement( &sh.preDecor[i] );
+		SH_ClearElement( &sh.postDecor[i] );
+	}
+}
+
+static void SH_CopyElement( shElement_t *dst, const shElement_t *src ) {
+	*dst = *src;
+}
+
+static void SH_WarnOnce( const char *msg ) {
+	if ( strstr( sh.warnedUnknown, msg ) ) {
+		return;
+	}
+	if ( strlen( sh.warnedUnknown ) + strlen( msg ) + 2 < sizeof( sh.warnedUnknown ) ) {
+		Q_strcat( sh.warnedUnknown, sizeof( sh.warnedUnknown ), msg );
+		Q_strcat( sh.warnedUnknown, sizeof( sh.warnedUnknown ), ";" );
+	}
+	CG_Printf( S_COLOR_YELLOW "SuperHUD: %s\n", msg );
+}
+
+/* -------------------------------------------------------------------------- */
+/* Name table                                                                 */
+/* -------------------------------------------------------------------------- */
+
+typedef struct {
+	const char	*name;
+	int			id;			/* shElemId_t or special: -1 PreDecorate, -2 PostDecorate */
+	qboolean	stub;
+} shNameMap_t;
+
+static const shNameMap_t shNames[] = {
+	{ "!DEFAULT", SH_DEFAULT, qfalse },
+	{ "AmmoMessage", SH_AmmoMessage, qfalse },
+	{ "AttackerIcon", SH_AttackerIcon, qfalse },
+	{ "AttackerName", SH_AttackerName, qfalse },
+	{ "Chat1", SH_Chat1, qfalse }, { "Chat2", SH_Chat2, qfalse },
+	{ "Chat3", SH_Chat3, qfalse }, { "Chat4", SH_Chat4, qfalse },
+	{ "Chat5", SH_Chat5, qfalse }, { "Chat6", SH_Chat6, qfalse },
+	{ "Chat7", SH_Chat7, qfalse }, { "Chat8", SH_Chat8, qfalse },
+	{ "FlagStatus_OWN", SH_FlagStatus_OWN, qfalse },
+	{ "FlagStatus_NME", SH_FlagStatus_NME, qfalse },
+	{ "FollowMessage", SH_FollowMessage, qfalse },
+	{ "FPS", SH_FPS, qfalse },
+	{ "FragMessage", SH_FragMessage, qfalse },
+	{ "GameTime", SH_GameTime, qfalse },
+	{ "GameType", SH_GameType, qfalse },
+	{ "ItemPickup", SH_ItemPickup, qfalse },
+	{ "ItemPickupIcon", SH_ItemPickupIcon, qfalse },
+	{ "NetGraph", SH_NetGraph, qfalse },
+	{ "NetGraphPing", SH_NetGraphPing, qfalse },
+	{ "PlayerSpeed", SH_PlayerSpeed, qfalse },
+	{ "PowerUp1_Icon", SH_PowerUp1_Icon, qfalse },
+	{ "PowerUp2_Icon", SH_PowerUp2_Icon, qfalse },
+	{ "PowerUp3_Icon", SH_PowerUp3_Icon, qfalse },
+	{ "PowerUp4_Icon", SH_PowerUp4_Icon, qfalse },
+	{ "PowerUp1_Time", SH_PowerUp1_Time, qfalse },
+	{ "PowerUp2_Time", SH_PowerUp2_Time, qfalse },
+	{ "PowerUp3_Time", SH_PowerUp3_Time, qfalse },
+	{ "PowerUp4_Time", SH_PowerUp4_Time, qfalse },
+	{ "RankMessage", SH_RankMessage, qfalse },
+	{ "Score_Limit", SH_Score_Limit, qfalse },
+	{ "Score_NME", SH_Score_NME, qfalse },
+	{ "Score_OWN", SH_Score_OWN, qfalse },
+	{ "SpecMessage", SH_SpecMessage, qfalse },
+	{ "StatusBar_ArmorBar", SH_StatusBar_ArmorBar, qfalse },
+	{ "StatusBar_ArmorCount", SH_StatusBar_ArmorCount, qfalse },
+	{ "StatusBar_ArmorIcon", SH_StatusBar_ArmorIcon, qfalse },
+	{ "StatusBar_AmmoBar", SH_StatusBar_AmmoBar, qfalse },
+	{ "StatusBar_AmmoCount", SH_StatusBar_AmmoCount, qfalse },
+	{ "StatusBar_AmmoIcon", SH_StatusBar_AmmoIcon, qfalse },
+	{ "StatusBar_HealthBar", SH_StatusBar_HealthBar, qfalse },
+	{ "StatusBar_HealthCount", SH_StatusBar_HealthCount, qfalse },
+	{ "StatusBar_HealthIcon", SH_StatusBar_HealthIcon, qfalse },
+	{ "TargetName", SH_TargetName, qfalse },
+	{ "TargetStatus", SH_TargetStatus, qfalse },
+	{ "Team1", SH_Team1, qfalse }, { "Team2", SH_Team2, qfalse },
+	{ "Team3", SH_Team3, qfalse }, { "Team4", SH_Team4, qfalse },
+	{ "Team5", SH_Team5, qfalse }, { "Team6", SH_Team6, qfalse },
+	{ "Team7", SH_Team7, qfalse }, { "Team8", SH_Team8, qfalse },
+	{ "VoteMessageWorld", SH_VoteMessageWorld, qfalse },
+	{ "VoteMessage", SH_VoteMessageWorld, qfalse },
+	{ "WarmupInfo", SH_WarmupInfo, qfalse },
+	{ "WeaponList", SH_WeaponList, qfalse },
+	{ "Console", SH_Console, qfalse },
+	{ "PreDecorate", -1, qfalse },
+	{ "PostDecorate", -2, qfalse },
+	/* stubs */
+	{ "ItemTimers1_Icons", SH_ItemTimers, qtrue },
+	{ "ItemTimers1_Times", SH_ItemTimers, qtrue },
+	{ "ItemTimers2_Icons", SH_ItemTimers, qtrue },
+	{ "ItemTimers2_Times", SH_ItemTimers, qtrue },
+	{ "ItemTimers3_Icons", SH_ItemTimers, qtrue },
+	{ "ItemTimers3_Times", SH_ItemTimers, qtrue },
+	{ "ItemTimers4_Icons", SH_ItemTimers, qtrue },
+	{ "ItemTimers4_Times", SH_ItemTimers, qtrue },
+	{ "KeyDown_Forward", SH_KeyIndicator, qtrue },
+	{ "KeyDown_Back", SH_KeyIndicator, qtrue },
+	{ "KeyDown_Left", SH_KeyIndicator, qtrue },
+	{ "KeyDown_Right", SH_KeyIndicator, qtrue },
+	{ "KeyDown_Jump", SH_KeyIndicator, qtrue },
+	{ "KeyDown_Crouch", SH_KeyIndicator, qtrue },
+	{ "KeyUp_Forward", SH_KeyIndicator, qtrue },
+	{ "KeyUp_Back", SH_KeyIndicator, qtrue },
+	{ "KeyUp_Left", SH_KeyIndicator, qtrue },
+	{ "KeyUp_Right", SH_KeyIndicator, qtrue },
+	{ "KeyUp_Jump", SH_KeyIndicator, qtrue },
+	{ "KeyUp_Crouch", SH_KeyIndicator, qtrue },
+	{ "WeaponSelection", SH_WeaponSelection, qtrue },
+	{ "WeaponSelectionName", SH_WeaponSelection, qtrue },
+	{ "RecordingDemo", SH_RecordingDemo, qtrue },
+	{ "MultiView", SH_MultiView, qtrue },
+	{ "TeamCount_OWN", SH_TeamCount, qtrue },
+	{ "TeamCount_NME", SH_TeamCount, qtrue },
+	{ "TeamIcon_OWN", SH_TeamIcon, qtrue },
+	{ "TeamIcon_NME", SH_TeamIcon, qtrue },
+	{ "PowerUp5_Icon", SH_PowerUpHigh, qtrue },
+	{ "PowerUp6_Icon", SH_PowerUpHigh, qtrue },
+	{ "PowerUp7_Icon", SH_PowerUpHigh, qtrue },
+	{ "PowerUp8_Icon", SH_PowerUpHigh, qtrue },
+	{ "PowerUp5_Time", SH_PowerUpHigh, qtrue },
+	{ "PowerUp6_Time", SH_PowerUpHigh, qtrue },
+	{ "PowerUp7_Time", SH_PowerUpHigh, qtrue },
+	{ "PowerUp8_Time", SH_PowerUpHigh, qtrue },
+	{ "LocalTime", SH_ItemTimers, qtrue },
+	{ "Name_OWN", SH_Score_OWN, qtrue },
+	{ "Name_NME", SH_Score_NME, qtrue },
+};
+
+static int SH_LookupName( const char *name, qboolean *isStub, int *decorKind ) {
+	int i;
+
+	*isStub = qfalse;
+	*decorKind = 0;
+	for ( i = 0; i < (int)( sizeof( shNames ) / sizeof( shNames[0] ) ); i++ ) {
+		if ( !Q_stricmp( name, shNames[i].name ) ) {
+			*isStub = shNames[i].stub;
+			if ( shNames[i].id == -1 ) {
+				*decorKind = 1;
+				return -1;
+			}
+			if ( shNames[i].id == -2 ) {
+				*decorKind = 2;
+				return -2;
+			}
+			return shNames[i].id;
+		}
+	}
+	return -100;
+}
+
+static const char *SH_ElemName( int id ) {
+	int i;
+	for ( i = 0; i < (int)( sizeof( shNames ) / sizeof( shNames[0] ) ); i++ ) {
+		if ( shNames[i].id == id && shNames[i].id >= 0 ) {
+			return shNames[i].name;
+		}
+	}
+	return "?";
+}
+
+/* -------------------------------------------------------------------------- */
+/* Tokenizer                                                                  */
+/* -------------------------------------------------------------------------- */
+
+static qboolean SH_IsSkipped( char c ) {
+	return ( c == '\n' || c == '\r' || c == ';' || c == '\t' || c == ' ' || c == ',' );
+}
+
+static int SH_Tokenize( char *buffer, int len, shToken_t *tokens, int maxTokens ) {
+	static char flat[SH_MAX_FILE_LEN];
+	int i, charCount, tokenNum;
+	qboolean lastSpace, inComment;
+
+	if ( len >= SH_MAX_FILE_LEN ) {
+		len = SH_MAX_FILE_LEN - 1;
+	}
+	charCount = 0;
+	lastSpace = qtrue;
+	inComment = qfalse;
+
+	for ( i = 0; i < len; i++ ) {
+		if ( buffer[i] == '#' ) {
+			inComment = qtrue;
+			continue;
+		}
+		if ( inComment ) {
+			if ( buffer[i] == '\n' || buffer[i] == '\r' ) {
+				inComment = qfalse;
+				lastSpace = qtrue;
+			}
+			continue;
+		}
+		if ( SH_IsSkipped( buffer[i] ) ) {
+			if ( !lastSpace && charCount < SH_MAX_FILE_LEN - 1 ) {
+				flat[charCount++] = ' ';
+				lastSpace = qtrue;
+			}
+			continue;
+		}
+		lastSpace = qfalse;
+		if ( charCount < SH_MAX_FILE_LEN - 1 ) {
+			flat[charCount++] = buffer[i];
+		}
+	}
+	flat[charCount] = '\0';
+
+	tokenNum = 0;
+	i = 0;
+	while ( flat[i] && tokenNum < maxTokens ) {
+		int j = 0;
+		while ( flat[i] && flat[i] != ' ' && j < SH_TOKEN_SIZE - 1 ) {
+			tokens[tokenNum].value[j++] = flat[i++];
+		}
+		tokens[tokenNum].value[j] = '\0';
+		if ( flat[i] == ' ' ) {
+			i++;
+		}
+		if ( tokens[tokenNum].value[0] == '{' && tokens[tokenNum].value[1] == '\0' ) {
+			tokens[tokenNum].type = SH_TOT_LPAREN;
+		} else if ( tokens[tokenNum].value[0] == '}' && tokens[tokenNum].value[1] == '\0' ) {
+			tokens[tokenNum].type = SH_TOT_RPAREN;
+		} else {
+			qboolean hasAlpha = qfalse;
+			qboolean hasDigit = qfalse;
+			qboolean hasDot = qfalse;
+			qboolean badNum = qfalse;
+			int k;
+			const char *v = tokens[tokenNum].value;
+
+			for ( k = 0; v[k]; k++ ) {
+				char c = v[k];
+				if ( ( c >= 'a' && c <= 'z' ) || ( c >= 'A' && c <= 'Z' ) || c == '_' || c == '/' || c == '!' ) {
+					hasAlpha = qtrue;
+				} else if ( c >= '0' && c <= '9' ) {
+					hasDigit = qtrue;
+				} else if ( c == '.' ) {
+					if ( hasDot ) {
+						badNum = qtrue;
+					}
+					hasDot = qtrue;
+				} else if ( c == '-' || c == '+' ) {
+					if ( k != 0 ) {
+						badNum = qtrue;
+					}
+				} else {
+					badNum = qtrue;
+				}
+			}
+			/* "0.5" is a number; paths like gfx/2d/x are words */
+			if ( hasAlpha || badNum ) {
+				tokens[tokenNum].type = SH_TOT_WORD;
+			} else if ( hasDigit ) {
+				tokens[tokenNum].type = SH_TOT_NUMBER;
+			} else {
+				tokens[tokenNum].type = SH_TOT_NIL;
+			}
+		}
+		tokenNum++;
+	}
+	return tokenNum;
+}
+
+/* -------------------------------------------------------------------------- */
+/* Property apply                                                             */
+/* -------------------------------------------------------------------------- */
+
+static void SH_ApplyInherit( shElement_t *e, const shElement_t *def, unsigned filledMask ) {
+	if ( !( filledMask & 1 ) ) {
+		e->xpos = def->xpos;
+		e->ypos = def->ypos;
+		e->width = def->width;
+		e->height = def->height;
+	}
+	if ( !( filledMask & 2 ) ) {
+		Vector4Copy( def->bgcolor, e->bgcolor );
+	}
+	if ( !( filledMask & 4 ) ) {
+		Vector4Copy( def->color, e->color );
+		e->teamColor = def->teamColor;
+	}
+	if ( !( filledMask & 8 ) ) {
+		e->fill = def->fill;
+	}
+	if ( !( filledMask & 16 ) ) {
+		e->fontWidth = def->fontWidth;
+		e->fontHeight = def->fontHeight;
+	}
+	if ( !( filledMask & 32 ) ) {
+		Q_strncpyz( e->image, def->image, sizeof( e->image ) );
+		e->imageHandle = def->imageHandle;
+	}
+	if ( !( filledMask & 64 ) ) {
+		Q_strncpyz( e->text, def->text, sizeof( e->text ) );
+	}
+	if ( !( filledMask & 128 ) ) {
+		e->textAlign = def->textAlign;
+	}
+	if ( !( filledMask & 256 ) ) {
+		e->time = def->time;
+	}
+	if ( !( filledMask & 512 ) ) {
+		e->textstyle = def->textstyle;
+	}
+	if ( !( filledMask & 1024 ) ) {
+		e->font = def->font;
+	}
+	if ( !( filledMask & 2048 ) ) {
+		e->monospace = def->monospace;
+	}
+	if ( !( filledMask & 4096 ) ) {
+		e->doublebar = def->doublebar;
+	}
+	if ( !( filledMask & 8192 ) ) {
+		Vector4Copy( def->fade, e->fade );
+		e->hasFade = def->hasFade;
+	}
+	if ( !( filledMask & 16384 ) ) {
+		e->teamBgColor = def->teamBgColor;
+	}
+}
+
+static unsigned SH_ApplyProps( shElement_t *e, shToken_t *tok, int start, int end ) {
+	int i;
+	unsigned mask = 0;
+
+	for ( i = start; i <= end; i++ ) {
+		const char *p = tok[i].value;
+
+		if ( !Q_stricmp( p, "rect" ) && i + 4 <= end ) {
+			e->xpos = atof( tok[i + 1].value );
+			e->ypos = atof( tok[i + 2].value );
+			e->width = atof( tok[i + 3].value );
+			e->height = atof( tok[i + 4].value );
+			mask |= 1;
+			i += 4;
+		} else if ( !Q_stricmp( p, "bgcolor" ) && i + 4 <= end ) {
+			e->bgcolor[0] = atof( tok[i + 1].value );
+			e->bgcolor[1] = atof( tok[i + 2].value );
+			e->bgcolor[2] = atof( tok[i + 3].value );
+			e->bgcolor[3] = atof( tok[i + 4].value );
+			mask |= 2;
+			i += 4;
+		} else if ( !Q_stricmp( p, "color" ) ) {
+			if ( i + 1 <= end && !Q_stricmp( tok[i + 1].value, "T" ) ) {
+				e->teamColor = 1;
+				mask |= 4;
+				i += 1;
+			} else if ( i + 1 <= end && !Q_stricmp( tok[i + 1].value, "E" ) ) {
+				e->teamColor = 2;
+				mask |= 4;
+				i += 1;
+			} else if ( i + 4 <= end ) {
+				e->color[0] = atof( tok[i + 1].value );
+				e->color[1] = atof( tok[i + 2].value );
+				e->color[2] = atof( tok[i + 3].value );
+				e->color[3] = atof( tok[i + 4].value );
+				e->teamColor = 0;
+				mask |= 4;
+				i += 4;
+			}
+		} else if ( !Q_stricmp( p, "fill" ) ) {
+			e->fill = qtrue;
+			mask |= 8;
+		} else if ( !Q_stricmp( p, "fontsize" ) ) {
+			if ( i + 2 <= end && tok[i + 2].type == SH_TOT_NUMBER ) {
+				e->fontWidth = atoi( tok[i + 1].value );
+				e->fontHeight = atoi( tok[i + 2].value );
+				mask |= 16;
+				i += 2;
+			} else if ( i + 1 <= end ) {
+				e->fontWidth = atoi( tok[i + 1].value );
+				e->fontHeight = (int)( e->fontWidth * 1.25f );
+				if ( e->fontHeight < e->fontWidth ) {
+					e->fontHeight = e->fontWidth;
+				}
+				mask |= 16;
+				i += 1;
+			}
+		} else if ( !Q_stricmp( p, "image" ) && i + 1 <= end ) {
+			Q_strncpyz( e->image, tok[i + 1].value, sizeof( e->image ) );
+			e->imageHandle = trap_R_RegisterShaderNoMip( e->image );
+			if ( !e->imageHandle ) {
+				e->imageHandle = trap_R_RegisterShader( e->image );
+			}
+			mask |= 32;
+			i += 1;
+		} else if ( !Q_stricmp( p, "text" ) && i + 1 <= end ) {
+			int t;
+			Q_strncpyz( e->text, tok[i + 1].value, sizeof( e->text ) );
+			for ( t = 0; e->text[t]; t++ ) {
+				if ( e->text[t] == '_' ) {
+					e->text[t] = ' ';
+				}
+			}
+			mask |= 64;
+			i += 1;
+		} else if ( !Q_stricmp( p, "textalign" ) && i + 1 <= end ) {
+			if ( !Q_stricmp( tok[i + 1].value, "L" ) ) {
+				e->textAlign = SH_ALIGN_L;
+			} else if ( !Q_stricmp( tok[i + 1].value, "R" ) ) {
+				e->textAlign = SH_ALIGN_R;
+			} else {
+				e->textAlign = SH_ALIGN_C;
+			}
+			mask |= 128;
+			i += 1;
+		} else if ( !Q_stricmp( p, "time" ) && i + 1 <= end ) {
+			e->time = atoi( tok[i + 1].value );
+			mask |= 256;
+			i += 1;
+		} else if ( !Q_stricmp( p, "textstyle" ) && i + 1 <= end ) {
+			e->textstyle = atoi( tok[i + 1].value );
+			mask |= 512;
+			i += 1;
+		} else if ( !Q_stricmp( p, "font" ) && i + 1 <= end ) {
+			if ( !Q_stricmp( tok[i + 1].value, "CPMA" ) ) {
+				e->font = SH_FONT_CPMA;
+			} else if ( !Q_stricmp( tok[i + 1].value, "THREEWAVE" ) ) {
+				e->font = SH_FONT_THREEWAVE;
+			} else if ( !Q_stricmp( tok[i + 1].value, "SANSMAN" ) ) {
+				e->font = SH_FONT_SANSMAN;
+			} else if ( !Q_stricmp( tok[i + 1].value, "IDBLOCK" ) ) {
+				e->font = SH_FONT_IDBLOCK;
+			} else {
+				e->font = SH_FONT_ID;
+			}
+			if ( e->font != SH_FONT_ID && e->font != SH_FONT_IDBLOCK ) {
+				SH_WarnOnce( "font fallback to ID" );
+			}
+			mask |= 1024;
+			i += 1;
+		} else if ( !Q_stricmp( p, "monospace" ) ) {
+			e->monospace = qtrue;
+			mask |= 2048;
+		} else if ( !Q_stricmp( p, "doublebar" ) ) {
+			e->doublebar = qtrue;
+			mask |= 4096;
+		} else if ( !Q_stricmp( p, "fade" ) ) {
+			if ( i + 4 <= end && tok[i + 1].type == SH_TOT_NUMBER ) {
+				e->fade[0] = atof( tok[i + 1].value );
+				e->fade[1] = atof( tok[i + 2].value );
+				e->fade[2] = atof( tok[i + 3].value );
+				e->fade[3] = atof( tok[i + 4].value );
+				e->hasFade = qtrue;
+				mask |= 8192;
+				i += 4;
+			} else {
+				e->fade[0] = e->fade[1] = e->fade[2] = 0;
+				e->fade[3] = 0;
+				e->hasFade = qtrue;
+				mask |= 8192;
+			}
+		} else if ( !Q_stricmp( p, "model" ) || !Q_stricmp( p, "angles" ) ||
+					!Q_stricmp( p, "offset" ) || !Q_stricmp( p, "visflags" ) ||
+					!Q_stricmp( p, "alignh" ) || !Q_stricmp( p, "alignv" ) ||
+					!Q_stricmp( p, "direction" ) || !Q_stricmp( p, "margins" ) ||
+					!Q_stricmp( p, "textoffset" ) || !Q_stricmp( p, "imagetc" ) ||
+					!Q_stricmp( p, "itteam" ) || !Q_stricmp( p, "fadedelay" ) ) {
+			/* skip known optional args loosely */
+			while ( i + 1 <= end && tok[i + 1].type != SH_TOT_WORD &&
+					Q_stricmp( tok[i + 1].value, "rect" ) &&
+					Q_stricmp( tok[i + 1].value, "color" ) &&
+					Q_stricmp( tok[i + 1].value, "bgcolor" ) &&
+					Q_stricmp( tok[i + 1].value, "fill" ) &&
+					Q_stricmp( tok[i + 1].value, "fontsize" ) &&
+					Q_stricmp( tok[i + 1].value, "image" ) &&
+					Q_stricmp( tok[i + 1].value, "text" ) &&
+					Q_stricmp( tok[i + 1].value, "textalign" ) &&
+					Q_stricmp( tok[i + 1].value, "time" ) &&
+					Q_stricmp( tok[i + 1].value, "font" ) &&
+					Q_stricmp( tok[i + 1].value, "fade" ) &&
+					Q_stricmp( tok[i + 1].value, "monospace" ) &&
+					Q_stricmp( tok[i + 1].value, "doublebar" ) ) {
+				i++;
+				if ( tok[i].type == SH_TOT_WORD ) {
+					break;
+				}
+			}
+		} else if ( tok[i].type == SH_TOT_WORD ) {
+			char buf[128];
+			Com_sprintf( buf, sizeof( buf ), "unknown cmd %s", p );
+			SH_WarnOnce( buf );
+		}
+	}
+	return mask;
+}
+
+static int SH_FindToken( shToken_t *tok, int n, int start, const char *s ) {
+	int i;
+	for ( i = start; i < n; i++ ) {
+		if ( !strcmp( tok[i].value, s ) ) {
+			return i;
+		}
+	}
+	return -1;
+}
+
+static void SH_ParseTokens( shToken_t *tok, int n ) {
+	shElement_t currentDefault;
+	int i;
+
+	SH_ClearElement( &currentDefault );
+	currentDefault.inuse = qtrue;
+
+	for ( i = 0; i < n; i++ ) {
+		qboolean isStub = qfalse;
+		int decorKind = 0;
+		int id;
+		int lpar, rpar;
+		shElement_t tmp;
+		unsigned mask;
+
+		if ( tok[i].type != SH_TOT_WORD && tok[i].value[0] != '!' ) {
+			continue;
+		}
+		id = SH_LookupName( tok[i].value, &isStub, &decorKind );
+		if ( id == -100 ) {
+			char buf[128];
+			Com_sprintf( buf, sizeof( buf ), "unknown element %s", tok[i].value );
+			SH_WarnOnce( buf );
+			continue;
+		}
+		if ( i + 1 >= n || strcmp( tok[i + 1].value, "{" ) != 0 ) {
+			continue;
+		}
+		lpar = i + 1;
+		rpar = SH_FindToken( tok, n, lpar + 1, "}" );
+		if ( rpar < 0 ) {
+			CG_Printf( S_COLOR_YELLOW "SuperHUD: missing } after %s\n", tok[i].value );
+			break;
+		}
+
+		SH_ClearElement( &tmp );
+		mask = SH_ApplyProps( &tmp, tok, lpar + 1, rpar - 1 );
+
+		if ( id == SH_DEFAULT ) {
+			/* DEFAULT only fills unset params from previous DEFAULT for following elements;
+			   itself accumulates: do not wipe previous DEFAULT fields that weren't set */
+			SH_ApplyInherit( &tmp, &currentDefault, mask );
+			SH_CopyElement( &currentDefault, &tmp );
+			currentDefault.inuse = qtrue;
+			sh.named[SH_DEFAULT] = currentDefault;
+		} else if ( decorKind == 1 ) {
+			if ( sh.preCount < SH_DECOR_POOL ) {
+				SH_ApplyInherit( &tmp, &currentDefault, mask );
+				tmp.inuse = qtrue;
+				tmp.isStub = isStub;
+				sh.preDecor[sh.preCount++] = tmp;
+			} else {
+				SH_WarnOnce( "PreDecorate pool full" );
+			}
+		} else if ( decorKind == 2 ) {
+			if ( sh.postCount < SH_DECOR_POOL ) {
+				SH_ApplyInherit( &tmp, &currentDefault, mask );
+				tmp.inuse = qtrue;
+				tmp.isStub = isStub;
+				sh.postDecor[sh.postCount++] = tmp;
+			} else {
+				SH_WarnOnce( "PostDecorate pool full" );
+			}
+		} else if ( id >= 0 && id < SH_NAMED_MAX ) {
+			SH_ApplyInherit( &tmp, &currentDefault, mask );
+			tmp.inuse = qtrue;
+			tmp.isStub = isStub;
+			sh.named[id] = tmp;
+		} else if ( isStub ) {
+			/* accept and ignore */
+		}
+
+		i = rpar;
+	}
+}
+
+/* -------------------------------------------------------------------------- */
+/* Load / commands                                                            */
+/* -------------------------------------------------------------------------- */
+
+static qboolean SH_ElementHiddenByCvar( const char *name ) {
+	char buf[MAX_CVAR_VALUE_STRING];
+	char *p, *token;
+
+	if ( !ch_hiddenElements.string[0] ) {
+		return qfalse;
+	}
+	Q_strncpyz( buf, ch_hiddenElements.string, sizeof( buf ) );
+	p = buf;
+	while ( 1 ) {
+		token = COM_Parse( &p );
+		if ( !token[0] ) {
+			break;
+		}
+		if ( !Q_stricmp( token, name ) ) {
+			return qtrue;
+		}
+	}
+	return qfalse;
+}
+
+static void SH_ApplyHiddenFlags( void ) {
+	int i;
+	for ( i = 1; i < SH_NAMED_MAX; i++ ) {
+		if ( sh.named[i].inuse && SH_ElementHiddenByCvar( SH_ElemName( i ) ) ) {
+			sh.named[i].hidden = qtrue;
+		}
+	}
+}
+
+void CG_SH_Load( void ) {
+	char path[MAX_QPATH];
+	static char buffer[SH_MAX_FILE_LEN];
+	static shToken_t tokens[SH_MAX_TOKENS];
+	fileHandle_t f;
+	int len;
+	int n;
+
+	SH_ClearAll();
+	sh.chFileModificationCount = ch_file.modificationCount;
+
+	if ( !ch_file.string[0] ) {
+		sh.active = qfalse;
+		return;
+	}
+
+	Com_sprintf( path, sizeof( path ), "hud/%s.cfg", ch_file.string );
+	len = trap_FS_FOpenFile( path, &f, FS_READ );
+	if ( !f ) {
+		CG_Printf( S_COLOR_YELLOW "SuperHUD: %s not found, trying devotion_default\n", path );
+		Q_strncpyz( path, "hud/devotion_default.cfg", sizeof( path ) );
+		len = trap_FS_FOpenFile( path, &f, FS_READ );
+		if ( !f ) {
+			CG_Printf( S_COLOR_RED "SuperHUD: no HUD file available\n" );
+			sh.active = qfalse;
+			return;
+		}
+	}
+
+	if ( len <= 0 || len >= SH_MAX_FILE_LEN ) {
+		CG_Printf( S_COLOR_RED "SuperHUD: bad file size %i for %s\n", len, path );
+		trap_FS_FCloseFile( f );
+		sh.active = qfalse;
+		return;
+	}
+
+	trap_FS_Read( buffer, len, f );
+	buffer[len] = 0;
+	trap_FS_FCloseFile( f );
+
+	n = SH_Tokenize( buffer, len, tokens, SH_MAX_TOKENS );
+	SH_ParseTokens( tokens, n );
+	SH_ApplyHiddenFlags();
+
+	Q_strncpyz( sh.loadedFile, path, sizeof( sh.loadedFile ) );
+	sh.active = qtrue;
+	CG_Printf( "SuperHUD loaded %s (%i tokens, %i pre, %i post)\n",
+			path, n, sh.preCount, sh.postCount );
+}
+
+void CG_SH_Init( void ) {
+	SH_ClearAll();
+	if ( ch_file.string[0] ) {
+		CG_SH_Load();
+	}
+}
+
+void CG_SH_CheckCvars( void ) {
+	if ( ch_file.modificationCount != sh.chFileModificationCount ) {
+		CG_SH_Load();
+	}
+}
+
+void CG_ReloadHUD_f( void ) {
+	CG_SH_Load();
+}
+
+void CG_SH_Dump_f( void ) {
+	int i;
+	if ( !sh.active ) {
+		CG_Printf( "SuperHUD inactive\n" );
+		return;
+	}
+	CG_Printf( "SuperHUD file: %s\n", sh.loadedFile );
+	for ( i = 1; i < SH_NAMED_MAX; i++ ) {
+		if ( !sh.named[i].inuse ) {
+			continue;
+		}
+		CG_Printf( "  %s%s rect %.0f %.0f %.0f %.0f fs %i %i\n",
+				SH_ElemName( i ),
+				sh.named[i].hidden ? " [hidden]" : "",
+				sh.named[i].xpos, sh.named[i].ypos,
+				sh.named[i].width, sh.named[i].height,
+				sh.named[i].fontWidth, sh.named[i].fontHeight );
+	}
+	CG_Printf( "  PreDecorate %i  PostDecorate %i\n", sh.preCount, sh.postCount );
+}
+
+void CG_HudHide_f( void ) {
+	char arg[MAX_TOKEN_CHARS];
+	char buf[MAX_CVAR_VALUE_STRING];
+	int i;
+
+	if ( trap_Argc() < 2 ) {
+		CG_Printf( "usage: hud_hide <element>\n" );
+		return;
+	}
+	trap_Argv( 1, arg, sizeof( arg ) );
+	for ( i = 1; i < SH_NAMED_MAX; i++ ) {
+		if ( !Q_stricmp( arg, SH_ElemName( i ) ) && sh.named[i].inuse ) {
+			sh.named[i].hidden = qtrue;
+		}
+	}
+	Q_strncpyz( buf, ch_hiddenElements.string, sizeof( buf ) );
+	if ( !SH_ElementHiddenByCvar( arg ) ) {
+		if ( buf[0] ) {
+			Q_strcat( buf, sizeof( buf ), " " );
+		}
+		Q_strcat( buf, sizeof( buf ), arg );
+		trap_Cvar_Set( "ch_hiddenElements", buf );
+	}
+}
+
+void CG_HudShow_f( void ) {
+	char arg[MAX_TOKEN_CHARS];
+	char buf[MAX_CVAR_VALUE_STRING];
+	char out[MAX_CVAR_VALUE_STRING];
+	char *p, *token;
+	int i;
+
+	if ( trap_Argc() < 2 ) {
+		CG_Printf( "usage: hud_show <element>\n" );
+		return;
+	}
+	trap_Argv( 1, arg, sizeof( arg ) );
+	for ( i = 1; i < SH_NAMED_MAX; i++ ) {
+		if ( !Q_stricmp( arg, SH_ElemName( i ) ) && sh.named[i].inuse ) {
+			sh.named[i].hidden = qfalse;
+		}
+	}
+	out[0] = '\0';
+	Q_strncpyz( buf, ch_hiddenElements.string, sizeof( buf ) );
+	p = buf;
+	while ( 1 ) {
+		token = COM_Parse( &p );
+		if ( !token[0] ) {
+			break;
+		}
+		if ( !Q_stricmp( token, arg ) ) {
+			continue;
+		}
+		if ( out[0] ) {
+			Q_strcat( out, sizeof( out ), " " );
+		}
+		Q_strcat( out, sizeof( out ), token );
+	}
+	trap_Cvar_Set( "ch_hiddenElements", out );
+}
+
+/* -------------------------------------------------------------------------- */
+/* Draw helpers                                                               */
+/* -------------------------------------------------------------------------- */
+
+static void SH_ResolveColor( const shElement_t *e, vec4_t out, qboolean bg ) {
+	int team;
+	float *base;
+	int mode;
+
+	base = bg ? (float *)e->bgcolor : (float *)e->color;
+	mode = bg ? e->teamBgColor : e->teamColor;
+	Vector4Copy( base, out );
+
+	if ( !mode ) {
+		/* color T/E without bgcolor: treat teamColor on bgcolor path via fill */
+		if ( !bg && e->teamColor ) {
+			mode = e->teamColor;
+		} else {
+			return;
+		}
+	}
+
+	team = cg.snap->ps.persistant[PERS_TEAM];
+	if ( team != TEAM_RED && team != TEAM_BLUE ) {
+		team = cgs.clientinfo[cg.clientNum].team;
+	}
+	if ( mode == 1 ) { /* T */
+		if ( team == TEAM_BLUE ) {
+			out[0] = 0.2f; out[1] = 0.2f; out[2] = 1.0f;
+		} else {
+			out[0] = 1.0f; out[1] = 0.2f; out[2] = 0.2f;
+		}
+	} else if ( mode == 2 ) { /* E */
+		if ( team == TEAM_BLUE ) {
+			out[0] = 1.0f; out[1] = 0.2f; out[2] = 0.2f;
+		} else {
+			out[0] = 0.2f; out[1] = 0.2f; out[2] = 1.0f;
+		}
+	}
+	if ( bg ) {
+		out[3] = e->bgcolor[3];
+	} else {
+		out[3] = e->color[3];
+	}
+}
+
+static void SH_DrawFill( const shElement_t *e ) {
+	vec4_t c;
+	if ( !e->fill && e->bgcolor[3] <= 0.0f && !e->teamColor ) {
+		return;
+	}
+	if ( !e->fill && e->bgcolor[3] <= 0.0f ) {
+		return;
+	}
+	SH_ResolveColor( e, c, qtrue );
+	if ( e->teamColor && e->fill ) {
+		/* CPMA: color T/E modulates bgcolor for fill */
+		SH_ResolveColor( e, c, qfalse );
+		c[3] = e->bgcolor[3] > 0 ? e->bgcolor[3] : e->color[3];
+	}
+	if ( c[3] <= 0.0f && !e->fill ) {
+		return;
+	}
+	if ( e->fill || e->bgcolor[3] > 0.0f || e->teamColor ) {
+		CG_FillRect( e->xpos, e->ypos, e->width, e->height, c );
+	}
+}
+
+/* Returns qfalse when the element is fully faded out. */
+static qboolean SH_ApplyFade( const shElement_t *e, int startTime, vec4_t c ) {
+	if ( e->hasFade && e->time > 0 && startTime > 0 ) {
+		float f = CG_FadeScale( startTime, e->time );
+		if ( f <= 0.0f ) {
+			return qfalse;
+		}
+		c[0] = e->fade[0] + ( c[0] - e->fade[0] ) * f;
+		c[1] = e->fade[1] + ( c[1] - e->fade[1] ) * f;
+		c[2] = e->fade[2] + ( c[2] - e->fade[2] ) * f;
+		c[3] = e->fade[3] + ( c[3] - e->fade[3] ) * f;
+		return qtrue;
+	}
+	if ( e->time > 0 && startTime > 0 ) {
+		float *fc = CG_FadeColor( startTime, e->time );
+		if ( !fc ) {
+			return qfalse;
+		}
+		c[3] *= fc[3];
+	}
+	return qtrue;
+}
+
+static void SH_DrawImage( const shElement_t *e, qhandle_t overrideHandle, int startTime ) {
+	vec4_t c;
+	qhandle_t h = overrideHandle ? overrideHandle : e->imageHandle;
+	if ( !h ) {
+		return;
+	}
+	SH_ResolveColor( e, c, qfalse );
+	if ( !SH_ApplyFade( e, startTime, c ) ) {
+		return;
+	}
+	trap_R_SetColor( c );
+	CG_DrawPic( e->xpos, e->ypos, e->width > 0 ? e->width : 32, e->height > 0 ? e->height : 32, h );
+	trap_R_SetColor( NULL );
+}
+
+static void SH_DrawString( const shElement_t *e, const char *str, int startTime ) {
+	vec4_t c;
+	float x, y;
+	int cw, ch;
+	int len;
+	qboolean shadow;
+
+	if ( !str || !str[0] ) {
+		return;
+	}
+	SH_ResolveColor( e, c, qfalse );
+	if ( !SH_ApplyFade( e, startTime, c ) ) {
+		return;
+	}
+
+	cw = e->fontWidth > 0 ? e->fontWidth : 8;
+	ch = e->fontHeight > 0 ? e->fontHeight : 8;
+	len = CG_DrawStrlen( str );
+	x = e->xpos;
+	y = e->ypos;
+	if ( e->textAlign == SH_ALIGN_C ) {
+		x = e->xpos + ( e->width - len * cw ) * 0.5f;
+	} else if ( e->textAlign == SH_ALIGN_R ) {
+		x = e->xpos + e->width - len * cw;
+	}
+	shadow = ( e->textstyle & 1 ) ? qtrue : qfalse;
+	CG_DrawStringExt( (int)x, (int)y, str, c, qfalse, shadow, cw, ch, 0 );
+}
+
+static void SH_DrawBar( const shElement_t *e, float frac ) {
+	vec4_t c;
+	float w, h;
+
+	if ( frac < 0.0f ) {
+		frac = 0.0f;
+	}
+	if ( frac > 1.0f ) {
+		frac = 1.0f;
+	}
+	SH_ResolveColor( e, c, qfalse );
+	SH_DrawFill( e );
+	w = e->width;
+	h = e->height;
+	if ( e->doublebar && h >= 6 ) {
+		float half = ( h - 4 ) * 0.5f;
+		CG_FillRect( e->xpos, e->ypos, w * frac, half, c );
+		CG_FillRect( e->xpos, e->ypos + half + 4, w * frac, half, c );
+	} else {
+		if ( e->textAlign == SH_ALIGN_R ) {
+			CG_FillRect( e->xpos + w * ( 1.0f - frac ), e->ypos, w * frac, h, c );
+		} else if ( e->textAlign == SH_ALIGN_C ) {
+			CG_FillRect( e->xpos, e->ypos + h * ( 1.0f - frac ), w, h * frac, c );
+		} else {
+			CG_FillRect( e->xpos, e->ypos, w * frac, h, c );
+		}
+	}
+}
+
+static qboolean SH_Visible( const shElement_t *e ) {
+	return e->inuse && !e->hidden && !e->isStub;
+}
+
+static int SH_OwnScore( void ) {
+	if ( cgs.gametype >= GT_TEAM ) {
+		if ( cg.snap->ps.persistant[PERS_TEAM] == TEAM_RED ) {
+			return cgs.scores1;
+		}
+		if ( cg.snap->ps.persistant[PERS_TEAM] == TEAM_BLUE ) {
+			return cgs.scores2;
+		}
+	}
+	return cg.snap->ps.persistant[PERS_SCORE];
+}
+
+static int SH_NmeScore( void ) {
+	if ( cgs.gametype >= GT_TEAM ) {
+		if ( cg.snap->ps.persistant[PERS_TEAM] == TEAM_RED ) {
+			return cgs.scores2;
+		}
+		if ( cg.snap->ps.persistant[PERS_TEAM] == TEAM_BLUE ) {
+			return cgs.scores1;
+		}
+		return cgs.scores2;
+	}
+	/* FFA/tourney: best other score */
+	{
+		int best = 0;
+		int i;
+		for ( i = 0; i < cg.numScores; i++ ) {
+			if ( cg.scores[i].client == cg.snap->ps.clientNum ) {
+				continue;
+			}
+			if ( cg.scores[i].score > best ) {
+				best = cg.scores[i].score;
+			}
+		}
+		return best;
+	}
+}
+
+static const char *SH_GameTypeString( void ) {
+	switch ( cgs.gametype ) {
+	case GT_FFA: return "Free For All";
+	case GT_TOURNAMENT: return "Tournament";
+	case GT_TEAM: return "Team Deathmatch";
+	case GT_CTF: return "Capture the Flag";
+#ifdef MISSIONPACK
+	case GT_1FCTF: return "One Flag CTF";
+	case GT_OBELISK: return "Overload";
+	case GT_HARVESTER: return "Harvester";
+#endif
+	case GT_ELIMINATION: return "Elimination";
+	case GT_CTF_ELIMINATION: return "CTF Elimination";
+	case GT_LMS: return "Last Man Standing";
+#ifdef MISSIONPACK
+	case GT_DOUBLE_D: return "Double Domination";
+	case GT_DOMINATION: return "Domination";
+#endif
+	default: return "Deathmatch";
+	}
+}
+
+/* -------------------------------------------------------------------------- */
+/* Element drawers                                                            */
+/* -------------------------------------------------------------------------- */
+
+static void SH_DrawDecor( const shElement_t *e ) {
+	if ( !SH_Visible( e ) ) {
+		return;
+	}
+	SH_DrawFill( e );
+	if ( e->imageHandle ) {
+		SH_DrawImage( e, 0, 0 );
+	}
+	if ( e->text[0] ) {
+		SH_DrawString( e, e->text, 0 );
+	}
+}
+
+static void SH_DrawStatusCounts( void ) {
+	playerState_t *ps = &cg.snap->ps;
+	centity_t *cent = &cg_entities[cg.snap->ps.clientNum];
+	char buf[32];
+	int ammo = 0;
+	float hfrac, afrac, mfrac;
+	const int maxH = ps->stats[STAT_MAX_HEALTH] > 0 ? ps->stats[STAT_MAX_HEALTH] : 100;
+
+	if ( cent->currentState.weapon ) {
+		ammo = ps->ammo[cent->currentState.weapon];
+	}
+
+	if ( SH_Visible( &sh.named[SH_StatusBar_HealthCount] ) ) {
+		SH_DrawFill( &sh.named[SH_StatusBar_HealthCount] );
+		Com_sprintf( buf, sizeof( buf ), "%i", ps->stats[STAT_HEALTH] );
+		SH_DrawString( &sh.named[SH_StatusBar_HealthCount], buf, 0 );
+	}
+	if ( SH_Visible( &sh.named[SH_StatusBar_ArmorCount] ) ) {
+		SH_DrawFill( &sh.named[SH_StatusBar_ArmorCount] );
+		Com_sprintf( buf, sizeof( buf ), "%i", ps->stats[STAT_ARMOR] );
+		SH_DrawString( &sh.named[SH_StatusBar_ArmorCount], buf, 0 );
+	}
+	if ( SH_Visible( &sh.named[SH_StatusBar_AmmoCount] ) ) {
+		SH_DrawFill( &sh.named[SH_StatusBar_AmmoCount] );
+		Com_sprintf( buf, sizeof( buf ), "%i", ammo );
+		SH_DrawString( &sh.named[SH_StatusBar_AmmoCount], buf, 0 );
+	}
+	if ( SH_Visible( &sh.named[SH_StatusBar_HealthIcon] ) ) {
+		SH_DrawImage( &sh.named[SH_StatusBar_HealthIcon], cgs.media.healthIcon, 0 );
+	}
+	if ( SH_Visible( &sh.named[SH_StatusBar_ArmorIcon] ) ) {
+		SH_DrawImage( &sh.named[SH_StatusBar_ArmorIcon], cgs.media.armorIcon, 0 );
+	}
+	if ( SH_Visible( &sh.named[SH_StatusBar_AmmoIcon] ) && cent->currentState.weapon ) {
+		SH_DrawImage( &sh.named[SH_StatusBar_AmmoIcon], cg_weapons[cent->currentState.weapon].ammoIcon, 0 );
+	}
+
+	hfrac = (float)ps->stats[STAT_HEALTH] / (float)( maxH > 100 ? maxH : 100 );
+	afrac = (float)ps->stats[STAT_ARMOR] / 200.0f;
+	mfrac = ammo > 0 ? ( ammo / 200.0f ) : 0.0f;
+	if ( SH_Visible( &sh.named[SH_StatusBar_HealthBar] ) ) {
+		SH_DrawBar( &sh.named[SH_StatusBar_HealthBar], hfrac );
+	}
+	if ( SH_Visible( &sh.named[SH_StatusBar_ArmorBar] ) ) {
+		SH_DrawBar( &sh.named[SH_StatusBar_ArmorBar], afrac );
+	}
+	if ( SH_Visible( &sh.named[SH_StatusBar_AmmoBar] ) ) {
+		SH_DrawBar( &sh.named[SH_StatusBar_AmmoBar], mfrac );
+	}
+}
+
+static void SH_DrawFPSElem( void ) {
+	static int previousTimes[4];
+	static int index;
+	int t, i, total;
+	int fps;
+	char buf[32];
+	static int previous;
+
+	if ( !SH_Visible( &sh.named[SH_FPS] ) ) {
+		return;
+	}
+	t = trap_Milliseconds();
+	previousTimes[index % 4] = t - previous;
+	previous = t;
+	total = 0;
+	for ( i = 0; i < 4; i++ ) {
+		total += previousTimes[i];
+	}
+	if ( total == 0 ) {
+		total = 1;
+	}
+	fps = 4000 / total;
+	index++;
+	Com_sprintf( buf, sizeof( buf ), "%ifps", fps );
+	SH_DrawFill( &sh.named[SH_FPS] );
+	SH_DrawString( &sh.named[SH_FPS], buf, 0 );
+}
+
+static void SH_DrawGameTime( void ) {
+	int msec, mins, seconds;
+	char buf[32];
+
+	if ( !SH_Visible( &sh.named[SH_GameTime] ) ) {
+		return;
+	}
+	msec = cg.time - cgs.levelStartTime;
+	if ( msec < 0 ) {
+		msec = 0;
+	}
+	seconds = msec / 1000;
+	mins = seconds / 60;
+	seconds %= 60;
+	Com_sprintf( buf, sizeof( buf ), "%i:%02i", mins, seconds );
+	SH_DrawFill( &sh.named[SH_GameTime] );
+	SH_DrawString( &sh.named[SH_GameTime], buf, 0 );
+}
+
+static void SH_DrawScores( void ) {
+	char buf[32];
+	if ( SH_Visible( &sh.named[SH_Score_OWN] ) ) {
+		SH_DrawFill( &sh.named[SH_Score_OWN] );
+		Com_sprintf( buf, sizeof( buf ), "%i", SH_OwnScore() );
+		SH_DrawString( &sh.named[SH_Score_OWN], buf, 0 );
+	}
+	if ( SH_Visible( &sh.named[SH_Score_NME] ) ) {
+		SH_DrawFill( &sh.named[SH_Score_NME] );
+		Com_sprintf( buf, sizeof( buf ), "%i", SH_NmeScore() );
+		SH_DrawString( &sh.named[SH_Score_NME], buf, 0 );
+	}
+	if ( SH_Visible( &sh.named[SH_Score_Limit] ) && cgs.fraglimit ) {
+		SH_DrawFill( &sh.named[SH_Score_Limit] );
+		Com_sprintf( buf, sizeof( buf ), "%i", cgs.fraglimit );
+		SH_DrawString( &sh.named[SH_Score_Limit], buf, 0 );
+	}
+}
+
+static void SH_DrawSpeed( void ) {
+	vec3_t vel;
+	char buf[32];
+	int speed;
+
+	if ( !SH_Visible( &sh.named[SH_PlayerSpeed] ) ) {
+		return;
+	}
+	VectorCopy( cg.snap->ps.velocity, vel );
+	vel[2] = 0;
+	speed = (int)VectorLength( vel );
+	Com_sprintf( buf, sizeof( buf ), "%i", speed );
+	SH_DrawFill( &sh.named[SH_PlayerSpeed] );
+	SH_DrawString( &sh.named[SH_PlayerSpeed], buf, 0 );
+}
+
+static void SH_DrawPing( void ) {
+	char buf[32];
+	if ( !SH_Visible( &sh.named[SH_NetGraphPing] ) ) {
+		return;
+	}
+	Com_sprintf( buf, sizeof( buf ), "%i", cg.snap->ping );
+	SH_DrawFill( &sh.named[SH_NetGraphPing] );
+	SH_DrawString( &sh.named[SH_NetGraphPing], buf, 0 );
+}
+
+static void SH_DrawNetGraph( void ) {
+	shElement_t *e = &sh.named[SH_NetGraph];
+	static int pingHist[64];
+	static int pingHistCount;
+	float x, y, w, h;
+	int i, samples;
+	float barW;
+	vec4_t c;
+
+	if ( !SH_Visible( e ) ) {
+		return;
+	}
+	/* Only paint a backdrop when the cfg asked for fill/bg — a later
+	 * !DEFAULT often leaves bgcolor alpha > 0 which looked like an empty box. */
+	if ( e->fill || e->bgcolor[3] > 0.01f ) {
+		SH_DrawFill( e );
+	}
+
+	pingHist[pingHistCount % 64] = cg.snap->ping;
+	pingHistCount++;
+
+	x = e->xpos;
+	y = e->ypos;
+	w = e->width > 0 ? e->width : 48;
+	h = e->height > 0 ? e->height : 24;
+	samples = (int)w;
+	if ( samples > 64 ) {
+		samples = 64;
+	}
+	if ( samples < 1 ) {
+		samples = 1;
+	}
+	barW = w / (float)samples;
+	SH_ResolveColor( e, c, qfalse );
+	if ( c[3] < 0.2f ) {
+		c[0] = c[1] = c[2] = 1.0f;
+		c[3] = 0.75f;
+	}
+	for ( i = 0; i < samples; i++ ) {
+		int idx = ( pingHistCount - 1 - i + 64 * 8 ) % 64;
+		float ping = (float)pingHist[idx];
+		float frac = ping / 200.0f;
+		vec4_t bc;
+
+		if ( pingHistCount <= i ) {
+			break;
+		}
+		if ( frac > 1.0f ) {
+			frac = 1.0f;
+		}
+		Vector4Copy( c, bc );
+		if ( ping > 100.0f ) {
+			bc[1] *= 0.4f;
+			bc[2] *= 0.4f;
+		}
+		CG_FillRect( x + w - ( i + 1 ) * barW, y + h * ( 1.0f - frac ), barW, h * frac, bc );
+	}
+}
+
+static void SH_DrawPowerups( void ) {
+	playerState_t *ps = &cg.snap->ps;
+	int slots[4] = { 0, 0, 0, 0 };
+	int times[4] = { 0, 0, 0, 0 };
+	int n = 0;
+	int i;
+	int iconIds[4] = { SH_PowerUp1_Icon, SH_PowerUp2_Icon, SH_PowerUp3_Icon, SH_PowerUp4_Icon };
+	int timeIds[4] = { SH_PowerUp1_Time, SH_PowerUp2_Time, SH_PowerUp3_Time, SH_PowerUp4_Time };
+
+	for ( i = 0; i < PW_NUM_POWERUPS && n < 4; i++ ) {
+		if ( ps->powerups[i] > cg.time ) {
+			gitem_t *item = BG_FindItemForPowerup( i );
+			if ( !item ) {
+				continue;
+			}
+			slots[n] = trap_R_RegisterShader( item->icon );
+			times[n] = ( ps->powerups[i] - cg.time ) / 1000;
+			n++;
+		}
+	}
+	for ( i = 0; i < 4; i++ ) {
+		if ( i < n && SH_Visible( &sh.named[iconIds[i]] ) ) {
+			SH_DrawImage( &sh.named[iconIds[i]], slots[i], 0 );
+		}
+		if ( i < n && SH_Visible( &sh.named[timeIds[i]] ) ) {
+			char buf[16];
+			Com_sprintf( buf, sizeof( buf ), "%i", times[i] );
+			SH_DrawString( &sh.named[timeIds[i]], buf, 0 );
+		}
+	}
+}
+
+static void SH_DrawWeaponList( void ) {
+	shElement_t *e = &sh.named[SH_WeaponList];
+	int i;
+	float x, y, w, h;
+	int bits;
+
+	if ( !SH_Visible( e ) ) {
+		return;
+	}
+	w = e->width > 0 ? e->width : 32;
+	h = e->height > 0 ? e->height : 16;
+	bits = cg.snap->ps.stats[STAT_WEAPONS];
+	x = e->xpos;
+	y = e->ypos;
+	if ( e->textAlign == SH_ALIGN_C ) {
+		int count = 0;
+		for ( i = WP_MACHINEGUN; i <= WP_BFG; i++ ) {
+			if ( bits & ( 1 << i ) ) {
+				count++;
+			}
+		}
+		x = e->xpos - ( count * w ) * 0.5f;
+	}
+	for ( i = WP_GAUNTLET; i <= WP_BFG; i++ ) {
+		char buf[16];
+		if ( !( bits & ( 1 << i ) ) && !e->fill ) {
+			continue;
+		}
+		if ( !cg_weapons[i].weaponIcon ) {
+			continue;
+		}
+		trap_R_SetColor( e->color );
+		CG_DrawPic( x, y, h, h, cg_weapons[i].weaponIcon );
+		trap_R_SetColor( NULL );
+		Com_sprintf( buf, sizeof( buf ), "%i", cg.snap->ps.ammo[i] );
+		CG_DrawStringExt( (int)( x + h ), (int)y, buf, e->color, qfalse,
+				( e->textstyle & 1 ) ? qtrue : qfalse,
+				e->fontWidth > 0 ? e->fontWidth : 8,
+				e->fontHeight > 0 ? e->fontHeight : 8, 0 );
+		y += h;
+		if ( y + h > 480 ) {
+			y = e->ypos;
+			x += w;
+		}
+	}
+}
+
+static void SH_DrawPickup( void ) {
+	gitem_t *item;
+
+	if ( !cg.itemPickupTime || cg.itemPickup <= 0 || cg.itemPickup >= bg_numItems ) {
+		return;
+	}
+	item = &bg_itemlist[cg.itemPickup];
+	if ( !item || !item->classname ) {
+		return;
+	}
+	CG_RegisterItemVisuals( cg.itemPickup );
+	if ( SH_Visible( &sh.named[SH_ItemPickup] ) && item->pickup_name ) {
+		SH_DrawString( &sh.named[SH_ItemPickup], item->pickup_name, cg.itemPickupTime );
+	}
+	if ( SH_Visible( &sh.named[SH_ItemPickupIcon] ) ) {
+		qhandle_t h = cg_items[cg.itemPickup].icon;
+		if ( h ) {
+			SH_DrawImage( &sh.named[SH_ItemPickupIcon], h, cg.itemPickupTime );
+		}
+	}
+}
+
+static void SH_DrawAmmoMessage( void ) {
+	centity_t *cent = &cg_entities[cg.snap->ps.clientNum];
+	int ammo;
+	const char *msg = NULL;
+
+	if ( !SH_Visible( &sh.named[SH_AmmoMessage] ) ) {
+		return;
+	}
+	if ( !cent->currentState.weapon ) {
+		return;
+	}
+	ammo = cg.snap->ps.ammo[cent->currentState.weapon];
+	if ( ammo == 0 ) {
+		msg = "OUT OF AMMO";
+	} else if ( ammo <= 5 ) {
+		msg = "LOW AMMO";
+	}
+	if ( msg ) {
+		SH_DrawString( &sh.named[SH_AmmoMessage], msg, cg.time - 500 );
+	}
+}
+
+static void SH_DrawAttacker( void ) {
+	if ( !cg.attackerTime ) {
+		return;
+	}
+	if ( SH_Visible( &sh.named[SH_AttackerName] ) && cg.killerName[0] ) {
+		SH_DrawString( &sh.named[SH_AttackerName], cg.killerName, cg.attackerTime );
+	}
+	if ( SH_Visible( &sh.named[SH_AttackerIcon] ) ) {
+		int client = cg.snap->ps.persistant[PERS_ATTACKER];
+		if ( client >= 0 && client < MAX_CLIENTS && cgs.clientinfo[client].infoValid ) {
+			SH_DrawImage( &sh.named[SH_AttackerIcon], cgs.clientinfo[client].modelIcon, cg.attackerTime );
+		}
+	}
+}
+
+static void SH_DrawFlags( void ) {
+	if ( cgs.gametype != GT_CTF && cgs.gametype != GT_CTF_ELIMINATION
+#ifdef MISSIONPACK
+			&& cgs.gametype != GT_1FCTF
+#endif
+			) {
+		return;
+	}
+	if ( SH_Visible( &sh.named[SH_FlagStatus_OWN] ) ) {
+		int team = cg.snap->ps.persistant[PERS_TEAM];
+		SH_DrawFill( &sh.named[SH_FlagStatus_OWN] );
+		CG_DrawFlagModel( sh.named[SH_FlagStatus_OWN].xpos, sh.named[SH_FlagStatus_OWN].ypos,
+				sh.named[SH_FlagStatus_OWN].width, sh.named[SH_FlagStatus_OWN].height, team, qtrue );
+	}
+	if ( SH_Visible( &sh.named[SH_FlagStatus_NME] ) ) {
+		int team = cg.snap->ps.persistant[PERS_TEAM];
+		int enemy = ( team == TEAM_RED ) ? TEAM_BLUE : TEAM_RED;
+		SH_DrawFill( &sh.named[SH_FlagStatus_NME] );
+		CG_DrawFlagModel( sh.named[SH_FlagStatus_NME].xpos, sh.named[SH_FlagStatus_NME].ypos,
+				sh.named[SH_FlagStatus_NME].width, sh.named[SH_FlagStatus_NME].height, enemy, qtrue );
+	}
+}
+
+static void SH_DrawTarget( void ) {
+	clientInfo_t *ci;
+	char buf[64];
+
+	if ( cg.crosshairClientTime + 1000 < cg.time ) {
+		return;
+	}
+	if ( cg.crosshairClientNum < 0 || cg.crosshairClientNum >= MAX_CLIENTS ) {
+		return;
+	}
+	ci = &cgs.clientinfo[cg.crosshairClientNum];
+	if ( !ci->infoValid ) {
+		return;
+	}
+	if ( SH_Visible( &sh.named[SH_TargetName] ) ) {
+		SH_DrawString( &sh.named[SH_TargetName], ci->name, cg.crosshairClientTime );
+	}
+	if ( SH_Visible( &sh.named[SH_TargetStatus] ) && ci->team == cg.snap->ps.persistant[PERS_TEAM]
+			&& cgs.gametype >= GT_TEAM ) {
+		Com_sprintf( buf, sizeof( buf ), "%i/%i", ci->health, ci->armor );
+		SH_DrawString( &sh.named[SH_TargetStatus], buf, cg.crosshairClientTime );
+	}
+}
+
+static void SH_DrawChat( void ) {
+	int i;
+	int ids[8] = { SH_Chat1, SH_Chat2, SH_Chat3, SH_Chat4, SH_Chat5, SH_Chat6, SH_Chat7, SH_Chat8 };
+	int chatHeight = TEAMCHAT_HEIGHT;
+
+	if ( cgs.teamLastChatPos == cgs.teamChatPos ) {
+		return;
+	}
+	for ( i = 0; i < 8; i++ ) {
+		int msgIndex;
+		shElement_t *e = &sh.named[ids[i]];
+		if ( !SH_Visible( e ) ) {
+			continue;
+		}
+		msgIndex = cgs.teamChatPos - 1 - i;
+		if ( msgIndex < cgs.teamLastChatPos ) {
+			continue;
+		}
+		if ( cg.time - cgs.teamChatMsgTimes[msgIndex % chatHeight] >
+				( e->time > 0 ? e->time : cg_teamChatTime.integer ) ) {
+			continue;
+		}
+		SH_DrawFill( e );
+		SH_DrawString( e, cgs.teamChatMsgs[msgIndex % chatHeight],
+				cgs.teamChatMsgTimes[msgIndex % chatHeight] );
+	}
+}
+
+static void SH_DrawTeamOverlay( void ) {
+	int i, n = 0;
+	int ids[8] = { SH_Team1, SH_Team2, SH_Team3, SH_Team4, SH_Team5, SH_Team6, SH_Team7, SH_Team8 };
+	int myTeam = cg.snap->ps.persistant[PERS_TEAM];
+
+	if ( cgs.gametype < GT_TEAM || myTeam == TEAM_SPECTATOR ) {
+		return;
+	}
+	for ( i = 0; i < cgs.maxclients && n < 8; i++ ) {
+		clientInfo_t *ci = &cgs.clientinfo[i];
+		char buf[128];
+		shElement_t *e;
+		if ( !ci->infoValid || ci->team != myTeam ) {
+			continue;
+		}
+		e = &sh.named[ids[n]];
+		if ( !SH_Visible( e ) ) {
+			n++;
+			continue;
+		}
+		Com_sprintf( buf, sizeof( buf ), "%-12s %3i %3i", ci->name, ci->health, ci->armor );
+		SH_DrawFill( e );
+		SH_DrawString( e, buf, 0 );
+		n++;
+	}
+}
+
+static void SH_SplitCenterPrint( char *line1, int line1Size, char *line2, int line2Size ) {
+	const char *src = cg.centerPrint;
+	int i;
+
+	line1[0] = '\0';
+	line2[0] = '\0';
+	if ( !src || !src[0] ) {
+		return;
+	}
+	for ( i = 0; src[i] && src[i] != '\n' && i < line1Size - 1; i++ ) {
+		line1[i] = src[i];
+	}
+	line1[i] = '\0';
+	if ( src[i] == '\n' ) {
+		Q_strncpyz( line2, src + i + 1, line2Size );
+	}
+}
+
+static void SH_DrawMessages( void ) {
+	if ( cg.centerPrintTime &&
+			( SH_Visible( &sh.named[SH_FragMessage] ) || SH_Visible( &sh.named[SH_RankMessage] ) ) ) {
+		char line1[256];
+		char line2[256];
+		qboolean hasFrag = SH_Visible( &sh.named[SH_FragMessage] );
+		qboolean hasRank = SH_Visible( &sh.named[SH_RankMessage] );
+
+		SH_SplitCenterPrint( line1, sizeof( line1 ), line2, sizeof( line2 ) );
+		if ( hasFrag && line1[0] ) {
+			if ( !hasRank && line2[0] ) {
+				char buf[512];
+				Com_sprintf( buf, sizeof( buf ), "%s  %s", line1, line2 );
+				SH_DrawString( &sh.named[SH_FragMessage], buf, cg.centerPrintTime );
+			} else {
+				SH_DrawString( &sh.named[SH_FragMessage], line1, cg.centerPrintTime );
+			}
+		}
+		if ( hasRank ) {
+			if ( line2[0] ) {
+				SH_DrawString( &sh.named[SH_RankMessage], line2, cg.centerPrintTime );
+			} else if ( !hasFrag && line1[0] ) {
+				SH_DrawString( &sh.named[SH_RankMessage], line1, cg.centerPrintTime );
+			}
+		}
+	}
+	if ( SH_Visible( &sh.named[SH_FollowMessage] ) && ( cg.snap->ps.pm_flags & PMF_FOLLOW ) ) {
+		char buf[128];
+		Com_sprintf( buf, sizeof( buf ), "Following %s",
+				cgs.clientinfo[cg.snap->ps.clientNum].name );
+		SH_DrawString( &sh.named[SH_FollowMessage], buf, 0 );
+	}
+	if ( SH_Visible( &sh.named[SH_SpecMessage] ) &&
+			cg.snap->ps.persistant[PERS_TEAM] == TEAM_SPECTATOR ) {
+		SH_DrawString( &sh.named[SH_SpecMessage], "SPECTATOR", 0 );
+	}
+	if ( SH_Visible( &sh.named[SH_WarmupInfo] ) ) {
+		if ( cg.warmup < 0 ) {
+			SH_DrawString( &sh.named[SH_WarmupInfo], "Waiting for players", 0 );
+		} else if ( cg.warmup > 0 ) {
+			int sec = ( cg.warmup - cg.time ) / 1000;
+			char buf[32];
+			if ( sec < 0 ) {
+				sec = 0;
+			}
+			Com_sprintf( buf, sizeof( buf ), "Starts in: %i", sec + 1 );
+			SH_DrawString( &sh.named[SH_WarmupInfo], buf, 0 );
+		}
+	}
+	if ( SH_Visible( &sh.named[SH_GameType] ) && ( cg.warmup || !cg.snap->ps.stats[STAT_HEALTH] ) ) {
+		SH_DrawString( &sh.named[SH_GameType], SH_GameTypeString(), 0 );
+	}
+	if ( SH_Visible( &sh.named[SH_VoteMessageWorld] ) && cgs.voteTime ) {
+		char buf[256];
+		Com_sprintf( buf, sizeof( buf ), "VOTE(%i): %s",
+				( cgs.voteTime + VOTE_TIME - cg.time ) / 1000, cgs.voteString );
+		SH_DrawString( &sh.named[SH_VoteMessageWorld], buf, cgs.voteTime );
+	}
+	if ( SH_Visible( &sh.named[SH_Console] ) ) {
+		/* best-effort: last team chat line as notify stand-in */
+		int idx = ( cgs.teamChatPos - 1 + TEAMCHAT_HEIGHT ) % TEAMCHAT_HEIGHT;
+		if ( cgs.teamChatMsgs[idx][0] ) {
+			SH_DrawString( &sh.named[SH_Console], cgs.teamChatMsgs[idx], cgs.teamChatMsgTimes[idx] );
+		}
+	}
+}
+
+void CG_SH_DrawFrame( void ) {
+	int i;
+
+	if ( !sh.active || !cg.snap ) {
+		return;
+	}
+
+	CG_SH_CheckCvars();
+
+	for ( i = 0; i < sh.preCount; i++ ) {
+		SH_DrawDecor( &sh.preDecor[i] );
+	}
+
+	if ( !cg.showScores && cg.snap->ps.stats[STAT_HEALTH] > 0 &&
+			cg.snap->ps.persistant[PERS_TEAM] != TEAM_SPECTATOR ) {
+		SH_DrawStatusCounts();
+		SH_DrawPowerups();
+		SH_DrawWeaponList();
+		SH_DrawAmmoMessage();
+		SH_DrawPickup();
+		SH_DrawFlags();
+	}
+
+	SH_DrawFPSElem();
+	SH_DrawGameTime();
+	SH_DrawScores();
+	SH_DrawSpeed();
+	SH_DrawPing();
+	SH_DrawNetGraph();
+	SH_DrawAttacker();
+	SH_DrawTarget();
+	SH_DrawChat();
+	SH_DrawTeamOverlay();
+	SH_DrawMessages();
+
+	for ( i = 0; i < sh.postCount; i++ ) {
+		SH_DrawDecor( &sh.postDecor[i] );
+	}
+}
+
+qboolean CG_SH_HasWeaponList( void ) {
+	return sh.active && SH_Visible( &sh.named[SH_WeaponList] );
+}
+
+qboolean CG_SH_HasChat( void ) {
+	return sh.active && SH_Visible( &sh.named[SH_Chat1] );
+}
+
+qboolean CG_SH_HasNetGraph( void ) {
+	return sh.active && SH_Visible( &sh.named[SH_NetGraph] );
+}
+
+qboolean CG_SH_HasCenterMessages( void ) {
+	return sh.active &&
+			( SH_Visible( &sh.named[SH_FragMessage] ) || SH_Visible( &sh.named[SH_RankMessage] ) );
+}

--- a/ratoa_gamecode/code/game/bg_cvar_desc.c
+++ b/ratoa_gamecode/code/game/bg_cvar_desc.c
@@ -656,6 +656,8 @@ static const cvarDesc_t cgameCvarDescriptions[] = {
 	{ "cg_zoomToggle", "When `1`, the zoom key toggles zoom on and off instead of needing to be held." },
 	{ "cg_zoomfov", "Field of view while zoomed." },
 	{ "cg_zoomfovTmp", "Temporary storage of your FOV before zooming; restored on zoom-out. Leave alone." },
+	{ "ch_file", "SuperHUD config basename under `hud/` (without `.cfg`). Empty disables SuperHUD. See [SUPERHUD.md](SUPERHUD.md)." },
+	{ "ch_hiddenElements", "Space-separated SuperHUD element names to hide (`hud_hide` / `hud_show` update this)." },
 	{ "cl_paused", "Read-only: `1` while the game is paused." },
 	{ "cl_timeNudge", "Milliseconds to shift incoming snapshots for smoother playback, at the cost of added delay." },
 	{ "com_blood", "When `1`, shows blood and gore effects." },

--- a/ratoa_gamecode/windows_scripts/cgame.q3asm
+++ b/ratoa_gamecode/windows_scripts/cgame.q3asm
@@ -18,6 +18,7 @@ cg_scoreboard
 cg_servercmds
 cg_snapshot
 cg_demo_history
+cg_superhud
 cg_unlagged
 cg_view
 cg_weapons

--- a/ratoa_gamecode/windows_scripts/cgame_mp.q3asm
+++ b/ratoa_gamecode/windows_scripts/cgame_mp.q3asm
@@ -19,6 +19,7 @@ cg_scoreboard
 cg_servercmds
 cg_snapshot
 cg_demo_history
+cg_superhud
 cg_unlagged
 cg_view
 cg_weapons

--- a/ratoa_gamecode/windows_scripts/windows_compile_cgame.bat
+++ b/ratoa_gamecode/windows_scripts/windows_compile_cgame.bat
@@ -37,6 +37,7 @@ cd windows\build\cgame
 %cc%  ../../../code/cgame/cg_servercmds.c
 %cc%  ../../../code/cgame/cg_snapshot.c
 %cc%  ../../../code/cgame/cg_demo_history.c
+%cc%  ../../../code/cgame/cg_superhud.c
 %cc%  ../../../code/cgame/cg_unlagged.c
 %cc%  ../../../code/cgame/cg_view.c
 %cc%  ../../../code/cgame/cg_weapons.c

--- a/ratoa_gamecode/windows_scripts/windows_compile_cgame_missionpack.bat
+++ b/ratoa_gamecode/windows_scripts/windows_compile_cgame_missionpack.bat
@@ -37,6 +37,7 @@ cd windows\build\cgame
 %cc%  ../../../code/cgame/cg_servercmds.c
 %cc%  ../../../code/cgame/cg_snapshot.c
 %cc%  ../../../code/cgame/cg_demo_history.c
+%cc%  ../../../code/cgame/cg_superhud.c
 %cc%  ../../../code/cgame/cg_unlagged.c
 %cc%  ../../../code/cgame/cg_view.c
 %cc%  ../../../code/cgame/cg_weapons.c


### PR DESCRIPTION
It is SuperHUD.

Compatible with existing HUD .cfg files from CPMA etc.

Skip over any elements not implemented in the backing game code (e.g. item timers).

Build clean-room styles from scant available source and CaudeStarr's partial implementation on a fork of Devo a few years back.

Usage:
\ch_file - When empty/blank, SuperHUD is disabled. Populate with a path to a hud file (defaults to .cfg files in \hud) to turn it on. Three configs ship with the PK3 that can be enabled immediately:
- devotion_default.cfg
- test_oldstyle.cfg
- test_status.cfg \reloadHUD - Reload the current configuration file in-game after editing it