### PR TITLE
Improved cg_autoRecord

### DIFF
--- a/docs/CLIENT-CVARS.md
+++ b/docs/CLIENT-CVARS.md
@@ -28,7 +28,7 @@ Client-side variables registered by the **cgame** module (`cg_*`, plus related n
 | `cg_announcer` | RatMod | `quake3` | string or numeric (see default) | Announcer voice pack for match callouts (e.g. `quake3`). |
 | `cg_announcerNewAwards` | RatMod | `` | string or numeric (see default) | Announcer pack for newer award callouts; empty uses `cg_announcer`. |
 | `cg_attackerScale` | RatMod | `0.75` | float | Size of the last-attacker icon/name shown when `cg_drawAttacker` is on. |
-| `cg_autorecord` | RatMod | `0` | 0 or 1 | When `1`, automatically records demos for supported matches (such as duels). |
+| `cg_autorecord` | RatMod | `0` | 0 or 1 | When `1`, automatically records a demo/replay for each match. Starts 10 seconds before match start, ends after final scoreboard |
 | `cg_autoswitch` | Vanilla | `0` | 0 or 1 | When `1`, automatically switches to a newly picked-up weapon if it is better. |
 | `cg_autovertex` | RatMod | `0` | 0 or 1 | When `1`, enables vertex lighting on maps that need it, restoring your old setting when turned off. |
 | `cg_backupDrawflat` | RatMod | `-1` | integer >= 0 (typical) | Temporary backup of `r_drawFlat` while video settings are locked; leave alone. |

--- a/ratoa_gamecode/code/cgame/cg_consolecmds.c
+++ b/ratoa_gamecode/code/cgame/cg_consolecmds.c
@@ -1353,14 +1353,14 @@ static void CG_Rec_f( void ) {
 	char demoName[MAX_OSPATH];
 	char cmd[MAX_STRING_CHARS];
 
+	if ( cg.demoPlayback || cg.demoRecording ) {
+		return;
+	}
+
 	if ( trap_Argc() > 1 ) {
 		Com_sprintf( cmd, sizeof( cmd ), "record %s\n", ConcatArgs( 1 ) );
 		trap_SendConsoleCommand( cmd );
 		cg.demoRecording = qtrue;
-		return;
-	}
-
-	if ( cg.demoPlayback ) {
 		return;
 	}
 
@@ -1463,6 +1463,20 @@ qboolean CG_ConsoleCommand( void ) {
 	int		i;
 
 	cmd = CG_Argv(0);
+
+	if ( !Q_stricmp( cmd, "stoprecord" ) ) {
+		cg.autoRecording = qfalse;
+		cg.demoRecording = qfalse;
+		return qfalse;
+	}
+
+	if ( !Q_stricmp( cmd, "record" ) ) {
+		if ( !cg.demoRecording ) {
+			cg.demoRecording = qtrue;
+			cg.autoRecording = qfalse;
+		}
+		return qfalse;
+	}
 
 	for ( i = 0 ; i < sizeof( commands ) / sizeof( commands[0] ) ; i++ ) {
 		if ( !Q_stricmp( cmd, commands[i].cmd ) ) {

--- a/ratoa_gamecode/code/cgame/cg_local.h
+++ b/ratoa_gamecode/code/cgame/cg_local.h
@@ -653,6 +653,7 @@ typedef struct {
 	
 	qboolean	demoPlayback;
 	qboolean	demoRecording;
+	qboolean	autoRecording;			// demoRecording was started by cg_autorecord
 	qboolean	levelShot;			// taking a level menu screenshot
 	int			deferredPlayerLoading;
 	qboolean	loading;			// don't defer players at initial startup

--- a/ratoa_gamecode/code/cgame/cg_main.c
+++ b/ratoa_gamecode/code/cgame/cg_main.c
@@ -2697,6 +2697,7 @@ Called before every level change or subsystem restart
 void CG_Shutdown( void ) {
 	// some mods may need to do cleanup work here,
 	// like closing files or archiving session data
+	CG_AutoRecordStop();
 	CG_MenuHud_Shutdown();
 	CG_DemoHistory_Clear();
 	challenges_save();
@@ -3092,14 +3093,16 @@ void CG_BuildDemoFilename( char *demoName, int demoNameSize ) {
 	CG_SanitizeDemoFilenameChars( demoName );
 }
 
+#define CG_AUTORECORD_PREFIGHT_MS 10000
+
 void CG_AutoRecordStart(void) {
 	char demoName[MAX_OSPATH];
 
-	if (cg.demoPlayback) {
+	if (cg.demoPlayback || cg.demoRecording || !cg_autorecord.integer) {
 		return;
 	}
 
-	if (!cg_autorecord.integer) {
+	if (!cg.snap) {
 		return;
 	}
 
@@ -3107,16 +3110,29 @@ void CG_AutoRecordStart(void) {
 		return;
 	}
 
+	// Waiting for players / ready-up. CS_WARMUP is a timestamp; start
+	// 10s before it elapses so this tracks g_warmup and ready rules.
+	if (cg.warmup < 0) {
+		return;
+	}
+	if (cg.warmup > 0 && cg.warmup - cg.time > CG_AUTORECORD_PREFIGHT_MS) {
+		return;
+	}
+
 	CG_BuildDemoFilename( demoName, sizeof( demoName ) );
 	trap_SendConsoleCommand(va("record \"%s\"\n", demoName));
 	cg.demoRecording = qtrue;
+	cg.autoRecording = qtrue;
 }
 
 void CG_AutoRecordStop(void) {
-	if (cg.demoRecording) {
-		trap_SendConsoleCommand("stoprecord\n");
-		cg.demoRecording = qfalse;
+	if (!cg.autoRecording) {
+		return;
 	}
+
+	trap_SendConsoleCommand("stoprecord\n");
+	cg.autoRecording = qfalse;
+	cg.demoRecording = qfalse;
 }
 
 qboolean CG_IsTeamGametype(void) {

--- a/ratoa_gamecode/code/cgame/cg_servercmds.c
+++ b/ratoa_gamecode/code/cgame/cg_servercmds.c
@@ -1341,6 +1341,10 @@ static void CG_ParseWarmup( void ) {
 	}
 
 	cg.warmup = warmup;
+
+	if ( cg.warmup > 0 ) {
+		CG_AutoRecordStart();
+	}
 }
 
 #ifdef WITH_MULTITOURNAMENT
@@ -1683,7 +1687,14 @@ static void CG_MapRestart( void ) {
 
 	cg.timelimitWarnings = 0;
 
-	cg.intermissionStarted = qfalse;
+	{
+		qboolean wasIntermission = cg.intermissionStarted;
+
+		cg.intermissionStarted = qfalse;
+		if ( wasIntermission ) {
+			CG_AutoRecordStop();
+		}
+	}
 
 	cgs.voteTime = 0;
 
@@ -1705,8 +1716,8 @@ static void CG_MapRestart( void ) {
 		CG_AutoRecordStart();
 		trap_S_StartLocalSound( cgs.media.countFightSound, CHAN_ANNOUNCER );
 		CG_CenterPrint( "FIGHT!", 120, GIANTCHAR_WIDTH*2 );
-	} else {
-		CG_AutoRecordStop();
+	} else if ( cg.warmup > 0 ) {
+		CG_AutoRecordStart();
 	}
 #ifdef MISSIONPACK
 	if (cg_singlePlayerActive.integer) {

--- a/ratoa_gamecode/code/cgame/cg_view.c
+++ b/ratoa_gamecode/code/cgame/cg_view.c
@@ -1028,6 +1028,10 @@ void CG_DrawActiveFrame( int serverTime, stereoFrame_t stereoView, qboolean demo
 
 	CG_DemoHistory_Frame();
 
+	if ( cg.warmup > 0 ) {
+		CG_AutoRecordStart();
+	}
+
 	// let the client system know what our weapon and zoom settings are
 	trap_SetUserCmdValue( cg.weaponSelect, cg.zoomSensitivity );
 

--- a/ratoa_gamecode/code/game/bg_cvar_desc.c
+++ b/ratoa_gamecode/code/game/bg_cvar_desc.c
@@ -366,7 +366,7 @@ static const cvarDesc_t cgameCvarDescriptions[] = {
 	{ "cg_announcer", "Announcer voice pack for match callouts (e.g. `quake3`)." },
 	{ "cg_announcerNewAwards", "Announcer pack for newer award callouts; empty uses `cg_announcer`." },
 	{ "cg_attackerScale", "Size of the last-attacker icon/name shown when `cg_drawAttacker` is on." },
-	{ "cg_autorecord", "When `1`, automatically records demos for supported matches (such as duels)." },
+	{ "cg_autorecord", "When `1`, automatically records a demo/replay for each match. Starts 10 seconds before match start, ends after final scoreboard." },
 	{ "cg_autoswitch", "When `1`, automatically switches to a newly picked-up weapon if it is better." },
 	{ "cg_autovertex", "When `1`, enables vertex lighting on maps that need it, restoring your old setting when turned off." },
 	{ "cg_backupDrawflat", "Temporary backup of `r_drawFlat` while video settings are locked; leave alone." },


### PR DESCRIPTION
Improved behavior of cg_autoRecord so that:
- Recording starts 10 seconds before match start
- Recording ends after match-end scoreboard
- A separate recording is generated for each match, rather than carrying over between contiguous matches.