### PR TITLE
Replay tweaks

### DIFF
--- a/ratoa_gamecode/code/cgame/cg_demo_history.c
+++ b/ratoa_gamecode/code/cgame/cg_demo_history.c
@@ -41,6 +41,8 @@ void CG_DemoHistory_Clear( void ) {
 	cg_demoDelagPingSmoothed = -1;
 	for ( i = 0; i < MAX_GENTITIES; i++ ) {
 		cg_entities[i].demoDelagVisualCached = qfalse;
+		cg_entities[i].demoDelagDrawStateValid = qfalse;
+		cg_entities[i].demoDelagLastVisualEFlagsValid = qfalse;
 	}
 	Com_Memset( cg_demoHistoryBuf, 0, sizeof( cg_demoHistoryBuf ) );
 }
@@ -127,6 +129,22 @@ const snapshot_t *CG_DemoHistory_GetByFramesAgo( int framesAgo ) {
 
 qboolean CG_DemoHistory_DemoDelagActive( void ) {
 	return cg.demoPlayback && cg_demoDelag.integer && cgs.delagHitscan && CG_DemoHistory_GetCount() > 0;
+}
+
+qboolean CG_DemoHistory_SuppressLivePlayerTeleportEvent( int clientNum ) {
+	if ( !CG_DemoHistory_DemoDelagActive() ) {
+		return qfalse;
+	}
+	if ( !cg.snap ) {
+		return qfalse;
+	}
+	if ( clientNum < 0 || clientNum >= MAX_CLIENTS ) {
+		return qfalse;
+	}
+	if ( clientNum == cg.predictedPlayerState.clientNum ) {
+		return qfalse;
+	}
+	return qtrue;
 }
 
 static qboolean findEntityInSnapshot( const snapshot_t *snap, int entityNum, entityState_t *out ) {
@@ -304,8 +322,28 @@ int CG_DemoHistory_LocalFireDelay( void ) {
 	return ping;
 }
 
+static qboolean demoDelagEFlagsTeleported( int eFlagsA, int eFlagsB ) {
+	return ( ( eFlagsA ^ eFlagsB ) & EF_TELEPORT_BIT ) != 0;
+}
+
+static void demoDelagEvalEsPose( const entityState_t *es, int time, vec3_t origin, vec_t *anglesOpt, int *solidOpt, int *eFlagsOpt, entityState_t *outEsOpt ) {
+	BG_EvaluateTrajectory( &es->pos, time, origin );
+	if ( anglesOpt ) {
+		BG_EvaluateTrajectory( &es->apos, time, anglesOpt );
+	}
+	if ( solidOpt ) {
+		*solidOpt = es->solid;
+	}
+	if ( eFlagsOpt ) {
+		*eFlagsOpt = es->eFlags;
+	}
+	if ( outEsOpt ) {
+		*outEsOpt = *es;
+	}
+}
+
 static void entityPoseFromBracket( int entityNum, int evalTime, const snapshot_t *sOld, const snapshot_t *sNew, float frac,
-		vec3_t outOrigin, vec_t *outAnglesOpt, int *outSolidOpt, qboolean *outOk ) {
+		vec3_t outOrigin, vec_t *outAnglesOpt, int *outSolidOpt, int *outEFlagsOpt, entityState_t *outEsOpt, qboolean *outOk ) {
 	entityState_t esLo, esHi;
 	qboolean hasLo, hasHi;
 	vec3_t oLo, oHi;
@@ -319,11 +357,20 @@ static void entityPoseFromBracket( int entityNum, int evalTime, const snapshot_t
 	hasHi = findEntityInSnapshot( sNew, entityNum, &esHi );
 
 	if ( hasLo && hasHi && sOld != sNew && sOld->serverTime < sNew->serverTime ) {
-		/* Always lerp endpoints so frac 0/1 stay continuous with the open interval. */
 		if ( frac < 0.0f ) {
 			frac = 0.0f;
 		} else if ( frac > 1.0f ) {
 			frac = 1.0f;
+		}
+		/* Respawn and teleporters flip EF_TELEPORT_BIT; do not lerp through the world. */
+		if ( demoDelagEFlagsTeleported( esLo.eFlags, esHi.eFlags ) ) {
+			if ( frac < 1.0f ) {
+				demoDelagEvalEsPose( &esLo, sOld->serverTime, outOrigin, outAnglesOpt, outSolidOpt, outEFlagsOpt, outEsOpt );
+			} else {
+				demoDelagEvalEsPose( &esHi, sNew->serverTime, outOrigin, outAnglesOpt, outSolidOpt, outEFlagsOpt, outEsOpt );
+			}
+			*outOk = qtrue;
+			return;
 		}
 		BG_EvaluateTrajectory( &esLo.pos, sOld->serverTime, oLo );
 		BG_EvaluateTrajectory( &esHi.pos, sNew->serverTime, oHi );
@@ -341,46 +388,40 @@ static void entityPoseFromBracket( int entityNum, int evalTime, const snapshot_t
 		if ( outSolidOpt ) {
 			*outSolidOpt = ( frac < 1.0f ) ? esLo.solid : esHi.solid;
 		}
+		if ( outEFlagsOpt ) {
+			*outEFlagsOpt = ( frac < 1.0f ) ? esLo.eFlags : esHi.eFlags;
+		}
+		if ( outEsOpt ) {
+			*outEsOpt = ( frac < 1.0f ) ? esLo : esHi;
+		}
 		*outOk = qtrue;
 		return;
 	}
 	if ( hasLo ) {
-		BG_EvaluateTrajectory( &esLo.pos, evalTime, outOrigin );
-		if ( outAnglesOpt ) {
-			BG_EvaluateTrajectory( &esLo.apos, evalTime, outAnglesOpt );
-		}
-		if ( outSolidOpt ) {
-			*outSolidOpt = esLo.solid;
-		}
+		demoDelagEvalEsPose( &esLo, evalTime, outOrigin, outAnglesOpt, outSolidOpt, outEFlagsOpt, outEsOpt );
 		*outOk = qtrue;
 	} else if ( hasHi ) {
-		BG_EvaluateTrajectory( &esHi.pos, evalTime, outOrigin );
-		if ( outAnglesOpt ) {
-			BG_EvaluateTrajectory( &esHi.apos, evalTime, outAnglesOpt );
-		}
-		if ( outSolidOpt ) {
-			*outSolidOpt = esHi.solid;
-		}
+		demoDelagEvalEsPose( &esHi, evalTime, outOrigin, outAnglesOpt, outSolidOpt, outEFlagsOpt, outEsOpt );
 		*outOk = qtrue;
 	}
 }
 
-static qboolean getEntityPoseAtHistoryTime( int entityNum, int serverTime, vec3_t outOrigin, vec3_t outAngles ) {
+static qboolean getEntityPoseAtHistoryTime( int entityNum, int serverTime, vec3_t outOrigin, vec3_t outAngles, int *outEFlags, entityState_t *outEs ) {
 	const snapshot_t *sOld, *sNew;
 	float frac;
 	qboolean ok;
 
 	bracketServerTime( serverTime, &sOld, &sNew, &frac );
-	entityPoseFromBracket( entityNum, serverTime, sOld, sNew, frac, outOrigin, outAngles, NULL, &ok );
+	entityPoseFromBracket( entityNum, serverTime, sOld, sNew, frac, outOrigin, outAngles, NULL, outEFlags, outEs, &ok );
 	return ok;
 }
 
 static void computeRewoundPlayerState( int entityNum, int evalTime, const snapshot_t *sOld, const snapshot_t *sNew, float frac,
 		vec3_t outOrigin, int *outSolid, qboolean *outOk ) {
-	entityPoseFromBracket( entityNum, evalTime, sOld, sNew, frac, outOrigin, NULL, outSolid, outOk );
+	entityPoseFromBracket( entityNum, evalTime, sOld, sNew, frac, outOrigin, NULL, outSolid, NULL, NULL, outOk );
 }
 
-static qboolean demoDelagPoseFromActiveSnapWindow( const centity_t *cent, int tHist, vec3_t outOrigin, vec3_t outAngles ) {
+static qboolean demoDelagPoseFromActiveSnapWindow( const centity_t *cent, int tHist, vec3_t outOrigin, vec3_t outAngles, int *outEFlags, entityState_t *outEs ) {
 	vec3_t curp, nxtp, cura, nxta;
 	float f;
 	int delta;
@@ -396,6 +437,14 @@ static qboolean demoDelagPoseFromActiveSnapWindow( const centity_t *cent, int tH
 		return qfalse;
 	}
 	f = (float)( tHist - cg.snap->serverTime ) / (float)delta;
+	if ( demoDelagEFlagsTeleported( cent->currentState.eFlags, cent->nextState.eFlags ) ) {
+		if ( f < 1.0f ) {
+			demoDelagEvalEsPose( &cent->currentState, cg.snap->serverTime, outOrigin, outAngles, NULL, outEFlags, outEs );
+		} else {
+			demoDelagEvalEsPose( &cent->nextState, cg.nextSnap->serverTime, outOrigin, outAngles, NULL, outEFlags, outEs );
+		}
+		return qtrue;
+	}
 	BG_EvaluateTrajectory( &cent->currentState.pos, cg.snap->serverTime, curp );
 	BG_EvaluateTrajectory( &cent->nextState.pos, cg.nextSnap->serverTime, nxtp );
 	outOrigin[0] = curp[0] + f * ( nxtp[0] - curp[0] );
@@ -406,10 +455,16 @@ static qboolean demoDelagPoseFromActiveSnapWindow( const centity_t *cent, int tH
 	outAngles[0] = LerpAngle( cura[0], nxta[0], f );
 	outAngles[1] = LerpAngle( cura[1], nxta[1], f );
 	outAngles[2] = LerpAngle( cura[2], nxta[2], f );
+	if ( outEFlags ) {
+		*outEFlags = ( f < 1.0f ) ? cent->currentState.eFlags : cent->nextState.eFlags;
+	}
+	if ( outEs ) {
+		*outEs = ( f < 1.0f ) ? cent->currentState : cent->nextState;
+	}
 	return qtrue;
 }
 
-static qboolean demoDelagPoseFromHistoryEnvelope( int entityNum, int tHist, vec3_t outOrigin, vec3_t outAngles ) {
+static qboolean demoDelagPoseFromHistoryEnvelope( int entityNum, int tHist, vec3_t outOrigin, vec3_t outAngles, int *outEFlags, entityState_t *outEs ) {
 	int c;
 	int i;
 	const snapshot_t *snLo, *snHi;
@@ -453,16 +508,22 @@ static qboolean demoDelagPoseFromHistoryEnvelope( int entityNum, int tHist, vec3
 		tlo = snLo->serverTime;
 		thi = snHi->serverTime;
 		if ( tHist <= tlo ) {
-			BG_EvaluateTrajectory( &esLo.pos, tHist, outOrigin );
-			BG_EvaluateTrajectory( &esLo.apos, tHist, outAngles );
+			demoDelagEvalEsPose( &esLo, tHist, outOrigin, outAngles, NULL, outEFlags, outEs );
 			return qtrue;
 		}
 		if ( tHist >= thi ) {
-			BG_EvaluateTrajectory( &esHi.pos, tHist, outOrigin );
-			BG_EvaluateTrajectory( &esHi.apos, tHist, outAngles );
+			demoDelagEvalEsPose( &esHi, tHist, outOrigin, outAngles, NULL, outEFlags, outEs );
 			return qtrue;
 		}
 		frac = (float)( tHist - tlo ) / (float)( thi - tlo );
+		if ( demoDelagEFlagsTeleported( esLo.eFlags, esHi.eFlags ) ) {
+			if ( frac < 1.0f ) {
+				demoDelagEvalEsPose( &esLo, tlo, outOrigin, outAngles, NULL, outEFlags, outEs );
+			} else {
+				demoDelagEvalEsPose( &esHi, thi, outOrigin, outAngles, NULL, outEFlags, outEs );
+			}
+			return qtrue;
+		}
 		BG_EvaluateTrajectory( &esLo.pos, tlo, oLo );
 		BG_EvaluateTrajectory( &esHi.pos, thi, oHi );
 		outOrigin[0] = oLo[0] + frac * ( oHi[0] - oLo[0] );
@@ -473,16 +534,20 @@ static qboolean demoDelagPoseFromHistoryEnvelope( int entityNum, int tHist, vec3
 		outAngles[0] = LerpAngle( aLo[0], aHi[0], frac );
 		outAngles[1] = LerpAngle( aLo[1], aHi[1], frac );
 		outAngles[2] = LerpAngle( aLo[2], aHi[2], frac );
+		if ( outEFlags ) {
+			*outEFlags = ( frac < 1.0f ) ? esLo.eFlags : esHi.eFlags;
+		}
+		if ( outEs ) {
+			*outEs = ( frac < 1.0f ) ? esLo : esHi;
+		}
 		return qtrue;
 	}
 	if ( hasLo ) {
-		BG_EvaluateTrajectory( &esLo.pos, tHist, outOrigin );
-		BG_EvaluateTrajectory( &esLo.apos, tHist, outAngles );
+		demoDelagEvalEsPose( &esLo, tHist, outOrigin, outAngles, NULL, outEFlags, outEs );
 		return qtrue;
 	}
 	if ( hasHi ) {
-		BG_EvaluateTrajectory( &esHi.pos, tHist, outOrigin );
-		BG_EvaluateTrajectory( &esHi.apos, tHist, outAngles );
+		demoDelagEvalEsPose( &esHi, tHist, outOrigin, outAngles, NULL, outEFlags, outEs );
 		return qtrue;
 	}
 	return qfalse;
@@ -496,11 +561,11 @@ newest entry (still within the open interpolation window) stay interpolated.
 Fall back to history bracket / envelope for older times.
 */
 static qboolean demoDelagSamplePoseAtTime( centity_t *cent, int entityNum, int tSample,
-		vec3_t outOrigin, vec3_t outAngles ) {
+		vec3_t outOrigin, vec3_t outAngles, int *outEFlags, entityState_t *outEs ) {
 	const snapshot_t *newest;
 	int tHist;
 
-	if ( cent && demoDelagPoseFromActiveSnapWindow( cent, tSample, outOrigin, outAngles ) ) {
+	if ( cent && demoDelagPoseFromActiveSnapWindow( cent, tSample, outOrigin, outAngles, outEFlags, outEs ) ) {
 		return qtrue;
 	}
 
@@ -516,21 +581,55 @@ static qboolean demoDelagSamplePoseAtTime( centity_t *cent, int entityNum, int t
 		tHist = clampServerTimeToHistory( tSample );
 	}
 
-	if ( getEntityPoseAtHistoryTime( entityNum, tHist, outOrigin, outAngles ) ) {
+	if ( getEntityPoseAtHistoryTime( entityNum, tHist, outOrigin, outAngles, outEFlags, outEs ) ) {
 		return qtrue;
 	}
-	if ( demoDelagPoseFromHistoryEnvelope( entityNum, tSample, outOrigin, outAngles ) ) {
+	if ( demoDelagPoseFromHistoryEnvelope( entityNum, tSample, outOrigin, outAngles, outEFlags, outEs ) ) {
 		return qtrue;
 	}
 	return qfalse;
 }
 
-static void demoDelagApplyPoseAndCache( centity_t *cent, const vec3_t origin, const vec3_t angles ) {
+static void demoDelagApplyVisual( centity_t *cent, const vec3_t origin, const vec3_t angles, const entityState_t *drawEs ) {
+	vec3_t oldOrigin;
+	int oldFlags;
+	qboolean hadPrev;
+
+	hadPrev = cent->demoDelagLastVisualEFlagsValid;
+	oldFlags = cent->demoDelagLastVisualEFlags;
+	VectorCopy( cent->demoDelagVisualOrigin, oldOrigin );
+
 	VectorCopy( origin, cent->lerpOrigin );
 	VectorCopy( angles, cent->lerpAngles );
 	VectorCopy( origin, cent->demoDelagVisualOrigin );
 	VectorCopy( angles, cent->demoDelagVisualAngles );
 	cent->demoDelagVisualCached = qtrue;
+
+	if ( !drawEs ) {
+		return;
+	}
+
+	cent->demoDelagDrawState = *drawEs;
+	cent->demoDelagDrawStateValid = qtrue;
+
+	if ( hadPrev && demoDelagEFlagsTeleported( oldFlags, drawEs->eFlags ) ) {
+		vec3_t fxOrigin;
+
+		VectorCopy( origin, fxOrigin );
+		if ( !( oldFlags & EF_DEAD ) && !( drawEs->eFlags & EF_DEAD ) ) {
+			trap_S_StartSound( NULL, cent->currentState.number, CHAN_AUTO, cgs.media.teleOutSound );
+			CG_SpawnEffect( oldOrigin );
+			trap_S_StartSound( NULL, cent->currentState.number, CHAN_AUTO, cgs.media.teleInSound );
+			CG_SpawnEffect( fxOrigin );
+		} else if ( ( oldFlags & EF_DEAD ) && !( drawEs->eFlags & EF_DEAD ) ) {
+			trap_S_StartSound( NULL, cent->currentState.number, CHAN_AUTO, cgs.media.teleInSound );
+			CG_SpawnEffect( fxOrigin );
+		}
+		CG_DemoDelagResetPlayerAnims( cent, drawEs->legsAnim, drawEs->torsoAnim );
+	}
+
+	cent->demoDelagLastVisualEFlags = drawEs->eFlags;
+	cent->demoDelagLastVisualEFlagsValid = qtrue;
 }
 
 void CG_DemoHistory_BeginHitscanRewind( int rewindToServerTime, int skipEntityNum ) {
@@ -596,8 +695,10 @@ void CG_DemoHistory_AdjustPlayerLerpForDemoDelag( centity_t *cent ) {
 	vec3_t originLo, anglesLo;
 	vec3_t originHi, anglesHi;
 	vec3_t origin, angles;
+	entityState_t esLo, esHi, drawEs;
 	float f;
 	qboolean okLo, okHi;
+	int flagsLo, flagsHi;
 
 	if ( !CG_DemoHistory_DemoDelagActive() || !cg.snap ) {
 		return;
@@ -616,10 +717,9 @@ void CG_DemoHistory_AdjustPlayerLerpForDemoDelag( centity_t *cent ) {
 	}
 
 	/*
-	 * Reuse the same frameInterpolation stepper as normal playback, but on
-	 * ping-rewound endpoints: lerp(pose(snap−ping), pose(nextSnap−ping), f).
-	 * That keeps motion continuous between server ticks instead of collapsing
-	 * onto a single clamped history snap.
+	 * Same interpolation as live playback, but both endpoints are ping-rewound.
+	 * Teleport/respawn is decided from those delayed states only (not live
+	 * currentState), so enter and exit stay 1:1 on the delayed clock.
 	 */
 	f = cg.frameInterpolation;
 	if ( f < 0.0f ) {
@@ -631,30 +731,38 @@ void CG_DemoHistory_AdjustPlayerLerpForDemoDelag( centity_t *cent ) {
 	if ( cg.nextSnap && cg.nextSnap->serverTime > cg.snap->serverTime ) {
 		tLo = cg.snap->serverTime - ping;
 		tHi = cg.nextSnap->serverTime - ping;
-		okLo = demoDelagSamplePoseAtTime( cent, cent->currentState.number, tLo, originLo, anglesLo );
-		okHi = demoDelagSamplePoseAtTime( cent, cent->currentState.number, tHi, originHi, anglesHi );
+		okLo = demoDelagSamplePoseAtTime( cent, cent->currentState.number, tLo, originLo, anglesLo, &flagsLo, &esLo );
+		okHi = demoDelagSamplePoseAtTime( cent, cent->currentState.number, tHi, originHi, anglesHi, &flagsHi, &esHi );
 		if ( okLo && okHi ) {
-			origin[0] = originLo[0] + f * ( originHi[0] - originLo[0] );
-			origin[1] = originLo[1] + f * ( originHi[1] - originLo[1] );
-			origin[2] = originLo[2] + f * ( originHi[2] - originLo[2] );
-			angles[0] = LerpAngle( anglesLo[0], anglesHi[0], f );
-			angles[1] = LerpAngle( anglesLo[1], anglesHi[1], f );
-			angles[2] = LerpAngle( anglesLo[2], anglesHi[2], f );
-			demoDelagApplyPoseAndCache( cent, origin, angles );
+			if ( demoDelagEFlagsTeleported( flagsLo, flagsHi ) ) {
+				/* interpolate=false: stay on delayed-current until the delayed snap transitions. */
+				VectorCopy( originLo, origin );
+				VectorCopy( anglesLo, angles );
+				drawEs = esLo;
+			} else {
+				origin[0] = originLo[0] + f * ( originHi[0] - originLo[0] );
+				origin[1] = originLo[1] + f * ( originHi[1] - originLo[1] );
+				origin[2] = originLo[2] + f * ( originHi[2] - originLo[2] );
+				angles[0] = LerpAngle( anglesLo[0], anglesHi[0], f );
+				angles[1] = LerpAngle( anglesLo[1], anglesHi[1], f );
+				angles[2] = LerpAngle( anglesLo[2], anglesHi[2], f );
+				drawEs = esLo;
+			}
+			demoDelagApplyVisual( cent, origin, angles, &drawEs );
 			return;
 		}
 		if ( okLo ) {
-			demoDelagApplyPoseAndCache( cent, originLo, anglesLo );
+			demoDelagApplyVisual( cent, originLo, anglesLo, &esLo );
 			return;
 		}
 		if ( okHi ) {
-			demoDelagApplyPoseAndCache( cent, originHi, anglesHi );
+			demoDelagApplyVisual( cent, originHi, anglesHi, &esHi );
 			return;
 		}
 	} else {
 		tLo = cg.snap->serverTime - ping;
-		if ( demoDelagSamplePoseAtTime( cent, cent->currentState.number, tLo, origin, angles ) ) {
-			demoDelagApplyPoseAndCache( cent, origin, angles );
+		if ( demoDelagSamplePoseAtTime( cent, cent->currentState.number, tLo, origin, angles, &flagsLo, &esLo ) ) {
+			demoDelagApplyVisual( cent, origin, angles, &esLo );
 			return;
 		}
 	}
@@ -673,6 +781,7 @@ qboolean CG_DemoHistory_AdjustMissileLerpForDemoDelag( centity_t *cent ) {
 	vec3_t origin, angles;
 	float f;
 	qboolean okLo, okHi;
+	int flagsLo, flagsHi;
 
 	if ( !CG_DemoHistory_DemoDelagActive() || !cg.snap ) {
 		return qfalse;
@@ -697,9 +806,14 @@ qboolean CG_DemoHistory_AdjustMissileLerpForDemoDelag( centity_t *cent ) {
 	if ( cg.nextSnap && cg.nextSnap->serverTime > cg.snap->serverTime ) {
 		tLo = cg.snap->serverTime - ping;
 		tHi = cg.nextSnap->serverTime - ping;
-		okLo = demoDelagSamplePoseAtTime( cent, cent->currentState.number, tLo, originLo, anglesLo );
-		okHi = demoDelagSamplePoseAtTime( cent, cent->currentState.number, tHi, originHi, anglesHi );
+		okLo = demoDelagSamplePoseAtTime( cent, cent->currentState.number, tLo, originLo, anglesLo, &flagsLo, NULL );
+		okHi = demoDelagSamplePoseAtTime( cent, cent->currentState.number, tHi, originHi, anglesHi, &flagsHi, NULL );
 		if ( okLo && okHi ) {
+			if ( demoDelagEFlagsTeleported( flagsLo, flagsHi ) ) {
+				VectorCopy( originLo, cent->lerpOrigin );
+				VectorCopy( anglesLo, cent->lerpAngles );
+				return qtrue;
+			}
 			origin[0] = originLo[0] + f * ( originHi[0] - originLo[0] );
 			origin[1] = originLo[1] + f * ( originHi[1] - originLo[1] );
 			origin[2] = originLo[2] + f * ( originHi[2] - originLo[2] );
@@ -724,7 +838,7 @@ qboolean CG_DemoHistory_AdjustMissileLerpForDemoDelag( centity_t *cent ) {
 	}
 
 	tLo = cg.snap->serverTime - ping;
-	if ( !demoDelagSamplePoseAtTime( cent, cent->currentState.number, tLo, origin, angles ) ) {
+	if ( !demoDelagSamplePoseAtTime( cent, cent->currentState.number, tLo, origin, angles, NULL, NULL ) ) {
 		return qfalse;
 	}
 	VectorCopy( origin, cent->lerpOrigin );

--- a/ratoa_gamecode/code/cgame/cg_demo_history.c
+++ b/ratoa_gamecode/code/cgame/cg_demo_history.c
@@ -43,6 +43,7 @@ void CG_DemoHistory_Clear( void ) {
 		cg_entities[i].demoDelagVisualCached = qfalse;
 		cg_entities[i].demoDelagDrawStateValid = qfalse;
 		cg_entities[i].demoDelagLastVisualEFlagsValid = qfalse;
+		cg_entities[i].demoDelagMissileNotYet = qfalse;
 	}
 	Com_Memset( cg_demoHistoryBuf, 0, sizeof( cg_demoHistoryBuf ) );
 }
@@ -773,15 +774,86 @@ void CG_DemoHistory_AdjustPlayerLerpForDemoDelag( centity_t *cent ) {
 	}
 }
 
+static qboolean demoDelagNewestHistoryEsAtOrBefore( int entityNum, int t, entityState_t *outEs ) {
+	int c;
+	int i;
+	const snapshot_t *sn;
+
+	c = CG_DemoHistory_GetCount();
+	for ( i = 0; i < c; i++ ) {
+		sn = CG_DemoHistory_GetByFramesAgo( i );
+		if ( sn->serverTime > t ) {
+			continue;
+		}
+		/* First snap at or before t. Do not search older (entity number reuse). */
+		return findEntityInSnapshot( sn, entityNum, outEs );
+	}
+	return qfalse;
+}
+
+static qboolean demoDelagMissilePathUnchanged( const entityState_t *a, const entityState_t *b ) {
+	if ( demoDelagEFlagsTeleported( a->eFlags, b->eFlags ) ) {
+		return qfalse;
+	}
+	if ( a->pos.trType != b->pos.trType || a->pos.trTime != b->pos.trTime ) {
+		return qfalse;
+	}
+	return qtrue;
+}
+
+/*
+Pick the entityState whose trajectory should be evaluated at delayed time t.
+History at t is preferred (bounce/portal). Otherwise the live missile state.
+notYet: delayed time is before this missile's trTime — caller should not draw.
+*/
+static qboolean demoDelagMissileEsForTime( const centity_t *cent, int t, entityState_t *outEs, qboolean *notYet ) {
+	*notYet = qfalse;
+
+	if ( demoDelagNewestHistoryEsAtOrBefore( cent->currentState.number, t, outEs ) ) {
+		if ( t < outEs->pos.trTime ) {
+			*notYet = qtrue;
+		}
+		return qtrue;
+	}
+
+	if ( cent->currentState.eType == ET_MISSILE ) {
+		if ( t < cent->currentState.pos.trTime ) {
+			*outEs = cent->currentState;
+			*notYet = qtrue;
+			return qtrue;
+		}
+		*outEs = cent->currentState;
+		return qtrue;
+	}
+
+	if ( cg.nextSnap && cent->nextState.eType == ET_MISSILE ) {
+		if ( t < cent->nextState.pos.trTime ) {
+			*outEs = cent->nextState;
+			*notYet = qtrue;
+			return qtrue;
+		}
+		*outEs = cent->nextState;
+		return qtrue;
+	}
+
+	return qfalse;
+}
+
+static void demoDelagEvalMissileEs( const entityState_t *es, int t, vec3_t origin, vec3_t angles ) {
+	BG_EvaluateTrajectory( &es->pos, t, origin );
+	BG_EvaluateTrajectory( &es->apos, t, angles );
+}
+
 qboolean CG_DemoHistory_AdjustMissileLerpForDemoDelag( centity_t *cent ) {
 	int ping;
-	int tLo, tHi;
-	vec3_t originLo, anglesLo;
-	vec3_t originHi, anglesHi;
+	int tLo, tHi, tEval;
 	vec3_t origin, angles;
+	entityState_t esLo, esHi;
 	float f;
 	qboolean okLo, okHi;
-	int flagsLo, flagsHi;
+	qboolean notYetLo, notYetHi;
+
+	cent->demoDelagMissileNotYet = qfalse;
 
 	if ( !CG_DemoHistory_DemoDelagActive() || !cg.snap ) {
 		return qfalse;
@@ -806,41 +878,71 @@ qboolean CG_DemoHistory_AdjustMissileLerpForDemoDelag( centity_t *cent ) {
 	if ( cg.nextSnap && cg.nextSnap->serverTime > cg.snap->serverTime ) {
 		tLo = cg.snap->serverTime - ping;
 		tHi = cg.nextSnap->serverTime - ping;
-		okLo = demoDelagSamplePoseAtTime( cent, cent->currentState.number, tLo, originLo, anglesLo, &flagsLo, NULL );
-		okHi = demoDelagSamplePoseAtTime( cent, cent->currentState.number, tHi, originHi, anglesHi, &flagsHi, NULL );
-		if ( okLo && okHi ) {
-			if ( demoDelagEFlagsTeleported( flagsLo, flagsHi ) ) {
-				VectorCopy( originLo, cent->lerpOrigin );
-				VectorCopy( anglesLo, cent->lerpAngles );
+		okLo = demoDelagMissileEsForTime( cent, tLo, &esLo, &notYetLo );
+		okHi = demoDelagMissileEsForTime( cent, tHi, &esHi, &notYetHi );
+
+		if ( okLo && notYetLo && okHi && notYetHi ) {
+			cent->demoDelagMissileNotYet = qtrue;
+			return qtrue;
+		}
+		if ( okLo && notYetLo && okHi && !notYetHi ) {
+			if ( f < 1.0f ) {
+				cent->demoDelagMissileNotYet = qtrue;
 				return qtrue;
 			}
-			origin[0] = originLo[0] + f * ( originHi[0] - originLo[0] );
-			origin[1] = originLo[1] + f * ( originHi[1] - originLo[1] );
-			origin[2] = originLo[2] + f * ( originHi[2] - originLo[2] );
-			angles[0] = LerpAngle( anglesLo[0], anglesHi[0], f );
-			angles[1] = LerpAngle( anglesLo[1], anglesHi[1], f );
-			angles[2] = LerpAngle( anglesLo[2], anglesHi[2], f );
+			demoDelagEvalMissileEs( &esHi, tHi, origin, angles );
 			VectorCopy( origin, cent->lerpOrigin );
 			VectorCopy( angles, cent->lerpAngles );
 			return qtrue;
 		}
-		if ( okLo ) {
-			VectorCopy( originLo, cent->lerpOrigin );
-			VectorCopy( anglesLo, cent->lerpAngles );
+		if ( okLo && !notYetLo && okHi && notYetHi ) {
+			demoDelagEvalMissileEs( &esLo, tLo, origin, angles );
+			VectorCopy( origin, cent->lerpOrigin );
+			VectorCopy( angles, cent->lerpAngles );
 			return qtrue;
 		}
-		if ( okHi ) {
-			VectorCopy( originHi, cent->lerpOrigin );
-			VectorCopy( anglesHi, cent->lerpAngles );
+		if ( okLo && !notYetLo && okHi && !notYetHi ) {
+			if ( demoDelagMissilePathUnchanged( &esLo, &esHi ) ) {
+				tEval = tLo + (int)( f * (float)( tHi - tLo ) );
+				demoDelagEvalMissileEs( &esLo, tEval, origin, angles );
+			} else if ( f < 1.0f ) {
+				demoDelagEvalMissileEs( &esLo, tLo, origin, angles );
+			} else {
+				demoDelagEvalMissileEs( &esHi, tHi, origin, angles );
+			}
+			VectorCopy( origin, cent->lerpOrigin );
+			VectorCopy( angles, cent->lerpAngles );
+			return qtrue;
+		}
+		if ( okLo && !notYetLo ) {
+			demoDelagEvalMissileEs( &esLo, tLo, origin, angles );
+			VectorCopy( origin, cent->lerpOrigin );
+			VectorCopy( angles, cent->lerpAngles );
+			return qtrue;
+		}
+		if ( okHi && !notYetHi ) {
+			demoDelagEvalMissileEs( &esHi, tHi, origin, angles );
+			VectorCopy( origin, cent->lerpOrigin );
+			VectorCopy( angles, cent->lerpAngles );
+			return qtrue;
+		}
+		if ( ( okLo && notYetLo ) || ( okHi && notYetHi ) ) {
+			cent->demoDelagMissileNotYet = qtrue;
 			return qtrue;
 		}
 		return qfalse;
 	}
 
 	tLo = cg.snap->serverTime - ping;
-	if ( !demoDelagSamplePoseAtTime( cent, cent->currentState.number, tLo, origin, angles, NULL, NULL ) ) {
+	okLo = demoDelagMissileEsForTime( cent, tLo, &esLo, &notYetLo );
+	if ( !okLo ) {
 		return qfalse;
 	}
+	if ( notYetLo ) {
+		cent->demoDelagMissileNotYet = qtrue;
+		return qtrue;
+	}
+	demoDelagEvalMissileEs( &esLo, tLo, origin, angles );
 	VectorCopy( origin, cent->lerpOrigin );
 	VectorCopy( angles, cent->lerpAngles );
 	return qtrue;

--- a/ratoa_gamecode/code/cgame/cg_demo_history.h
+++ b/ratoa_gamecode/code/cgame/cg_demo_history.h
@@ -22,6 +22,7 @@ const snapshot_t *CG_DemoHistory_GetNewest( void );
 const snapshot_t *CG_DemoHistory_GetByFramesAgo( int framesAgo );
 
 qboolean CG_DemoHistory_DemoDelagActive( void );
+qboolean CG_DemoHistory_SuppressLivePlayerTeleportEvent( int clientNum );
 void CG_DemoHistory_BeginHitscanRewind( int rewindToServerTime, int skipEntityNum );
 void CG_DemoHistory_EndHitscanRewind( void );
 void CG_DemoHistory_AdjustPlayerLerpForDemoDelag( struct centity_s *cent );

--- a/ratoa_gamecode/code/cgame/cg_ents.c
+++ b/ratoa_gamecode/code/cgame/cg_ents.c
@@ -1221,6 +1221,9 @@ CG_AddCEntity
 ===============
 */
 static void CG_AddCEntity( centity_t *cent ) {
+	entityState_t savedState;
+	qboolean swappedDrawState;
+
 	// event-only entities will have been dealt with already
 	if ( cent->currentState.eType >= ET_EVENTS ) {
 		return;
@@ -1228,6 +1231,13 @@ static void CG_AddCEntity( centity_t *cent ) {
 
 	// calculate the current origin
 	CG_CalcEntityLerpPositions( cent );
+
+	swappedDrawState = qfalse;
+	if ( cent->demoDelagDrawStateValid && cent->currentState.eType == ET_PLAYER ) {
+		savedState = cent->currentState;
+		cent->currentState = cent->demoDelagDrawState;
+		swappedDrawState = qtrue;
+	}
 
 	// add automatic effects
 	CG_EntityEffects( cent );
@@ -1272,6 +1282,10 @@ static void CG_AddCEntity( centity_t *cent ) {
 	case ET_TEAM:
 		CG_TeamBase( cent );
 		break;
+	}
+
+	if ( swappedDrawState ) {
+		cent->currentState = savedState;
 	}
 }
 

--- a/ratoa_gamecode/code/cgame/cg_ents.c
+++ b/ratoa_gamecode/code/cgame/cg_ents.c
@@ -1232,6 +1232,10 @@ static void CG_AddCEntity( centity_t *cent ) {
 	// calculate the current origin
 	CG_CalcEntityLerpPositions( cent );
 
+	if ( cent->demoDelagMissileNotYet && cent->currentState.eType == ET_MISSILE ) {
+		return;
+	}
+
 	swappedDrawState = qfalse;
 	if ( cent->demoDelagDrawStateValid && cent->currentState.eType == ET_PLAYER ) {
 		savedState = cent->currentState;

--- a/ratoa_gamecode/code/cgame/cg_event.c
+++ b/ratoa_gamecode/code/cgame/cg_event.c
@@ -1044,12 +1044,18 @@ void CG_EntityEvent( centity_t *cent, vec3_t position ) {
 	//
 	case EV_PLAYER_TELEPORT_IN:
 		DEBUGNAME("EV_PLAYER_TELEPORT_IN");
+		if ( CG_DemoHistory_SuppressLivePlayerTeleportEvent( es->clientNum ) ) {
+			break;
+		}
 		trap_S_StartSound (NULL, es->number, CHAN_AUTO, cgs.media.teleInSound );
 		CG_SpawnEffect( position);
 		break;
 
 	case EV_PLAYER_TELEPORT_OUT:
 		DEBUGNAME("EV_PLAYER_TELEPORT_OUT");
+		if ( CG_DemoHistory_SuppressLivePlayerTeleportEvent( es->clientNum ) ) {
+			break;
+		}
 		trap_S_StartSound (NULL, es->number, CHAN_AUTO, cgs.media.teleOutSound );
 		CG_SpawnEffect(  position);
 		break;

--- a/ratoa_gamecode/code/cgame/cg_local.h
+++ b/ratoa_gamecode/code/cgame/cg_local.h
@@ -280,6 +280,10 @@ typedef struct centity_s {
 	qboolean		demoDelagVisualCached;
 	vec3_t			demoDelagVisualOrigin;
 	vec3_t			demoDelagVisualAngles;
+	qboolean		demoDelagDrawStateValid;
+	entityState_t	demoDelagDrawState;
+	int				demoDelagLastVisualEFlags;
+	qboolean		demoDelagLastVisualEFlagsValid;
 
 	// for cg_projectileNudgeAuto
 	int			projectileNudge;
@@ -1940,6 +1944,7 @@ int CG_GetScoresMtrn(int scoreNum);
 void CG_Player( centity_t *cent );
 void CG_PlayerGetColors(clientInfo_t *ci, qboolean isDead, int bodyPart, byte *outColor);
 void CG_ResetPlayerEntity( centity_t *cent );
+void CG_DemoDelagResetPlayerAnims( centity_t *cent, int legsAnim, int torsoAnim );
 void CG_AddRefEntityWithPowerups( refEntity_t *ent, entityState_t *state, int team, qboolean isMissile,
 	       	clientInfo_t *ci, int orderIndicator, qboolean useBlendBrightshell );
 void CG_NewClientInfo( int clientNum );

--- a/ratoa_gamecode/code/cgame/cg_local.h
+++ b/ratoa_gamecode/code/cgame/cg_local.h
@@ -292,6 +292,7 @@ typedef struct centity_s {
 	qboolean		quiet;
 	qboolean		missileTeleported;
 	predictedMissileStatus_t missileStatus;
+	qboolean		demoDelagMissileNotYet;
 } centity_t;
 
 

--- a/ratoa_gamecode/code/cgame/cg_players.c
+++ b/ratoa_gamecode/code/cgame/cg_players.c
@@ -1824,6 +1824,30 @@ static void CG_ClearLerpFrame( clientInfo_t *ci, lerpFrame_t *lf, int animationN
 	lf->oldFrame = lf->frame = lf->animation->firstFrame;
 }
 
+void CG_DemoDelagResetPlayerAnims( centity_t *cent, int legsAnim, int torsoAnim ) {
+	int clientNum;
+
+	clientNum = cent->currentState.clientNum;
+	if ( clientNum < 0 || clientNum >= MAX_CLIENTS ) {
+		return;
+	}
+
+	CG_ClearLerpFrame( &cgs.clientinfo[ clientNum ], &cent->pe.legs, legsAnim );
+	CG_ClearLerpFrame( &cgs.clientinfo[ clientNum ], &cent->pe.torso, torsoAnim );
+
+	memset( &cent->pe.legs, 0, sizeof( cent->pe.legs ) );
+	cent->pe.legs.yawAngle = cent->lerpAngles[YAW];
+	cent->pe.legs.yawing = qfalse;
+	cent->pe.legs.pitchAngle = 0;
+	cent->pe.legs.pitching = qfalse;
+
+	memset( &cent->pe.torso, 0, sizeof( cent->pe.torso ) );
+	cent->pe.torso.yawAngle = cent->lerpAngles[YAW];
+	cent->pe.torso.yawing = qfalse;
+	cent->pe.torso.pitchAngle = cent->lerpAngles[PITCH];
+	cent->pe.torso.pitching = qfalse;
+}
+
 
 /*
 ===============
@@ -4127,12 +4151,21 @@ A player just came into view or teleported, so reset all animation info
 ===============
 */
 void CG_ResetPlayerEntity( centity_t *cent ) {
+	qboolean delayAnims;
+
 	cent->demoDelagVisualCached = qfalse;
 	cent->errorTime = -99999;		// guarantee no error decay added
-	cent->extrapolated = qfalse;	
+	cent->extrapolated = qfalse;
 
-	CG_ClearLerpFrame( &cgs.clientinfo[ cent->currentState.clientNum ], &cent->pe.legs, cent->currentState.legsAnim );
-	CG_ClearLerpFrame( &cgs.clientinfo[ cent->currentState.clientNum ], &cent->pe.torso, cent->currentState.torsoAnim );
+	delayAnims = CG_DemoHistory_DemoDelagActive()
+		&& cent->currentState.number < MAX_CLIENTS
+		&& cent->currentState.number != cg.predictedPlayerState.clientNum
+		&& cent->demoDelagLastVisualEFlagsValid;
+
+	if ( !delayAnims ) {
+		CG_ClearLerpFrame( &cgs.clientinfo[ cent->currentState.clientNum ], &cent->pe.legs, cent->currentState.legsAnim );
+		CG_ClearLerpFrame( &cgs.clientinfo[ cent->currentState.clientNum ], &cent->pe.torso, cent->currentState.torsoAnim );
+	}
 
 	BG_EvaluateTrajectory( &cent->currentState.pos, cg.time, cent->lerpOrigin );
 	BG_EvaluateTrajectory( &cent->currentState.apos, cg.time, cent->lerpAngles );
@@ -4142,17 +4175,19 @@ void CG_ResetPlayerEntity( centity_t *cent ) {
 	VectorCopy( cent->lerpOrigin, cent->rawOrigin );
 	VectorCopy( cent->lerpAngles, cent->rawAngles );
 
-	memset( &cent->pe.legs, 0, sizeof( cent->pe.legs ) );
-	cent->pe.legs.yawAngle = cent->rawAngles[YAW];
-	cent->pe.legs.yawing = qfalse;
-	cent->pe.legs.pitchAngle = 0;
-	cent->pe.legs.pitching = qfalse;
+	if ( !delayAnims ) {
+		memset( &cent->pe.legs, 0, sizeof( cent->pe.legs ) );
+		cent->pe.legs.yawAngle = cent->rawAngles[YAW];
+		cent->pe.legs.yawing = qfalse;
+		cent->pe.legs.pitchAngle = 0;
+		cent->pe.legs.pitching = qfalse;
 
-	memset( &cent->pe.torso, 0, sizeof( cent->pe.legs ) );
-	cent->pe.torso.yawAngle = cent->rawAngles[YAW];
-	cent->pe.torso.yawing = qfalse;
-	cent->pe.torso.pitchAngle = cent->rawAngles[PITCH];
-	cent->pe.torso.pitching = qfalse;
+		memset( &cent->pe.torso, 0, sizeof( cent->pe.torso ) );
+		cent->pe.torso.yawAngle = cent->rawAngles[YAW];
+		cent->pe.torso.yawing = qfalse;
+		cent->pe.torso.pitchAngle = cent->rawAngles[PITCH];
+		cent->pe.torso.pitching = qfalse;
+	}
 
 	cent->pe.crouchSlideSndCounter = rand() % CROUCHSLIDE_SOUNDS;
 

--- a/ratoa_gamecode/code/cgame/cg_unlagged.c
+++ b/ratoa_gamecode/code/cgame/cg_unlagged.c
@@ -1338,14 +1338,27 @@ CG_RefreshDemoPovDisplayPing
 
 Sample CG_ReliablePing() for scoreboard display. Called from the scoreboard's
 1 Hz refresh (scoresRequestTime) and when opening scores during demo playback.
+
+During intermission commandTime stops advancing, so ReliablePing walks up to 999.
+Keep the last in-match sample instead of showing that sentinel.
 =================
  */
 void CG_RefreshDemoPovDisplayPing( void ) {
-	if ( !cg.demoPlayback || !cg.snap ) {
+	int ping;
+
+	if ( !cg.demoPlayback ) {
 		cg.demoPovDisplayPingValid = qfalse;
 		return;
 	}
-	cg.demoPovDisplayPing = CG_ReliablePing();
+	if ( !cg.snap ) {
+		return;
+	}
+	ping = CG_ReliablePing();
+	/* Same junk threshold as demo delag ping (commandTime freeze / snap->ping 999). */
+	if ( ping < 0 || ping >= 900 ) {
+		return;
+	}
+	cg.demoPovDisplayPing = ping;
 	cg.demoPovDisplayPingValid = qtrue;
 }
 


### PR DESCRIPTION
Several fixes for de-lagged replays:
- Scoreboard ping for the recording player at the end-game intermission will now show their last-calculated ping from snaps, instead of '999'.
- Teleport events are now handled correctly, showing a consistent entrance and exit of a teleporter by a player
- Projectiles now render only on their de-lagged state and don't jump around when initially fired.

Tested on a de-lagged replay in Quake3e.