### PR TITLE
Minor fixes

### DIFF
--- a/ratoa_gamecode/code/cgame/cg_demo_history.c
+++ b/ratoa_gamecode/code/cgame/cg_demo_history.c
@@ -28,8 +28,25 @@ typedef struct {
 static demoRewindSave_t cg_demoRewindSaves[MAX_CLIENTS];
 static int cg_demoRewindSaveCount;
 
+/*
+ * Witnessed tele IN/OUT from the recorded snapshot, held until the delayed
+ * clock reaches that snap. Not synthesized from later player visibility.
+ */
+#define CG_DEMO_DELAYED_TELE_CAP 128
+
+typedef struct {
+	int		snapServerTime;
+	int		event;
+	int		soundEntityNum;
+	vec3_t	origin;
+} demoDelayedTele_t;
+
+static demoDelayedTele_t cg_demoDelayedTele[CG_DEMO_DELAYED_TELE_CAP];
+static int cg_demoDelayedTeleCount;
+
 static int demoDelagPingRawAlongInterpolation( void );
 static qboolean demoDelagResolvePingMs( int *outPing );
+static void demoDelagFlushDelayedTeleports( void );
 
 void CG_DemoHistory_Clear( void ) {
 	int i;
@@ -38,6 +55,7 @@ void CG_DemoHistory_Clear( void ) {
 	cg_demoHistoryCount = 0;
 	cg_demoHistoryLastServerTime = -1;
 	cg_demoRewindSaveCount = 0;
+	cg_demoDelayedTeleCount = 0;
 	cg_demoDelagPingSmoothed = -1;
 	for ( i = 0; i < MAX_GENTITIES; i++ ) {
 		cg_entities[i].demoDelagVisualCached = qfalse;
@@ -75,6 +93,7 @@ void CG_DemoHistory_Frame( void ) {
 		cg_demoDelagPingSmoothed = -1;
 	}
 	cg_demoHistoryPrevPlayback = cg.demoPlayback;
+	demoDelagFlushDelayedTeleports();
 }
 
 void CG_DemoHistory_OnSnapshot( const snapshot_t *snap ) {
@@ -132,19 +151,44 @@ qboolean CG_DemoHistory_DemoDelagActive( void ) {
 	return cg.demoPlayback && cg_demoDelag.integer && cgs.delagHitscan && CG_DemoHistory_GetCount() > 0;
 }
 
-qboolean CG_DemoHistory_SuppressLivePlayerTeleportEvent( int clientNum ) {
+qboolean CG_DemoHistory_DelayPlayerTeleportEvent( int clientNum, int event, const vec3_t origin, int soundEntityNum ) {
+	demoDelayedTele_t *slot;
+	int ping;
+
 	if ( !CG_DemoHistory_DemoDelagActive() ) {
 		return qfalse;
 	}
 	if ( !cg.snap ) {
 		return qfalse;
 	}
-	if ( clientNum < 0 || clientNum >= MAX_CLIENTS ) {
-		return qfalse;
-	}
 	if ( clientNum == cg.predictedPlayerState.clientNum ) {
 		return qfalse;
 	}
+	if ( !demoDelagResolvePingMs( &ping ) ) {
+		return qfalse;
+	}
+	if ( !origin ) {
+		return qtrue;
+	}
+
+	if ( cg_demoDelayedTeleCount >= CG_DEMO_DELAYED_TELE_CAP ) {
+		int i;
+
+		for ( i = 0; i < CG_DEMO_DELAYED_TELE_CAP - 1; i++ ) {
+			cg_demoDelayedTele[i] = cg_demoDelayedTele[i + 1];
+		}
+		cg_demoDelayedTeleCount = CG_DEMO_DELAYED_TELE_CAP - 1;
+	}
+
+	slot = &cg_demoDelayedTele[cg_demoDelayedTeleCount];
+	slot->snapServerTime = cg.snap->serverTime;
+	slot->event = event;
+	slot->soundEntityNum = soundEntityNum;
+	if ( clientNum >= 0 && clientNum < MAX_CLIENTS ) {
+		slot->soundEntityNum = clientNum;
+	}
+	VectorCopy( origin, slot->origin );
+	cg_demoDelayedTeleCount++;
 	return qtrue;
 }
 
@@ -295,6 +339,63 @@ static qboolean demoDelagResolvePingMs( int *outPing ) {
 	return qtrue;
 }
 
+static void demoDelagPlayDelayedTeleport( const demoDelayedTele_t *ev ) {
+	sfxHandle_t sfx;
+	int soundEnt;
+	vec3_t origin;
+
+	if ( !ev ) {
+		return;
+	}
+	if ( ev->event == EV_PLAYER_TELEPORT_OUT ) {
+		sfx = cgs.media.teleOutSound;
+	} else {
+		sfx = cgs.media.teleInSound;
+	}
+	soundEnt = ev->soundEntityNum;
+	if ( soundEnt < 0 || soundEnt >= MAX_GENTITIES ) {
+		soundEnt = ENTITYNUM_WORLD;
+	}
+	VectorCopy( ev->origin, origin );
+	trap_S_StartSound( origin, soundEnt, CHAN_AUTO, sfx );
+	CG_SpawnEffect( origin );
+}
+
+/*
+ * Release tele IN/OUT when interpolated delayed time (cg.time - ping) reaches
+ * the snap that contained them — the same clock remote players are drawn on.
+ * Presence in that recorded snap is the witness test: if the recorder never
+ * got the event, it is never queued and never played later.
+ */
+static void demoDelagFlushDelayedTeleports( void ) {
+	int ping;
+	int delayedTime;
+	int i;
+	int kept;
+
+	if ( !CG_DemoHistory_DemoDelagActive() || !cg.snap ) {
+		cg_demoDelayedTeleCount = 0;
+		return;
+	}
+	if ( !demoDelagResolvePingMs( &ping ) ) {
+		return;
+	}
+
+	delayedTime = cg.time - ping;
+	kept = 0;
+	for ( i = 0; i < cg_demoDelayedTeleCount; i++ ) {
+		if ( delayedTime >= cg_demoDelayedTele[i].snapServerTime ) {
+			demoDelagPlayDelayedTeleport( &cg_demoDelayedTele[i] );
+		} else {
+			if ( kept != i ) {
+				cg_demoDelayedTele[kept] = cg_demoDelayedTele[i];
+			}
+			kept++;
+		}
+	}
+	cg_demoDelayedTeleCount = kept;
+}
+
 static int demoDelagAttackerSampleTime( int attackServerTime ) {
 	int ping;
 
@@ -305,22 +406,12 @@ static int demoDelagAttackerSampleTime( int attackServerTime ) {
 }
 
 int CG_DemoHistory_LocalFireDelay( void ) {
-	int ping;
-	int frameMsec;
-
-	if ( !CG_DemoHistory_DemoDelagActive() ) {
-		return 0;
-	}
-	if ( !demoDelagResolvePingMs( &ping ) ) {
-		return 0;
-	}
-	if ( sv_fps.integer > 0 ) {
-		frameMsec = 1000 / sv_fps.integer;
-		if ( ping > frameMsec ) {
-			ping = frameMsec;
-		}
-	}
-	return ping;
+	/*
+	 * POV muzzle flash/sound must stay on the live demo clock. Own missiles
+	 * are not time-shifted (they skip missile delag); delaying fire here put
+	 * the gun a snapshot behind the bolt.
+	 */
+	return 0;
 }
 
 static qboolean demoDelagEFlagsTeleported( int eFlagsA, int eFlagsB ) {
@@ -592,13 +683,11 @@ static qboolean demoDelagSamplePoseAtTime( centity_t *cent, int entityNum, int t
 }
 
 static void demoDelagApplyVisual( centity_t *cent, const vec3_t origin, const vec3_t angles, const entityState_t *drawEs ) {
-	vec3_t oldOrigin;
 	int oldFlags;
 	qboolean hadPrev;
 
 	hadPrev = cent->demoDelagLastVisualEFlagsValid;
 	oldFlags = cent->demoDelagLastVisualEFlags;
-	VectorCopy( cent->demoDelagVisualOrigin, oldOrigin );
 
 	VectorCopy( origin, cent->lerpOrigin );
 	VectorCopy( angles, cent->lerpAngles );
@@ -614,23 +703,41 @@ static void demoDelagApplyVisual( centity_t *cent, const vec3_t origin, const ve
 	cent->demoDelagDrawStateValid = qtrue;
 
 	if ( hadPrev && demoDelagEFlagsTeleported( oldFlags, drawEs->eFlags ) ) {
-		vec3_t fxOrigin;
-
-		VectorCopy( origin, fxOrigin );
-		if ( !( oldFlags & EF_DEAD ) && !( drawEs->eFlags & EF_DEAD ) ) {
-			trap_S_StartSound( NULL, cent->currentState.number, CHAN_AUTO, cgs.media.teleOutSound );
-			CG_SpawnEffect( oldOrigin );
-			trap_S_StartSound( NULL, cent->currentState.number, CHAN_AUTO, cgs.media.teleInSound );
-			CG_SpawnEffect( fxOrigin );
-		} else if ( ( oldFlags & EF_DEAD ) && !( drawEs->eFlags & EF_DEAD ) ) {
-			trap_S_StartSound( NULL, cent->currentState.number, CHAN_AUTO, cgs.media.teleInSound );
-			CG_SpawnEffect( fxOrigin );
-		}
 		CG_DemoDelagResetPlayerAnims( cent, drawEs->legsAnim, drawEs->torsoAnim );
 	}
 
 	cent->demoDelagLastVisualEFlags = drawEs->eFlags;
 	cent->demoDelagLastVisualEFlagsValid = qtrue;
+}
+
+/*
+ * Server time of the first history snap in (tLo, tHi] where this player's
+ * teleport bit has flipped from flagsLo. That is the delayed-clock instant
+ * of the tele, matching EV_PLAYER_TELEPORT_* snapServerTime.
+ */
+static int demoDelagFirstTeleportHistoryTime( int entityNum, int flagsLo, int tLo, int tHi ) {
+	int c;
+	int i;
+	const snapshot_t *sn;
+	entityState_t es;
+
+	c = CG_DemoHistory_GetCount();
+	for ( i = c - 1; i >= 0; i-- ) {
+		sn = CG_DemoHistory_GetByFramesAgo( i );
+		if ( !sn ) {
+			continue;
+		}
+		if ( sn->serverTime <= tLo || sn->serverTime > tHi ) {
+			continue;
+		}
+		if ( !findEntityInSnapshot( sn, entityNum, &es ) ) {
+			continue;
+		}
+		if ( demoDelagEFlagsTeleported( flagsLo, es.eFlags ) ) {
+			return sn->serverTime;
+		}
+	}
+	return tHi;
 }
 
 void CG_DemoHistory_BeginHitscanRewind( int rewindToServerTime, int skipEntityNum ) {
@@ -736,10 +843,25 @@ void CG_DemoHistory_AdjustPlayerLerpForDemoDelag( centity_t *cent ) {
 		okHi = demoDelagSamplePoseAtTime( cent, cent->currentState.number, tHi, originHi, anglesHi, &flagsHi, &esHi );
 		if ( okLo && okHi ) {
 			if ( demoDelagEFlagsTeleported( flagsLo, flagsHi ) ) {
-				/* interpolate=false: stay on delayed-current until the delayed snap transitions. */
-				VectorCopy( originLo, origin );
-				VectorCopy( anglesLo, angles );
-				drawEs = esLo;
+				int delayedNow;
+				int teleTime;
+
+				/*
+				 * Snap on the interpolated delayed clock (cg.time - ping), not
+				 * at the next snapshot boundary. That keeps the model pop on
+				 * the same timeline as delayed tele FX.
+				 */
+				delayedNow = cg.time - ping;
+				teleTime = demoDelagFirstTeleportHistoryTime( cent->currentState.number, flagsLo, tLo, tHi );
+				if ( delayedNow >= teleTime ) {
+					VectorCopy( originHi, origin );
+					VectorCopy( anglesHi, angles );
+					drawEs = esHi;
+				} else {
+					VectorCopy( originLo, origin );
+					VectorCopy( anglesLo, angles );
+					drawEs = esLo;
+				}
 			} else {
 				origin[0] = originLo[0] + f * ( originHi[0] - originLo[0] );
 				origin[1] = originLo[1] + f * ( originHi[1] - originLo[1] );

--- a/ratoa_gamecode/code/cgame/cg_demo_history.c
+++ b/ratoa_gamecode/code/cgame/cg_demo_history.c
@@ -29,10 +29,10 @@ static demoRewindSave_t cg_demoRewindSaves[MAX_CLIENTS];
 static int cg_demoRewindSaveCount;
 
 /*
- * Witnessed tele IN/OUT from the recorded snapshot, held until the delayed
- * clock reaches that snap. Not synthesized from later player visibility.
+ * Witnessed tele IN/OUT, held until delayed clock (cg.time - ping) reaches
+ * that snap. Not synthesized from later player visibility.
  */
-#define CG_DEMO_DELAYED_TELE_CAP 128
+#define CG_DEMO_DELAYED_TELE_CAP 24
 
 typedef struct {
 	int		snapServerTime;
@@ -151,44 +151,25 @@ qboolean CG_DemoHistory_DemoDelagActive( void ) {
 	return cg.demoPlayback && cg_demoDelag.integer && cgs.delagHitscan && CG_DemoHistory_GetCount() > 0;
 }
 
-qboolean CG_DemoHistory_DelayPlayerTeleportEvent( int clientNum, int event, const vec3_t origin, int soundEntityNum ) {
+qboolean CG_DemoHistory_DelayPlayerTeleportEvent( int clientNum, int event, const vec3_t origin ) {
 	demoDelayedTele_t *slot;
 	int ping;
 
-	if ( !CG_DemoHistory_DemoDelagActive() ) {
+	if ( !CG_DemoHistory_DemoDelagActive() || !cg.snap || !origin ) {
 		return qfalse;
 	}
-	if ( !cg.snap ) {
+	if ( clientNum == cg.predictedPlayerState.clientNum || !demoDelagResolvePingMs( &ping ) ) {
 		return qfalse;
 	}
-	if ( clientNum == cg.predictedPlayerState.clientNum ) {
-		return qfalse;
-	}
-	if ( !demoDelagResolvePingMs( &ping ) ) {
-		return qfalse;
-	}
-	if ( !origin ) {
+	if ( cg_demoDelayedTeleCount >= CG_DEMO_DELAYED_TELE_CAP ) {
 		return qtrue;
 	}
 
-	if ( cg_demoDelayedTeleCount >= CG_DEMO_DELAYED_TELE_CAP ) {
-		int i;
-
-		for ( i = 0; i < CG_DEMO_DELAYED_TELE_CAP - 1; i++ ) {
-			cg_demoDelayedTele[i] = cg_demoDelayedTele[i + 1];
-		}
-		cg_demoDelayedTeleCount = CG_DEMO_DELAYED_TELE_CAP - 1;
-	}
-
-	slot = &cg_demoDelayedTele[cg_demoDelayedTeleCount];
+	slot = &cg_demoDelayedTele[cg_demoDelayedTeleCount++];
 	slot->snapServerTime = cg.snap->serverTime;
 	slot->event = event;
-	slot->soundEntityNum = soundEntityNum;
-	if ( clientNum >= 0 && clientNum < MAX_CLIENTS ) {
-		slot->soundEntityNum = clientNum;
-	}
+	slot->soundEntityNum = ( clientNum >= 0 && clientNum < MAX_CLIENTS ) ? clientNum : ENTITYNUM_WORLD;
 	VectorCopy( origin, slot->origin );
-	cg_demoDelayedTeleCount++;
 	return qtrue;
 }
 
@@ -339,39 +320,10 @@ static qboolean demoDelagResolvePingMs( int *outPing ) {
 	return qtrue;
 }
 
-static void demoDelagPlayDelayedTeleport( const demoDelayedTele_t *ev ) {
-	sfxHandle_t sfx;
-	int soundEnt;
-	vec3_t origin;
-
-	if ( !ev ) {
-		return;
-	}
-	if ( ev->event == EV_PLAYER_TELEPORT_OUT ) {
-		sfx = cgs.media.teleOutSound;
-	} else {
-		sfx = cgs.media.teleInSound;
-	}
-	soundEnt = ev->soundEntityNum;
-	if ( soundEnt < 0 || soundEnt >= MAX_GENTITIES ) {
-		soundEnt = ENTITYNUM_WORLD;
-	}
-	VectorCopy( ev->origin, origin );
-	trap_S_StartSound( origin, soundEnt, CHAN_AUTO, sfx );
-	CG_SpawnEffect( origin );
-}
-
-/*
- * Release tele IN/OUT when interpolated delayed time (cg.time - ping) reaches
- * the snap that contained them — the same clock remote players are drawn on.
- * Presence in that recorded snap is the witness test: if the recorder never
- * got the event, it is never queued and never played later.
- */
 static void demoDelagFlushDelayedTeleports( void ) {
-	int ping;
-	int delayedTime;
-	int i;
-	int kept;
+	int ping, i, kept, soundEnt;
+	vec3_t origin;
+	demoDelayedTele_t *ev;
 
 	if ( !CG_DemoHistory_DemoDelagActive() || !cg.snap ) {
 		cg_demoDelayedTeleCount = 0;
@@ -381,17 +333,21 @@ static void demoDelagFlushDelayedTeleports( void ) {
 		return;
 	}
 
-	delayedTime = cg.time - ping;
 	kept = 0;
 	for ( i = 0; i < cg_demoDelayedTeleCount; i++ ) {
-		if ( delayedTime >= cg_demoDelayedTele[i].snapServerTime ) {
-			demoDelagPlayDelayedTeleport( &cg_demoDelayedTele[i] );
-		} else {
-			if ( kept != i ) {
-				cg_demoDelayedTele[kept] = cg_demoDelayedTele[i];
-			}
-			kept++;
+		ev = &cg_demoDelayedTele[i];
+		if ( cg.time - ping < ev->snapServerTime ) {
+			cg_demoDelayedTele[kept++] = *ev;
+			continue;
 		}
+		soundEnt = ev->soundEntityNum;
+		if ( soundEnt < 0 || soundEnt >= MAX_GENTITIES ) {
+			soundEnt = ENTITYNUM_WORLD;
+		}
+		VectorCopy( ev->origin, origin );
+		trap_S_StartSound( origin, soundEnt, CHAN_AUTO,
+			ev->event == EV_PLAYER_TELEPORT_OUT ? cgs.media.teleOutSound : cgs.media.teleInSound );
+		CG_SpawnEffect( origin );
 	}
 	cg_demoDelayedTeleCount = kept;
 }
@@ -403,15 +359,6 @@ static int demoDelagAttackerSampleTime( int attackServerTime ) {
 		return clampServerTimeToHistory( attackServerTime );
 	}
 	return clampServerTimeToHistory( attackServerTime - ping );
-}
-
-int CG_DemoHistory_LocalFireDelay( void ) {
-	/*
-	 * POV muzzle flash/sound must stay on the live demo clock. Own missiles
-	 * are not time-shifted (they skip missile delag); delaying fire here put
-	 * the gun a snapshot behind the bolt.
-	 */
-	return 0;
 }
 
 static qboolean demoDelagEFlagsTeleported( int eFlagsA, int eFlagsB ) {
@@ -716,25 +663,22 @@ static void demoDelagApplyVisual( centity_t *cent, const vec3_t origin, const ve
  * of the tele, matching EV_PLAYER_TELEPORT_* snapServerTime.
  */
 static int demoDelagFirstTeleportHistoryTime( int entityNum, int flagsLo, int tLo, int tHi ) {
-	int c;
-	int i;
+	int c, i, e;
 	const snapshot_t *sn;
-	entityState_t es;
 
 	c = CG_DemoHistory_GetCount();
 	for ( i = c - 1; i >= 0; i-- ) {
 		sn = CG_DemoHistory_GetByFramesAgo( i );
-		if ( !sn ) {
+		if ( !sn || sn->serverTime <= tLo || sn->serverTime > tHi ) {
 			continue;
 		}
-		if ( sn->serverTime <= tLo || sn->serverTime > tHi ) {
-			continue;
-		}
-		if ( !findEntityInSnapshot( sn, entityNum, &es ) ) {
-			continue;
-		}
-		if ( demoDelagEFlagsTeleported( flagsLo, es.eFlags ) ) {
-			return sn->serverTime;
+		for ( e = 0; e < sn->numEntities; e++ ) {
+			if ( sn->entities[e].number == entityNum ) {
+				if ( demoDelagEFlagsTeleported( flagsLo, sn->entities[e].eFlags ) ) {
+					return sn->serverTime;
+				}
+				break;
+			}
 		}
 	}
 	return tHi;
@@ -843,24 +787,10 @@ void CG_DemoHistory_AdjustPlayerLerpForDemoDelag( centity_t *cent ) {
 		okHi = demoDelagSamplePoseAtTime( cent, cent->currentState.number, tHi, originHi, anglesHi, &flagsHi, &esHi );
 		if ( okLo && okHi ) {
 			if ( demoDelagEFlagsTeleported( flagsLo, flagsHi ) ) {
-				int delayedNow;
-				int teleTime;
-
-				/*
-				 * Snap on the interpolated delayed clock (cg.time - ping), not
-				 * at the next snapshot boundary. That keeps the model pop on
-				 * the same timeline as delayed tele FX.
-				 */
-				delayedNow = cg.time - ping;
-				teleTime = demoDelagFirstTeleportHistoryTime( cent->currentState.number, flagsLo, tLo, tHi );
-				if ( delayedNow >= teleTime ) {
-					VectorCopy( originHi, origin );
-					VectorCopy( anglesHi, angles );
-					drawEs = esHi;
+				if ( cg.time - ping >= demoDelagFirstTeleportHistoryTime( cent->currentState.number, flagsLo, tLo, tHi ) ) {
+					demoDelagApplyVisual( cent, originHi, anglesHi, &esHi );
 				} else {
-					VectorCopy( originLo, origin );
-					VectorCopy( anglesLo, angles );
-					drawEs = esLo;
+					demoDelagApplyVisual( cent, originLo, anglesLo, &esLo );
 				}
 			} else {
 				origin[0] = originLo[0] + f * ( originHi[0] - originLo[0] );
@@ -870,8 +800,8 @@ void CG_DemoHistory_AdjustPlayerLerpForDemoDelag( centity_t *cent ) {
 				angles[1] = LerpAngle( anglesLo[1], anglesHi[1], f );
 				angles[2] = LerpAngle( anglesLo[2], anglesHi[2], f );
 				drawEs = esLo;
+				demoDelagApplyVisual( cent, origin, angles, &drawEs );
 			}
-			demoDelagApplyVisual( cent, origin, angles, &drawEs );
 			return;
 		}
 		if ( okLo ) {

--- a/ratoa_gamecode/code/cgame/cg_demo_history.h
+++ b/ratoa_gamecode/code/cgame/cg_demo_history.h
@@ -22,7 +22,7 @@ const snapshot_t *CG_DemoHistory_GetNewest( void );
 const snapshot_t *CG_DemoHistory_GetByFramesAgo( int framesAgo );
 
 qboolean CG_DemoHistory_DemoDelagActive( void );
-qboolean CG_DemoHistory_SuppressLivePlayerTeleportEvent( int clientNum );
+qboolean CG_DemoHistory_DelayPlayerTeleportEvent( int clientNum, int event, const vec3_t origin, int soundEntityNum );
 void CG_DemoHistory_BeginHitscanRewind( int rewindToServerTime, int skipEntityNum );
 void CG_DemoHistory_EndHitscanRewind( void );
 void CG_DemoHistory_AdjustPlayerLerpForDemoDelag( struct centity_s *cent );

--- a/ratoa_gamecode/code/cgame/cg_demo_history.h
+++ b/ratoa_gamecode/code/cgame/cg_demo_history.h
@@ -22,11 +22,10 @@ const snapshot_t *CG_DemoHistory_GetNewest( void );
 const snapshot_t *CG_DemoHistory_GetByFramesAgo( int framesAgo );
 
 qboolean CG_DemoHistory_DemoDelagActive( void );
-qboolean CG_DemoHistory_DelayPlayerTeleportEvent( int clientNum, int event, const vec3_t origin, int soundEntityNum );
+qboolean CG_DemoHistory_DelayPlayerTeleportEvent( int clientNum, int event, const vec3_t origin );
 void CG_DemoHistory_BeginHitscanRewind( int rewindToServerTime, int skipEntityNum );
 void CG_DemoHistory_EndHitscanRewind( void );
 void CG_DemoHistory_AdjustPlayerLerpForDemoDelag( struct centity_s *cent );
 qboolean CG_DemoHistory_AdjustMissileLerpForDemoDelag( struct centity_s *cent );
-int CG_DemoHistory_LocalFireDelay( void );
 
 #endif

--- a/ratoa_gamecode/code/cgame/cg_event.c
+++ b/ratoa_gamecode/code/cgame/cg_event.c
@@ -1044,7 +1044,7 @@ void CG_EntityEvent( centity_t *cent, vec3_t position ) {
 	//
 	case EV_PLAYER_TELEPORT_IN:
 		DEBUGNAME("EV_PLAYER_TELEPORT_IN");
-		if ( CG_DemoHistory_DelayPlayerTeleportEvent( es->clientNum, EV_PLAYER_TELEPORT_IN, position, es->number ) ) {
+		if ( CG_DemoHistory_DelayPlayerTeleportEvent( es->clientNum, EV_PLAYER_TELEPORT_IN, position ) ) {
 			break;
 		}
 		trap_S_StartSound (NULL, es->number, CHAN_AUTO, cgs.media.teleInSound );
@@ -1053,7 +1053,7 @@ void CG_EntityEvent( centity_t *cent, vec3_t position ) {
 
 	case EV_PLAYER_TELEPORT_OUT:
 		DEBUGNAME("EV_PLAYER_TELEPORT_OUT");
-		if ( CG_DemoHistory_DelayPlayerTeleportEvent( es->clientNum, EV_PLAYER_TELEPORT_OUT, position, es->number ) ) {
+		if ( CG_DemoHistory_DelayPlayerTeleportEvent( es->clientNum, EV_PLAYER_TELEPORT_OUT, position ) ) {
 			break;
 		}
 		trap_S_StartSound (NULL, es->number, CHAN_AUTO, cgs.media.teleOutSound );

--- a/ratoa_gamecode/code/cgame/cg_event.c
+++ b/ratoa_gamecode/code/cgame/cg_event.c
@@ -1044,7 +1044,7 @@ void CG_EntityEvent( centity_t *cent, vec3_t position ) {
 	//
 	case EV_PLAYER_TELEPORT_IN:
 		DEBUGNAME("EV_PLAYER_TELEPORT_IN");
-		if ( CG_DemoHistory_SuppressLivePlayerTeleportEvent( es->clientNum ) ) {
+		if ( CG_DemoHistory_DelayPlayerTeleportEvent( es->clientNum, EV_PLAYER_TELEPORT_IN, position, es->number ) ) {
 			break;
 		}
 		trap_S_StartSound (NULL, es->number, CHAN_AUTO, cgs.media.teleInSound );
@@ -1053,7 +1053,7 @@ void CG_EntityEvent( centity_t *cent, vec3_t position ) {
 
 	case EV_PLAYER_TELEPORT_OUT:
 		DEBUGNAME("EV_PLAYER_TELEPORT_OUT");
-		if ( CG_DemoHistory_SuppressLivePlayerTeleportEvent( es->clientNum ) ) {
+		if ( CG_DemoHistory_DelayPlayerTeleportEvent( es->clientNum, EV_PLAYER_TELEPORT_OUT, position, es->number ) ) {
 			break;
 		}
 		trap_S_StartSound (NULL, es->number, CHAN_AUTO, cgs.media.teleOutSound );

--- a/ratoa_gamecode/code/cgame/cg_local.h
+++ b/ratoa_gamecode/code/cgame/cg_local.h
@@ -2033,7 +2033,6 @@ void CG_RegisterWeapon( int weaponNum );
 void CG_RegisterItemVisuals( int itemNum );
 
 void CG_FireWeapon( centity_t *cent );
-void CG_ProcessDelayedWeaponFires( void );
 void CG_MissileHitWall( int weapon, int clientNum, vec3_t origin, vec3_t dir, impactSound_t soundType, predictedMissileStatus_t *missileStatus );
 void CG_MissileHitPlayer( int weapon, vec3_t origin, vec3_t dir, int entityNum, predictedMissileStatus_t *missileStatus );
 void CG_ShotgunFire( entityState_t *es );

--- a/ratoa_gamecode/code/cgame/cg_superhud.c
+++ b/ratoa_gamecode/code/cgame/cg_superhud.c
@@ -1572,92 +1572,147 @@ static qboolean SH_Visible( const shElement_t *e ) {
 	return qfalse;
 }
 
-static int SH_OwnScore( void ) {
-	if ( CG_IsTeamGametype() ) {
-		if ( cg.snap->ps.persistant[PERS_TEAM] == TEAM_RED ) {
-			return cgs.scores1;
-		}
-		if ( cg.snap->ps.persistant[PERS_TEAM] == TEAM_BLUE ) {
-			return cgs.scores2;
-		}
+static qboolean SH_ClientIsPlaying( int clientNum ) {
+	clientInfo_t *ci;
+
+	if ( clientNum < 0 || clientNum >= MAX_CLIENTS ) {
+		return qfalse;
 	}
-	return cg.snap->ps.persistant[PERS_SCORE];
+	ci = &cgs.clientinfo[clientNum];
+	if ( !ci->infoValid || ci->team == TEAM_SPECTATOR ) {
+		return qfalse;
+	}
+	return qtrue;
 }
 
-static int SH_NmeScore( void ) {
-	if ( CG_IsTeamGametype() ) {
-		if ( cg.snap->ps.persistant[PERS_TEAM] == TEAM_RED ) {
-			return cgs.scores2;
-		}
-		if ( cg.snap->ps.persistant[PERS_TEAM] == TEAM_BLUE ) {
-			return cgs.scores1;
-		}
-		return cgs.scores2;
-	}
-
-	/* FFA/tourney: CS_SCORES1 is first place, CS_SCORES2 is second.
-	   Do not compare against own score — a tie makes both values equal. */
-	if ( ( cg.snap->ps.persistant[PERS_RANK] & ~RANK_TIED_FLAG ) == 0 ) {
-		return cgs.scores2;
-	}
-	return cgs.scores1;
-}
-
-static int SH_NmeClientNum( void ) {
+static int SH_FirstPlayingClient( int skipClient ) {
 	int i;
-	int own = cg.snap->ps.clientNum;
 
 	if ( cg.numScores > 0 ) {
 		for ( i = 0; i < cg.numScores; i++ ) {
-			clientInfo_t *ci = &cgs.clientinfo[cg.scores[i].client];
-			if ( cg.scores[i].client == own ) {
+			if ( cg.scores[i].client == skipClient ) {
 				continue;
 			}
-			if ( !ci->infoValid || ci->team == TEAM_SPECTATOR ) {
-				continue;
+			if ( SH_ClientIsPlaying( cg.scores[i].client ) ) {
+				return cg.scores[i].client;
 			}
-			return cg.scores[i].client;
 		}
 	}
 	for ( i = 0; i < cgs.maxclients; i++ ) {
-		if ( i == own ) {
+		if ( i == skipClient ) {
 			continue;
 		}
-		if ( !cgs.clientinfo[i].infoValid || cgs.clientinfo[i].team == TEAM_SPECTATOR ) {
-			continue;
+		if ( SH_ClientIsPlaying( i ) ) {
+			return i;
 		}
-		return i;
 	}
 	return -1;
 }
 
-static const char *SH_OwnName( void ) {
-	if ( CG_IsTeamGametype() ) {
-		int team = cg.snap->ps.persistant[PERS_TEAM];
-		if ( team == TEAM_RED ) {
-			return cg_redTeamName.string[0] ? cg_redTeamName.string : "Red";
-		}
-		if ( team == TEAM_BLUE ) {
-			return cg_blueTeamName.string[0] ? cg_blueTeamName.string : "Blue";
+static int SH_MatchupOwnClient( void ) {
+	int pov = cg.snap->ps.clientNum;
+
+	if ( SH_ClientIsPlaying( pov ) ) {
+		return pov;
+	}
+	return SH_FirstPlayingClient( -1 );
+}
+
+static int SH_MatchupNmeClient( void ) {
+	return SH_FirstPlayingClient( SH_MatchupOwnClient() );
+}
+
+static int SH_ClientScore( int clientNum ) {
+	int i;
+
+	if ( !SH_ClientIsPlaying( clientNum ) ) {
+		return SCORE_NOT_PRESENT;
+	}
+	if ( cg.numScores > 0 ) {
+		for ( i = 0; i < cg.numScores; i++ ) {
+			if ( cg.scores[i].client == clientNum ) {
+				return cg.scores[i].score;
+			}
 		}
 	}
-	return cgs.clientinfo[cg.snap->ps.clientNum].name;
+	return cgs.clientinfo[clientNum].score;
+}
+
+static int SH_MatchupOwnTeam( void ) {
+	int team;
+
+	team = cg.snap->ps.persistant[PERS_TEAM];
+	if ( team == TEAM_RED || team == TEAM_BLUE ) {
+		return team;
+	}
+	if ( ( cg.snap->ps.pm_flags & PMF_FOLLOW ) && SH_ClientIsPlaying( cg.snap->ps.clientNum ) ) {
+		team = cgs.clientinfo[cg.snap->ps.clientNum].team;
+		if ( team == TEAM_RED || team == TEAM_BLUE ) {
+			return team;
+		}
+	}
+	team = cgs.clientinfo[cg.clientNum].team;
+	if ( team == TEAM_RED || team == TEAM_BLUE ) {
+		return team;
+	}
+	/* Free spec: Red on the left, Blue on the right. */
+	return TEAM_RED;
+}
+
+static const char *SH_TeamMatchupName( int team ) {
+	if ( team == TEAM_BLUE ) {
+		return cg_blueTeamName.string[0] ? cg_blueTeamName.string : "Blue";
+	}
+	return cg_redTeamName.string[0] ? cg_redTeamName.string : "Red";
+}
+
+static int SH_OwnScore( void ) {
+	int cl;
+
+	if ( CG_IsTeamGametype() ) {
+		if ( SH_MatchupOwnTeam() == TEAM_BLUE ) {
+			return cgs.scores2;
+		}
+		return cgs.scores1;
+	}
+	cl = SH_MatchupOwnClient();
+	if ( cl == cg.snap->ps.clientNum && SH_ClientIsPlaying( cl ) ) {
+		return cg.snap->ps.persistant[PERS_SCORE];
+	}
+	return SH_ClientScore( cl );
+}
+
+static int SH_NmeScore( void ) {
+	if ( CG_IsTeamGametype() ) {
+		if ( SH_MatchupOwnTeam() == TEAM_BLUE ) {
+			return cgs.scores1;
+		}
+		return cgs.scores2;
+	}
+	return SH_ClientScore( SH_MatchupNmeClient() );
+}
+
+static const char *SH_OwnName( void ) {
+	int cl;
+
+	if ( CG_IsTeamGametype() ) {
+		return SH_TeamMatchupName( SH_MatchupOwnTeam() );
+	}
+	cl = SH_MatchupOwnClient();
+	if ( cl < 0 ) {
+		return "";
+	}
+	return cgs.clientinfo[cl].name;
 }
 
 static const char *SH_NmeName( void ) {
 	int cl;
 
 	if ( CG_IsTeamGametype() ) {
-		int team = cg.snap->ps.persistant[PERS_TEAM];
-		if ( team == TEAM_RED ) {
-			return cg_blueTeamName.string[0] ? cg_blueTeamName.string : "Blue";
-		}
-		if ( team == TEAM_BLUE ) {
-			return cg_redTeamName.string[0] ? cg_redTeamName.string : "Red";
-		}
-		return "Enemy";
+		int own = SH_MatchupOwnTeam();
+		return SH_TeamMatchupName( own == TEAM_BLUE ? TEAM_RED : TEAM_BLUE );
 	}
-	cl = SH_NmeClientNum();
+	cl = SH_MatchupNmeClient();
 	if ( cl < 0 ) {
 		return "";
 	}
@@ -1698,6 +1753,22 @@ static int SH_GameLimit( void ) {
 	return cgs.fraglimit;
 }
 
+/* Two-party matchup (1v1 or team vs team). Not FFA / LMS / other free-for-all. */
+static qboolean SH_IsMatchupGametype( void ) {
+	if ( CG_IsTeamGametype() ) {
+		return qtrue;
+	}
+	if ( cgs.gametype == GT_TOURNAMENT ) {
+		return qtrue;
+	}
+#ifdef WITH_MULTITOURNAMENT
+	if ( cgs.gametype == GT_MULTITOURNAMENT ) {
+		return qtrue;
+	}
+#endif
+	return qfalse;
+}
+
 /*
  * CPMA HUDs put a PreDecorate { text "vs" } in the same slot as Score_Limit.
  * Show "vs" only when there is no frag/capture limit; otherwise show the limit.
@@ -1710,7 +1781,7 @@ static void SH_DrawDecor( const shElement_t *e ) {
 	if ( !SH_Visible( e ) ) {
 		return;
 	}
-	if ( SH_IsVsDecor( e ) && SH_GameLimit() > 0 ) {
+	if ( SH_IsVsDecor( e ) && ( !SH_IsMatchupGametype() || SH_GameLimit() > 0 ) ) {
 		return;
 	}
 	SH_DrawFill( e );
@@ -1825,9 +1896,12 @@ static void SH_DrawScores( void ) {
 	int limit;
 
 	if ( SH_Visible( &sh.named[SH_Score_OWN] ) ) {
-		SH_DrawFill( &sh.named[SH_Score_OWN] );
-		Com_sprintf( buf, sizeof( buf ), "%i", SH_OwnScore() );
-		SH_DrawString( &sh.named[SH_Score_OWN], buf, 0 );
+		int own = SH_OwnScore();
+		if ( own != SCORE_NOT_PRESENT ) {
+			SH_DrawFill( &sh.named[SH_Score_OWN] );
+			Com_sprintf( buf, sizeof( buf ), "%i", own );
+			SH_DrawString( &sh.named[SH_Score_OWN], buf, 0 );
+		}
 	}
 	if ( SH_Visible( &sh.named[SH_Score_NME] ) ) {
 		nme = SH_NmeScore();
@@ -1844,13 +1918,18 @@ static void SH_DrawScores( void ) {
 		Com_sprintf( buf, sizeof( buf ), "%i", limit );
 		SH_DrawString( &sh.named[SH_Score_Limit], buf, 0 );
 	}
-	if ( SH_Visible( &sh.named[SH_Name_OWN] ) ) {
-		SH_DrawString( &sh.named[SH_Name_OWN], SH_OwnName(), 0 );
-	}
-	if ( SH_Visible( &sh.named[SH_Name_NME] ) ) {
-		const char *n = SH_NmeName();
-		if ( n && n[0] ) {
-			SH_DrawString( &sh.named[SH_Name_NME], n, 0 );
+	if ( SH_IsMatchupGametype() ) {
+		if ( SH_Visible( &sh.named[SH_Name_OWN] ) ) {
+			const char *n = SH_OwnName();
+			if ( n && n[0] ) {
+				SH_DrawString( &sh.named[SH_Name_OWN], n, 0 );
+			}
+		}
+		if ( SH_Visible( &sh.named[SH_Name_NME] ) ) {
+			const char *n = SH_NmeName();
+			if ( n && n[0] ) {
+				SH_DrawString( &sh.named[SH_Name_NME], n, 0 );
+			}
 		}
 	}
 }

--- a/ratoa_gamecode/code/cgame/cg_superhud.c
+++ b/ratoa_gamecode/code/cgame/cg_superhud.c
@@ -1572,151 +1572,91 @@ static qboolean SH_Visible( const shElement_t *e ) {
 	return qfalse;
 }
 
-static qboolean SH_ClientIsPlaying( int clientNum ) {
-	clientInfo_t *ci;
-
-	if ( clientNum < 0 || clientNum >= MAX_CLIENTS ) {
-		return qfalse;
-	}
-	ci = &cgs.clientinfo[clientNum];
-	if ( !ci->infoValid || ci->team == TEAM_SPECTATOR ) {
-		return qfalse;
-	}
-	return qtrue;
+static qboolean SH_Playing( int cl ) {
+	return cl >= 0 && cl < MAX_CLIENTS && cgs.clientinfo[cl].infoValid
+		&& cgs.clientinfo[cl].team != TEAM_SPECTATOR;
 }
 
-static int SH_FirstPlayingClient( int skipClient ) {
-	int i;
+static int SH_NextPlaying( int skip ) {
+	int i, cl;
 
-	if ( cg.numScores > 0 ) {
-		for ( i = 0; i < cg.numScores; i++ ) {
-			if ( cg.scores[i].client == skipClient ) {
-				continue;
-			}
-			if ( SH_ClientIsPlaying( cg.scores[i].client ) ) {
-				return cg.scores[i].client;
-			}
+	for ( i = 0; i < cg.numScores; i++ ) {
+		cl = cg.scores[i].client;
+		if ( cl != skip && SH_Playing( cl ) ) {
+			return cl;
 		}
 	}
 	for ( i = 0; i < cgs.maxclients; i++ ) {
-		if ( i == skipClient ) {
-			continue;
-		}
-		if ( SH_ClientIsPlaying( i ) ) {
+		if ( i != skip && SH_Playing( i ) ) {
 			return i;
 		}
 	}
 	return -1;
 }
 
-static int SH_MatchupOwnClient( void ) {
-	int pov = cg.snap->ps.clientNum;
+static int SH_OwnTeam( void ) {
+	int t;
 
-	if ( SH_ClientIsPlaying( pov ) ) {
-		return pov;
+	t = cg.snap->ps.persistant[PERS_TEAM];
+	if ( t == TEAM_RED || t == TEAM_BLUE ) {
+		return t;
 	}
-	return SH_FirstPlayingClient( -1 );
-}
-
-static int SH_MatchupNmeClient( void ) {
-	return SH_FirstPlayingClient( SH_MatchupOwnClient() );
-}
-
-static int SH_ClientScore( int clientNum ) {
-	int i;
-
-	if ( !SH_ClientIsPlaying( clientNum ) ) {
-		return SCORE_NOT_PRESENT;
+	t = cgs.clientinfo[cg.snap->ps.clientNum].team;
+	if ( t == TEAM_RED || t == TEAM_BLUE ) {
+		return t;
 	}
-	if ( cg.numScores > 0 ) {
-		for ( i = 0; i < cg.numScores; i++ ) {
-			if ( cg.scores[i].client == clientNum ) {
-				return cg.scores[i].score;
-			}
-		}
+	t = cgs.clientinfo[cg.clientNum].team;
+	if ( t == TEAM_RED || t == TEAM_BLUE ) {
+		return t;
 	}
-	return cgs.clientinfo[clientNum].score;
-}
-
-static int SH_MatchupOwnTeam( void ) {
-	int team;
-
-	team = cg.snap->ps.persistant[PERS_TEAM];
-	if ( team == TEAM_RED || team == TEAM_BLUE ) {
-		return team;
-	}
-	if ( ( cg.snap->ps.pm_flags & PMF_FOLLOW ) && SH_ClientIsPlaying( cg.snap->ps.clientNum ) ) {
-		team = cgs.clientinfo[cg.snap->ps.clientNum].team;
-		if ( team == TEAM_RED || team == TEAM_BLUE ) {
-			return team;
-		}
-	}
-	team = cgs.clientinfo[cg.clientNum].team;
-	if ( team == TEAM_RED || team == TEAM_BLUE ) {
-		return team;
-	}
-	/* Free spec: Red on the left, Blue on the right. */
 	return TEAM_RED;
 }
 
-static const char *SH_TeamMatchupName( int team ) {
+static const char *SH_TeamName( int team ) {
 	if ( team == TEAM_BLUE ) {
 		return cg_blueTeamName.string[0] ? cg_blueTeamName.string : "Blue";
 	}
 	return cg_redTeamName.string[0] ? cg_redTeamName.string : "Red";
 }
 
-static int SH_OwnScore( void ) {
-	int cl;
+static int SH_MatchupScore( qboolean nme ) {
+	int cl, i;
 
 	if ( CG_IsTeamGametype() ) {
-		if ( SH_MatchupOwnTeam() == TEAM_BLUE ) {
-			return cgs.scores2;
-		}
-		return cgs.scores1;
+		return ( ( SH_OwnTeam() == TEAM_BLUE ) == nme ) ? cgs.scores1 : cgs.scores2;
 	}
-	cl = SH_MatchupOwnClient();
-	if ( cl == cg.snap->ps.clientNum && SH_ClientIsPlaying( cl ) ) {
+	cl = SH_Playing( cg.snap->ps.clientNum ) ? cg.snap->ps.clientNum : SH_NextPlaying( -1 );
+	if ( nme ) {
+		cl = SH_NextPlaying( cl );
+	} else if ( cl == cg.snap->ps.clientNum ) {
 		return cg.snap->ps.persistant[PERS_SCORE];
 	}
-	return SH_ClientScore( cl );
-}
-
-static int SH_NmeScore( void ) {
-	if ( CG_IsTeamGametype() ) {
-		if ( SH_MatchupOwnTeam() == TEAM_BLUE ) {
-			return cgs.scores1;
+	if ( !SH_Playing( cl ) ) {
+		return SCORE_NOT_PRESENT;
+	}
+	for ( i = 0; i < cg.numScores; i++ ) {
+		if ( cg.scores[i].client == cl ) {
+			return cg.scores[i].score;
 		}
-		return cgs.scores2;
 	}
-	return SH_ClientScore( SH_MatchupNmeClient() );
+	return cgs.clientinfo[cl].score;
 }
 
-static const char *SH_OwnName( void ) {
-	int cl;
+static const char *SH_MatchupName( qboolean nme ) {
+	int cl, team;
 
 	if ( CG_IsTeamGametype() ) {
-		return SH_TeamMatchupName( SH_MatchupOwnTeam() );
+		team = SH_OwnTeam();
+		if ( nme ) {
+			team = ( team == TEAM_BLUE ) ? TEAM_RED : TEAM_BLUE;
+		}
+		return SH_TeamName( team );
 	}
-	cl = SH_MatchupOwnClient();
-	if ( cl < 0 ) {
-		return "";
+	cl = SH_Playing( cg.snap->ps.clientNum ) ? cg.snap->ps.clientNum : SH_NextPlaying( -1 );
+	if ( nme ) {
+		cl = SH_NextPlaying( cl );
 	}
-	return cgs.clientinfo[cl].name;
-}
-
-static const char *SH_NmeName( void ) {
-	int cl;
-
-	if ( CG_IsTeamGametype() ) {
-		int own = SH_MatchupOwnTeam();
-		return SH_TeamMatchupName( own == TEAM_BLUE ? TEAM_RED : TEAM_BLUE );
-	}
-	cl = SH_MatchupNmeClient();
-	if ( cl < 0 ) {
-		return "";
-	}
-	return cgs.clientinfo[cl].name;
+	return SH_Playing( cl ) ? cgs.clientinfo[cl].name : "";
 }
 
 static const char *SH_GameTypeString( void ) {
@@ -1755,33 +1695,23 @@ static int SH_GameLimit( void ) {
 
 /* Two-party matchup (1v1 or team vs team). Not FFA / LMS / other free-for-all. */
 static qboolean SH_IsMatchupGametype( void ) {
-	if ( CG_IsTeamGametype() ) {
-		return qtrue;
-	}
-	if ( cgs.gametype == GT_TOURNAMENT ) {
-		return qtrue;
-	}
+	return CG_IsTeamGametype() || cgs.gametype == GT_TOURNAMENT
 #ifdef WITH_MULTITOURNAMENT
-	if ( cgs.gametype == GT_MULTITOURNAMENT ) {
-		return qtrue;
-	}
+		|| cgs.gametype == GT_MULTITOURNAMENT
 #endif
-	return qfalse;
+		;
 }
 
 /*
  * CPMA HUDs put a PreDecorate { text "vs" } in the same slot as Score_Limit.
  * Show "vs" only when there is no frag/capture limit; otherwise show the limit.
  */
-static qboolean SH_IsVsDecor( const shElement_t *e ) {
-	return e->text[0] && !Q_stricmp( e->text, "vs" );
-}
-
 static void SH_DrawDecor( const shElement_t *e ) {
 	if ( !SH_Visible( e ) ) {
 		return;
 	}
-	if ( SH_IsVsDecor( e ) && ( !SH_IsMatchupGametype() || SH_GameLimit() > 0 ) ) {
+	if ( e->text[0] && !Q_stricmp( e->text, "vs" )
+			&& ( !SH_IsMatchupGametype() || SH_GameLimit() > 0 ) ) {
 		return;
 	}
 	SH_DrawFill( e );
@@ -1892,44 +1822,38 @@ static void SH_DrawGameTime( void ) {
 
 static void SH_DrawScores( void ) {
 	char buf[32];
-	int nme;
-	int limit;
+	int side, val, limit;
+	shElement_t *scoreEl, *nameEl;
+	const char *name;
 
-	if ( SH_Visible( &sh.named[SH_Score_OWN] ) ) {
-		int own = SH_OwnScore();
-		if ( own != SCORE_NOT_PRESENT ) {
-			SH_DrawFill( &sh.named[SH_Score_OWN] );
-			Com_sprintf( buf, sizeof( buf ), "%i", own );
-			SH_DrawString( &sh.named[SH_Score_OWN], buf, 0 );
+	for ( side = 0; side < 2; side++ ) {
+		scoreEl = &sh.named[side ? SH_Score_NME : SH_Score_OWN];
+		if ( SH_Visible( scoreEl ) ) {
+			val = SH_MatchupScore( side );
+			if ( val != SCORE_NOT_PRESENT ) {
+				SH_DrawFill( scoreEl );
+				Com_sprintf( buf, sizeof( buf ), "%i", val );
+				SH_DrawString( scoreEl, buf, 0 );
+			}
 		}
 	}
-	if ( SH_Visible( &sh.named[SH_Score_NME] ) ) {
-		nme = SH_NmeScore();
-		if ( nme != SCORE_NOT_PRESENT ) {
-			SH_DrawFill( &sh.named[SH_Score_NME] );
-			Com_sprintf( buf, sizeof( buf ), "%i", nme );
-			SH_DrawString( &sh.named[SH_Score_NME], buf, 0 );
-		}
-	}
-	/* Mutually exclusive with PreDecorate text "vs" (see SH_DrawDecor). */
 	limit = SH_GameLimit();
 	if ( SH_Visible( &sh.named[SH_Score_Limit] ) && limit > 0 ) {
 		SH_DrawFill( &sh.named[SH_Score_Limit] );
 		Com_sprintf( buf, sizeof( buf ), "%i", limit );
 		SH_DrawString( &sh.named[SH_Score_Limit], buf, 0 );
 	}
-	if ( SH_IsMatchupGametype() ) {
-		if ( SH_Visible( &sh.named[SH_Name_OWN] ) ) {
-			const char *n = SH_OwnName();
-			if ( n && n[0] ) {
-				SH_DrawString( &sh.named[SH_Name_OWN], n, 0 );
-			}
+	if ( !SH_IsMatchupGametype() ) {
+		return;
+	}
+	for ( side = 0; side < 2; side++ ) {
+		nameEl = &sh.named[side ? SH_Name_NME : SH_Name_OWN];
+		if ( !SH_Visible( nameEl ) ) {
+			continue;
 		}
-		if ( SH_Visible( &sh.named[SH_Name_NME] ) ) {
-			const char *n = SH_NmeName();
-			if ( n && n[0] ) {
-				SH_DrawString( &sh.named[SH_Name_NME], n, 0 );
-			}
+		name = SH_MatchupName( side );
+		if ( name && name[0] ) {
+			SH_DrawString( nameEl, name, 0 );
 		}
 	}
 }

--- a/ratoa_gamecode/code/cgame/cg_view.c
+++ b/ratoa_gamecode/code/cgame/cg_view.c
@@ -1041,8 +1041,6 @@ void CG_DrawActiveFrame( int serverTime, stereoFrame_t stereoView, qboolean demo
 	// update cg.predictedPlayerState
 	CG_PredictPlayerState();
 
-	CG_ProcessDelayedWeaponFires();
-
 	// decide on third person view
 	cg.renderingThirdPerson = cg_thirdPerson.integer || (cg.snap->ps.stats[STAT_HEALTH] <= 0);
 

--- a/ratoa_gamecode/code/cgame/cg_weapons.c
+++ b/ratoa_gamecode/code/cgame/cg_weapons.c
@@ -4153,108 +4153,6 @@ WEAPON EVENTS
 ===================================================================================================
 */
 
-#define MAX_DELAYED_WEAPON_FIRES 32
-
-typedef struct {
-	qboolean active;
-	int fireTime;
-	int centNum;
-	entityState_t state;
-} delayedWeaponFire_t;
-
-static delayedWeaponFire_t cg_delayedWeaponFires[MAX_DELAYED_WEAPON_FIRES];
-static qboolean cg_processingDelayedWeaponFire;
-
-static qboolean CG_IsDemoDelayedProjectileWeapon( int weapon ) {
-	switch ( weapon ) {
-	case WP_PLASMAGUN:
-	case WP_ROCKET_LAUNCHER:
-	case WP_GRENADE_LAUNCHER:
-	case WP_BFG:
-#ifdef MISSIONPACK
-	case WP_PROX_LAUNCHER:
-	case WP_NAILGUN:
-#endif
-		return qtrue;
-	default:
-		return qfalse;
-	}
-}
-
-static qboolean CG_QueueDelayedWeaponFire( centity_t *cent, int delay ) {
-	int i;
-	int best;
-	int bestTime;
-
-	if ( delay <= 0 ) {
-		return qfalse;
-	}
-	if ( !cent ) {
-		return qfalse;
-	}
-	if ( cent->currentState.number < 0 || cent->currentState.number >= MAX_GENTITIES ) {
-		return qfalse;
-	}
-
-	best = -1;
-	bestTime = 2147483647;
-	for ( i = 0; i < MAX_DELAYED_WEAPON_FIRES; i++ ) {
-		if ( !cg_delayedWeaponFires[i].active ) {
-			best = i;
-			break;
-		}
-		if ( cg_delayedWeaponFires[i].fireTime < bestTime ) {
-			bestTime = cg_delayedWeaponFires[i].fireTime;
-			best = i;
-		}
-	}
-	if ( best < 0 ) {
-		return qfalse;
-	}
-
-	cg_delayedWeaponFires[best].active = qtrue;
-	cg_delayedWeaponFires[best].fireTime = cg.time + delay;
-	cg_delayedWeaponFires[best].centNum = cent->currentState.number;
-	cg_delayedWeaponFires[best].state = cent->currentState;
-	return qtrue;
-}
-
-static void CG_FireWeaponNow( centity_t *cent );
-
-void CG_ProcessDelayedWeaponFires( void ) {
-	int i;
-
-	if ( !CG_DemoHistory_DemoDelagActive() ) {
-		Com_Memset( cg_delayedWeaponFires, 0, sizeof( cg_delayedWeaponFires ) );
-		return;
-	}
-
-	cg_processingDelayedWeaponFire = qtrue;
-	for ( i = 0; i < MAX_DELAYED_WEAPON_FIRES; i++ ) {
-		centity_t *cent;
-		entityState_t savedState;
-
-		if ( !cg_delayedWeaponFires[i].active ) {
-			continue;
-		}
-		if ( cg.time < cg_delayedWeaponFires[i].fireTime ) {
-			continue;
-		}
-		if ( cg_delayedWeaponFires[i].centNum < 0 || cg_delayedWeaponFires[i].centNum >= MAX_GENTITIES ) {
-			cg_delayedWeaponFires[i].active = qfalse;
-			continue;
-		}
-
-		cent = &cg_entities[cg_delayedWeaponFires[i].centNum];
-		savedState = cent->currentState;
-		cent->currentState = cg_delayedWeaponFires[i].state;
-		cg_delayedWeaponFires[i].active = qfalse;
-		CG_FireWeaponNow( cent );
-		cent->currentState = savedState;
-	}
-	cg_processingDelayedWeaponFire = qfalse;
-}
-
 /*
 ================
 CG_FireWeapon
@@ -4262,7 +4160,7 @@ CG_FireWeapon
 Caused by an EV_FIRE_WEAPON event
 ================
 */
-static void CG_FireWeaponNow( centity_t *cent ) {
+void CG_FireWeapon( centity_t *cent ) {
 	entityState_t *ent;
 	int				c;
 	weaponInfo_t	*weap;
@@ -4327,30 +4225,8 @@ static void CG_FireWeaponNow( centity_t *cent ) {
 	}
 
 //unlagged - attack prediction #1
-	if ( !( cg_processingDelayedWeaponFire && CG_IsDemoDelayedProjectileWeapon( ent->weapon ) ) ) {
-		CG_PredictWeaponEffects( cent );
-	}
+	CG_PredictWeaponEffects( cent );
 //unlagged - attack prediction #1
-}
-
-void CG_FireWeapon( centity_t *cent ) {
-	entityState_t *ent;
-	int delay;
-
-	if ( !cent ) {
-		return;
-	}
-	ent = &cent->currentState;
-	delay = CG_DemoHistory_LocalFireDelay();
-	if ( !cg_processingDelayedWeaponFire
-			&& delay > 0
-			&& ent->number == cg.predictedPlayerState.clientNum
-			&& CG_IsDemoDelayedProjectileWeapon( ent->weapon )
-			&& CG_QueueDelayedWeaponFire( cent, delay ) ) {
-		return;
-	}
-
-	CG_FireWeaponNow( cent );
 }
 
 


### PR DESCRIPTION
A couple of bug fixes and a general code cleanup pass.
- Teleporter events and weapon animations now moved to the correct timeline on de-lagged replays
- HUD no longer shows versus info in non-team, non-1v1 gamemodes
- HUD correctly shows correct versus parties when player is spectating

Code squash reduced by about 200 lines of code across 5 files relating to HUD, replay, and visual sounds code. 