### PR TITLE
Feature: Deathpit mercy

### DIFF
--- a/ratoa_gamecode/code/game/bg_cvar_desc.c
+++ b/ratoa_gamecode/code/game/bg_cvar_desc.c
@@ -98,6 +98,7 @@ static const cvarDesc_t gameCvarDescriptions[] = {
 	{ "g_debugAlloc", "Debug memory allocator logging." },
 	{ "g_debugDamage", "Debug damage calculation output." },
 	{ "g_debugMove", "Debug player movement and pmove logging." },
+	{ "g_deathpitMercy", "When `1`, falling into a lethal trigger_hurt (damage over 200) teleports the player to a spawn with inventory intact." },
 	{ "g_delagAllowHitsAfterTele", "When `1`, delagged hits still count shortly after teleporting." },
 	{ "g_delagHitscan", "When `1`, rewinds players for hitscan hit detection (unlagged)." },
 	{ "g_delagMissileBaseNudge", "Base milliseconds nudged for missile lag compensation." },

--- a/ratoa_gamecode/code/game/g_cmds.c
+++ b/ratoa_gamecode/code/game/g_cmds.c
@@ -3851,6 +3851,8 @@ void G_PrintVoteCommands(gentity_t *ent) {
 		strcat(buffer, " votenextmap\n");
 	if(allowedVote("custom"))
 		strcat(buffer, " custom <special>\n");
+	if(allowedVote("deathpit_mercy"))
+		strcat(buffer, " deathpit_mercy <0|1>\n");
 	buffer[strlen(buffer)-1] = 0;
 	strcat(buffer, "\n\"");
 	trap_SendServerCommand( ent-g_entities, buffer);
@@ -3925,6 +3927,7 @@ void Cmd_CallVote_f( gentity_t *ent ) {
         } else if ( !Q_stricmp( arg1, "unlock" ) ) {
         } else if ( !Q_stricmp( arg1, "arena" ) ) {
         } else if ( !Q_stricmp( arg1, "votenextmap" ) ) {
+	} else if ( !Q_stricmp( arg1, "deathpit_mercy" ) ) {
 	} else {
 		trap_SendServerCommand( ent-g_entities, "print \"Invalid vote string.\n\"" );
 		G_PrintVoteCommands(ent);
@@ -4108,6 +4111,16 @@ void Cmd_CallVote_f( gentity_t *ent ) {
                 else {
                     Com_sprintf( level.voteString, sizeof( level.voteString ), "g_doWarmup \"0\"" );
                     Com_sprintf( level.voteDisplayString, sizeof( level.voteDisplayString ), "Disable warmup?" );
+                }
+        } else if ( !Q_stricmp( arg1, "deathpit_mercy" ) ) {
+                i = atoi(arg2);
+                if(i) {
+                    Com_sprintf( level.voteString, sizeof( level.voteString ), "g_deathpitMercy \"1\"" );
+                    Com_sprintf( level.voteDisplayString, sizeof( level.voteDisplayString ), "Enable death pit mercy?" );
+                }
+                else {
+                    Com_sprintf( level.voteString, sizeof( level.voteString ), "g_deathpitMercy \"0\"" );
+                    Com_sprintf( level.voteDisplayString, sizeof( level.voteDisplayString ), "Disable death pit mercy?" );
                 }
         } else if ( !Q_stricmp( arg1, "clientkick" ) ) {
 		for( c = arg2; *c; ++c) {

--- a/ratoa_gamecode/code/game/g_cvar.h
+++ b/ratoa_gamecode/code/game/g_cvar.h
@@ -61,6 +61,7 @@ G_CVAR( g_teamBalanceDelay, "g_teamBalanceDelay", "30", CVAR_ARCHIVE, 0, qfalse,
 
 G_CVAR( g_warmup, "g_warmup", "20", CVAR_ARCHIVE, 0, qtrue, qfalse )
 G_CVAR( g_doWarmup, "g_doWarmup", "0", CVAR_SERVERINFO | CVAR_ARCHIVE, 0, qtrue, qfalse )
+G_CVAR( g_deathpitMercy, "g_deathpitMercy", "0", CVAR_ARCHIVE, 0, qtrue, qfalse )
 
 G_CVAR( g_logIPs, "g_logIPs", "0", CVAR_ARCHIVE, 0, qfalse, qfalse )
 
@@ -112,7 +113,7 @@ G_CVAR( g_podiumDrop, "g_podiumDrop", "70", 0, 0, qfalse, qfalse )
 G_CVAR( g_allowVote, "g_allowVote", "1", CVAR_SERVERINFO | CVAR_ARCHIVE, 0, qfalse, qfalse )
 G_CVAR( g_maxvotes, "g_maxVotes", MAX_VOTE_COUNT, CVAR_ARCHIVE, 0, qfalse, qfalse )
 G_CVAR( g_voteRepeatLimit, "g_voteRepeatLimit", "0", CVAR_ARCHIVE, 0, qfalse, qfalse )
-G_CVAR( g_voteNames, "g_voteNames", "/map_restart/nextmap/map/g_gametype/clientkick/g_doWarmup/timelimit/fraglimit/capturelimit/shuffle/bots/botskill/votenextmap/", CVAR_ARCHIVE, 0, qfalse, qfalse ) //clientkick g_doWarmup timelimit fraglimit
+G_CVAR( g_voteNames, "g_voteNames", "/map_restart/nextmap/map/g_gametype/clientkick/g_doWarmup/timelimit/fraglimit/capturelimit/shuffle/bots/botskill/votenextmap/deathpit_mercy/", CVAR_ARCHIVE, 0, qfalse, qfalse ) //clientkick g_doWarmup timelimit fraglimit
 G_CVAR( g_voteBan, "g_voteBan", "0", CVAR_ARCHIVE, 0, qfalse, qfalse )
 G_CVAR( g_voteGametypes, "g_voteGametypes", "/0/1/3/4/5/6/7/8/9/10/11/12/", CVAR_SERVERINFO | CVAR_ARCHIVE, 0, qfalse, qfalse )
 G_CVAR( g_voteMaxTimelimit, "g_voteMaxTimelimit", "1000", CVAR_SERVERINFO | CVAR_ARCHIVE, 0, qfalse, qfalse )

--- a/ratoa_gamecode/code/game/g_local.h
+++ b/ratoa_gamecode/code/game/g_local.h
@@ -1158,6 +1158,7 @@ void G_SetTeleporterDestinations(void);
 // g_misc.c
 //
 void TeleportPlayer( gentity_t *player, vec3_t origin, vec3_t angles );
+void G_DeathpitMercyRespawn( gentity_t *player );
 void DropPortalSource( gentity_t *ent );
 void DropPortalDestination( gentity_t *ent );
 
@@ -1453,6 +1454,7 @@ team_t PlayerStore_getLastTeam( const char *guid );
 // g_vote.c
 //
 int allowedVote(char *commandStr);
+void G_EnsureVoteName( const char *commandStr );
 void CheckVote( void );
 void CountVotes( void );
 void ClientLeaving(int clientNumber);

--- a/ratoa_gamecode/code/game/g_main.c
+++ b/ratoa_gamecode/code/game/g_main.c
@@ -766,6 +766,8 @@ void G_RegisterCvars( void ) {
 	BotEnhanced_RegisterCvars();
 
 	BG_RegisterGameCvarDescriptions();
+
+	G_EnsureVoteName( "deathpit_mercy" );
 }
 
 qboolean G_IsTeamGametype(void) {

--- a/ratoa_gamecode/code/game/g_misc.c
+++ b/ratoa_gamecode/code/game/g_misc.c
@@ -150,6 +150,69 @@ void TeleportPlayer( gentity_t *player, vec3_t origin, vec3_t angles ) {
 	player->client->lastTeleportTime = level.time;
 }
 
+/*
+================
+G_DeathpitMercyRespawn
+
+Move a living player to a spawn point without wiping inventory, health, armor,
+or powerups. Velocity (including downward fall) is cleared so they do not take
+fall damage on arrival.
+================
+*/
+void G_DeathpitMercyRespawn( gentity_t *player ) {
+	vec3_t		origin, angles;
+	gclient_t	*client;
+
+	if ( !player || !player->client ) {
+		return;
+	}
+
+	client = player->client;
+	SelectSpawnPoint( player, client->ps.origin, origin, angles, 0 );
+
+	trap_UnlinkEntity( player );
+
+	VectorCopy( origin, client->ps.origin );
+	client->ps.origin[2] += 1;
+
+	VectorClear( client->ps.velocity );
+	client->ps.pm_time = 0;
+	client->ps.pm_flags &= ~PMF_ALL_TIMES;
+	client->ps.groundEntityNum = ENTITYNUM_WORLD;
+	client->lastGroundTime = level.time;
+
+	SetClientViewAngle( player, angles );
+
+	client->ps.eFlags ^= EF_TELEPORT_BIT;
+
+	client->ps.stats[STAT_EXTFLAGS] &= ~EXTFL_SLIDING;
+	client->ps.stats[STAT_SLIDETIMEOUT] = 0;
+
+	if ( client->sess.sessionTeam != TEAM_SPECTATOR && client->ps.pm_type != PM_SPECTATOR ) {
+		G_KillBox( player );
+	}
+
+	BG_PlayerStateToEntityState( &client->ps, &player->s, (qboolean)!g_floatPlayerPosition.integer );
+	VectorCopy( client->ps.origin, player->r.currentOrigin );
+
+	if ( !g_delagAllowHitsAfterTele.integer ) {
+		G_ResetHistory( player );
+	}
+
+	if ( client->sess.sessionTeam != TEAM_SPECTATOR && client->ps.pm_type != PM_SPECTATOR ) {
+		trap_LinkEntity( player );
+	}
+
+	client->ps.persistant[PERS_SPAWN_COUNT]++;
+	{
+		gentity_t *tent;
+		tent = G_TempEntity( client->ps.origin, EV_PLAYER_TELEPORT_IN );
+		tent->s.clientNum = player->s.clientNum;
+	}
+
+	client->lastTeleportTime = level.time;
+}
+
 
 /*QUAKED misc_teleporter_dest (1 0 0) (-32 -32 -24) (32 32 -16)
 Point teleporters at these.

--- a/ratoa_gamecode/code/game/g_trigger.c
+++ b/ratoa_gamecode/code/game/g_trigger.c
@@ -439,6 +439,13 @@ void hurt_touch( gentity_t *self, gentity_t *other, trace_t *trace ) {
 		return;
 	}
 
+	if ( g_deathpitMercy.integer && other->client && self->damage > 200
+			&& other->client->ps.groundEntityNum == ENTITYNUM_NONE
+			&& other->client->ps.velocity[2] < 0 ) {
+		G_DeathpitMercyRespawn( other );
+		return;
+	}
+
 	if ( self->timestamp > level.time ) {
 		return;
 	}

--- a/ratoa_gamecode/code/game/g_vote.c
+++ b/ratoa_gamecode/code/game/g_vote.c
@@ -28,7 +28,7 @@ allowedVote
  *Note: Keep this in sync with allowedVote in ui_votemenu.c (except for cg_voteNames and g_voteNames)
 ==================
  */
-#define MAX_VOTENAME_LENGTH 15 //currently the longest string is "/capturelimit/\0" (15 chars)
+#define MAX_VOTENAME_LENGTH 24 // longest slash-wrapped name is "/deathpit_mercy/\0"
 int allowedVote(char *commandStr) {
     char tempStr[MAX_VOTENAME_LENGTH];
     int length;
@@ -51,6 +51,45 @@ int allowedVote(char *commandStr) {
         return qtrue;
     else
         return qfalse;
+}
+
+/*
+==================
+G_EnsureVoteName
+
+Archived g_voteNames keeps the old factory list across updates. Add a newly
+supported vote verb if it is missing (unless the server uses "*" or an empty list).
+==================
+ */
+void G_EnsureVoteName( const char *commandStr ) {
+	char voteNames[MAX_CVAR_VALUE_STRING];
+	char wrapped[MAX_VOTENAME_LENGTH];
+	int len;
+
+	if ( !commandStr || !commandStr[0] ) {
+		return;
+	}
+	trap_Cvar_VariableStringBuffer( "g_voteNames", voteNames, sizeof( voteNames ) );
+	if ( !voteNames[0] || !Q_stricmp( voteNames, "*" ) ) {
+		return;
+	}
+
+	wrapped[0] = '/';
+	wrapped[1] = '\0';
+	Q_strcat( wrapped, sizeof( wrapped ), commandStr );
+	Q_strcat( wrapped, sizeof( wrapped ), "/" );
+	if ( Q_stristr( voteNames, wrapped ) != NULL ) {
+		return;
+	}
+
+	len = strlen( voteNames );
+	if ( voteNames[len - 1] != '/' ) {
+		Q_strcat( voteNames, sizeof( voteNames ), "/" );
+	}
+	Q_strcat( voteNames, sizeof( voteNames ), commandStr );
+	Q_strcat( voteNames, sizeof( voteNames ), "/" );
+	trap_Cvar_Set( "g_voteNames", voteNames );
+	trap_Cvar_Update( &g_voteNames );
 }
 
 /*


### PR DESCRIPTION
Added the option for a death pit to instead respawn a player that falls into it.
- Voteable on \callvote deathpit_mercy 1/0
- Respawns the player with the usual sound/visual effect, but retaining their loadout and without losing a point
- Conditions for detecting a deathpit are 1) player is falling and 2) they interact with a trigger_hurt that does  200 or more damage

This is intended to make FFA games more fun and less punishing on space maps.

Tested offline with Quake3e client.