### PR TITLE
Improve hit prediction, disable yacc regeneration, and fix sound bug

### DIFF
--- a/BUILD_WINDOWS.md
+++ b/BUILD_WINDOWS.md
@@ -28,7 +28,7 @@ From the **MINGW64** shell:
 pacman -S --needed git make \
   mingw-w64-x86_64-gcc \
   mingw-w64-x86_64-make \
-  unzip zip patch
+  unzip zip patch bison
 ```
 
 - **`make`** — GNU Make as the `make` command (on `PATH` in MINGW64 as `/usr/bin/make`).

--- a/ratoa_gamecode/code/cgame/cg_ents.c
+++ b/ratoa_gamecode/code/cgame/cg_ents.c
@@ -1372,5 +1372,7 @@ void CG_AddPacketEntities( void ) {
 			CG_AddCEntity( cent );
 		} //Also unlagged
 	}
+
+	CG_SaveHitPredictPoses();
 }
 

--- a/ratoa_gamecode/code/cgame/cg_local.h
+++ b/ratoa_gamecode/code/cgame/cg_local.h
@@ -231,6 +231,7 @@ typedef struct {
 #define MF_REMOVEDPMISSILE	32
 #define MF_TRAILFINISHED	64
 #define MF_EXPLOSIONCONFIRMED	128
+#define MF_HITBEEP		256
 
 typedef struct predictedMissileStatus_s {
 	int	missileFlags;
@@ -276,6 +277,11 @@ typedef struct centity_s {
 	// exact interpolated position of entity on this frame
 	vec3_t			lerpOrigin;
 	vec3_t			lerpAngles;
+
+	/* Last AddPacketEntities pose, used next frame for live hit-sound rewind. */
+	qboolean		hitPredictValid;
+	vec3_t			hitPredictOrigin;
+	int			hitPredictSolid;
 
 	qboolean		demoDelagVisualCached;
 	vec3_t			demoDelagVisualOrigin;
@@ -1747,6 +1753,7 @@ extern	markPoly_t		cg_markPolys[MAX_MARK_POLYS];
 
 //unlagged - cg_unlagged.c
 void CG_PredictWeaponEffects( centity_t *cent );
+void CG_SaveHitPredictPoses( void );
 qboolean CG_ConsumePredictedHitSuppression( void );
 int CG_ReliablePing( void );
 int CG_ReliablePingFromSnaps(snapshot_t *snap, snapshot_t *nextsnap);

--- a/ratoa_gamecode/code/cgame/cg_unlagged.c
+++ b/ratoa_gamecode/code/cgame/cg_unlagged.c
@@ -31,6 +31,7 @@ void CG_Bullet( vec3_t end, int sourceEntityNum, vec3_t normal, qboolean flesh, 
 predictedMissile_t *CG_BasePredictMissile( entityState_t *ent,  vec3_t muzzlePoint );
 void CG_FinishPredictMissileModel( entityState_t *ent, predictedMissile_t *pm );
 void CG_PredictNailgunMissile( entityState_t *ent, vec3_t muzzlePoint, vec3_t forward, vec3_t right, vec3_t up );
+static qboolean CG_IsValidPredictedHitTarget( int clientNum );
 
 // and this as well
 //Must be in sync with g_weapon.c
@@ -45,6 +46,214 @@ static int CG_DemoAttackTime( void ) {
 		attackTime = cg.snap->serverTime;
 	}
 	return attackTime;
+}
+
+static int CG_LiveAttackTime( void ) {
+	if ( cg.oldTime > 0 ) {
+		return cg.oldTime;
+	}
+	if ( cg.predictedPlayerState.commandTime > 0 ) {
+		return cg.predictedPlayerState.commandTime;
+	}
+	if ( cg.snap ) {
+		return cg.snap->serverTime;
+	}
+	return cg.time;
+}
+
+static int CG_PredictHitAttackTime( void ) {
+	if ( CG_DemoHistory_DemoDelagActive() ) {
+		return CG_DemoAttackTime();
+	}
+	return CG_LiveAttackTime();
+}
+
+static void CG_DecodePlayerSolid( int solid, vec3_t mins, vec3_t maxs ) {
+	int x, zd, zu;
+
+	x = ( solid & 255 );
+	zd = ( ( solid >> 8 ) & 255 );
+	zu = ( ( solid >> 16 ) & 255 ) - 32;
+	mins[0] = mins[1] = -x;
+	maxs[0] = maxs[1] = x;
+	mins[2] = -zd;
+	maxs[2] = zu;
+}
+
+static int CG_EncodePlayerSolid( const vec3_t mins, const vec3_t maxs ) {
+	int i, j, k;
+
+	i = maxs[0];
+	if ( i < 1 ) {
+		i = 1;
+	}
+	if ( i > 255 ) {
+		i = 255;
+	}
+
+	j = ( -mins[2] );
+	if ( j < 1 ) {
+		j = 1;
+	}
+	if ( j > 255 ) {
+		j = 255;
+	}
+
+	k = ( maxs[2] + 32 );
+	if ( k < 1 ) {
+		k = 1;
+	}
+	if ( k > 255 ) {
+		k = 255;
+	}
+
+	return ( k << 16 ) | ( j << 8 ) | i;
+}
+
+static int CG_LerpEncodedPlayerSolid( int solidLo, int solidHi, float f ) {
+	vec3_t minsLo, maxsLo, minsHi, maxsHi, mins, maxs;
+
+	if ( solidLo == SOLID_BMODEL || solidHi == SOLID_BMODEL || solidLo == 0 ) {
+		return solidLo;
+	}
+	if ( solidHi == 0 ) {
+		return solidLo;
+	}
+
+	CG_DecodePlayerSolid( solidLo, minsLo, maxsLo );
+	CG_DecodePlayerSolid( solidHi, minsHi, maxsHi );
+	mins[0] = minsLo[0] + f * ( minsHi[0] - minsLo[0] );
+	mins[1] = minsLo[1] + f * ( minsHi[1] - minsLo[1] );
+	mins[2] = minsLo[2] + f * ( minsHi[2] - minsLo[2] );
+	maxs[0] = maxsLo[0] + f * ( maxsHi[0] - maxsLo[0] );
+	maxs[1] = maxsLo[1] + f * ( maxsHi[1] - maxsLo[1] );
+	maxs[2] = maxsLo[2] + f * ( maxsHi[2] - maxsLo[2] );
+	return CG_EncodePlayerSolid( mins, maxs );
+}
+
+static int CG_HitPredictSolidForCent( const centity_t *cent ) {
+	float f;
+
+	if ( !cent->interpolate || !cg.nextSnap || cent->nextState.solid == 0
+			|| cent->nextState.solid == SOLID_BMODEL
+			|| cent->currentState.solid == SOLID_BMODEL ) {
+		return cent->currentState.solid;
+	}
+
+	f = cg.frameInterpolation;
+	if ( f < 0.0f ) {
+		f = 0.0f;
+	} else if ( f > 1.0f ) {
+		f = 1.0f;
+	}
+	return CG_LerpEncodedPlayerSolid( cent->currentState.solid, cent->nextState.solid, f );
+}
+
+void CG_SaveHitPredictPoses( void ) {
+	int i;
+	centity_t *cent;
+
+	for ( i = 0; i < MAX_CLIENTS; i++ ) {
+		cent = &cg_entities[i];
+		cent->hitPredictValid = qfalse;
+		if ( i == cg.predictedPlayerState.clientNum ) {
+			continue;
+		}
+		if ( !cent->currentValid || cent->currentState.eType != ET_PLAYER ) {
+			continue;
+		}
+		if ( cent->currentState.eFlags & EF_DEAD ) {
+			continue;
+		}
+		if ( cent->currentState.solid == 0 || cent->currentState.solid == SOLID_BMODEL ) {
+			continue;
+		}
+
+		VectorCopy( cent->lerpOrigin, cent->hitPredictOrigin );
+		cent->hitPredictSolid = CG_HitPredictSolidForCent( cent );
+		cent->hitPredictValid = qtrue;
+	}
+}
+
+typedef struct {
+	centity_t	*cent;
+	vec3_t		savedLerp;
+	int		savedSolid;
+} predictHitRewindSave_t;
+
+static predictHitRewindSave_t	cg_predictHitRewindSaves[MAX_CLIENTS];
+static int			cg_predictHitRewindSaveCount;
+static qboolean			cg_predictHitRewindDemo;
+
+static void CG_BeginPredictHitRewind( int attackTime, int skipEntityNum ) {
+	int i;
+	centity_t *cent;
+
+	cg_predictHitRewindSaveCount = 0;
+	cg_predictHitRewindDemo = qfalse;
+
+	if ( CG_DemoHistory_DemoDelagActive() ) {
+		cg_predictHitRewindDemo = qtrue;
+		CG_DemoHistory_BeginHitscanRewind( attackTime, skipEntityNum );
+		return;
+	}
+
+	for ( i = 0; i < MAX_CLIENTS; i++ ) {
+		if ( i == skipEntityNum ) {
+			continue;
+		}
+		cent = &cg_entities[i];
+		if ( !cent->hitPredictValid || !cent->currentValid ) {
+			continue;
+		}
+		if ( cent->currentState.eType != ET_PLAYER ) {
+			continue;
+		}
+		if ( cg_predictHitRewindSaveCount >= MAX_CLIENTS ) {
+			break;
+		}
+		cg_predictHitRewindSaves[cg_predictHitRewindSaveCount].cent = cent;
+		VectorCopy( cent->lerpOrigin, cg_predictHitRewindSaves[cg_predictHitRewindSaveCount].savedLerp );
+		cg_predictHitRewindSaves[cg_predictHitRewindSaveCount].savedSolid = cent->currentState.solid;
+		cg_predictHitRewindSaveCount++;
+		VectorCopy( cent->hitPredictOrigin, cent->lerpOrigin );
+		cent->currentState.solid = cent->hitPredictSolid;
+	}
+}
+
+static void CG_EndPredictHitRewind( void ) {
+	int i;
+
+	if ( cg_predictHitRewindDemo ) {
+		CG_DemoHistory_EndHitscanRewind();
+		cg_predictHitRewindDemo = qfalse;
+		cg_predictHitRewindSaveCount = 0;
+		return;
+	}
+
+	for ( i = cg_predictHitRewindSaveCount - 1; i >= 0; i-- ) {
+		centity_t *cent = cg_predictHitRewindSaves[i].cent;
+
+		VectorCopy( cg_predictHitRewindSaves[i].savedLerp, cent->lerpOrigin );
+		cent->currentState.solid = cg_predictHitRewindSaves[i].savedSolid;
+	}
+	cg_predictHitRewindSaveCount = 0;
+}
+
+static int CG_PredictHitTracePlayer( const vec3_t start, const vec3_t mins, const vec3_t maxs,
+		const vec3_t end, int skipNum, int attackTime ) {
+	trace_t tr;
+
+	CG_BeginPredictHitRewind( attackTime, skipNum );
+	CG_Trace( &tr, start, mins, maxs, end, skipNum, MASK_SHOT );
+	CG_EndPredictHitRewind();
+
+	if ( tr.fraction < 1.0f && tr.entityNum < MAX_CLIENTS
+			&& !( tr.surfaceFlags & SURF_NOIMPACT )
+			&& CG_IsValidPredictedHitTarget( tr.entityNum ) ) {
+		return tr.entityNum;
+	}
+	return -1;
 }
 
 #define CG_PREDICTED_HIT_EXPIRE_EXTRA	150
@@ -526,7 +735,7 @@ void CG_RecoverMissile(centity_t *missile) {
 		// missile is still around at a time when we should have the
 		// confirmation from the server that it exploded. Prediction was
 		// wrong, recover the missile
-		pms->missileFlags &= ~(MF_EXPLODED | MF_DISAPPEARED | MF_HITPLAYER | MF_HITWALLMETAL | MF_HITWALL | MF_TRAILFINISHED);
+		pms->missileFlags &= ~(MF_EXPLODED | MF_DISAPPEARED | MF_HITPLAYER | MF_HITWALLMETAL | MF_HITWALL | MF_TRAILFINISHED | MF_HITBEEP);
 
 		CG_RemoveOldMissileExplosion(pms);
 
@@ -690,7 +899,6 @@ void CG_PredictedExplosion(trace_t *tr, int weapon, predictedMissile_t *predMiss
 				return;
 			}
 		}
-		CG_TryPredictedProjectileHitBeep( tr, weapon, predMissile, missileEnt, qtrue, tr->entityNum );
 		if (!cg_predictPlayerExplosions.integer) {
 			CG_UpdateMissileStatus( pms, MF_EXPLODED | MF_HITPLAYER, tr->endpos, tr->entityNum );
 			return;
@@ -705,15 +913,66 @@ void CG_PredictedExplosion(trace_t *tr, int weapon, predictedMissile_t *predMiss
 	} else if (tr->surfaceFlags & SURF_METALSTEPS) {
 		CG_MissileHitWall(weapon, 0, tr->endpos, tr->plane.normal, IMPACTSOUND_METAL, pms);
 		CG_UpdateMissileStatus(pms, MF_EXPLODED | MF_HITWALLMETAL, tr->endpos, tr->entityNum);
-		CG_TryPredictedProjectileHitBeep( tr, weapon, predMissile, missileEnt, qfalse, -1 );
 	} else {
 		CG_MissileHitWall(weapon, 0, tr->endpos, tr->plane.normal, IMPACTSOUND_DEFAULT, pms);
 		CG_UpdateMissileStatus(pms, MF_EXPLODED | MF_HITWALL, tr->endpos, tr->entityNum);
-		CG_TryPredictedProjectileHitBeep( tr, weapon, predMissile, missileEnt, qfalse, -1 );
 	}
 }
 
 
+
+static void CG_CheckPredictedMissileHitBeep( predictedMissile_t *pm ) {
+	vec3_t beepStart, beepEnd;
+	trace_t beepTr;
+	int startTime, endTime;
+
+	if ( pm->status.missileFlags & MF_HITBEEP ) {
+		return;
+	}
+	if ( !CG_ShouldPredictProjectileHitSound( pm->weapon ) ) {
+		return;
+	}
+	if ( !CG_ShouldPredictExplosion() ) {
+		return;
+	}
+
+	startTime = cg.oldTime;
+	if ( startTime < pm->pos.trTime ) {
+		startTime = pm->pos.trTime;
+	}
+	endTime = cg.time;
+	if ( endTime < pm->pos.trTime ) {
+		endTime = pm->pos.trTime;
+	}
+
+	BG_EvaluateTrajectory( &pm->pos, startTime, beepStart );
+	BG_EvaluateTrajectory( &pm->pos, endTime, beepEnd );
+
+	if ( DistanceSquared( beepStart, beepEnd ) < 1.0f ) {
+		return;
+	}
+
+	if ( CG_MissileTouchedPortal( beepStart, beepEnd ) ) {
+		pm->status.missileFlags |= MF_HITBEEP;
+		return;
+	}
+
+	CG_Trace( &beepTr, beepStart, NULL, NULL, beepEnd, cg.snap->ps.clientNum, MASK_SHOT );
+	if ( beepTr.fraction == 1.0f ) {
+		return;
+	}
+	if ( beepTr.surfaceFlags & SURF_NOIMPACT ) {
+		pm->status.missileFlags |= MF_HITBEEP;
+		return;
+	}
+
+	pm->status.missileFlags |= MF_HITBEEP;
+	if ( beepTr.entityNum < MAX_CLIENTS ) {
+		CG_TryPredictedProjectileHitBeep( &beepTr, pm->weapon, pm, NULL, qtrue, beepTr.entityNum );
+	} else {
+		CG_TryPredictedProjectileHitBeep( &beepTr, pm->weapon, pm, NULL, qfalse, -1 );
+	}
+}
 
 void CG_RunPredictedMissile( predictedMissile_t *pm) {
 	vec3_t	newOrigin;
@@ -731,6 +990,8 @@ void CG_RunPredictedMissile( predictedMissile_t *pm) {
 		// this missile exploded / disappeared
 		return;
 	}
+
+	CG_CheckPredictedMissileHitBeep( pm );
 
 	timeshift = 1000 / sv_fps.integer;
 	time = cg.time + timeshift;
@@ -846,7 +1107,7 @@ void CG_PredictWeaponEffects( centity_t *cent ) {
 
 			VectorMA( muzzlePoint, 32, forward, endPoint );
 			demoRewind = CG_DemoHistory_DemoDelagActive();
-			attackTime = CG_DemoAttackTime();
+			attackTime = CG_PredictHitAttackTime();
 			if ( demoRewind ) {
 				CG_DemoHistory_BeginHitscanRewind( attackTime, cg.predictedPlayerState.clientNum );
 			}
@@ -856,7 +1117,15 @@ void CG_PredictWeaponEffects( centity_t *cent ) {
 			}
 			if ( trace.fraction < 1.0f && trace.entityNum < MAX_CLIENTS && !( trace.surfaceFlags & SURF_NOIMPACT ) ) {
 				CG_MissileHitPlayer( WP_GAUNTLET, trace.endpos, trace.plane.normal, trace.entityNum, NULL );
-				CG_PredictWeaponEffects_PlayerHit( trace.entityNum, WP_GAUNTLET, attackTime );
+			}
+			if ( CG_ShouldPredictHitSound( WP_GAUNTLET ) ) {
+				int gauntVictim;
+
+				gauntVictim = CG_PredictHitTracePlayer( muzzlePoint, NULL, NULL, endPoint,
+					cg.predictedPlayerState.clientNum, attackTime );
+				if ( gauntVictim >= 0 ) {
+					CG_PredictWeaponEffects_PlayerHit( gauntVictim, WP_GAUNTLET, attackTime );
+				}
 			}
 		}
 	}
@@ -927,15 +1196,25 @@ void CG_PredictWeaponEffects( centity_t *cent ) {
 				}
 			}*/
 
-			// find the rail's end point
+			// find the rail's end point (visual trail; CONTENTS_SOLID ignores players)
 			demoRewind = CG_DemoHistory_DemoDelagActive();
-			attackTime = CG_DemoAttackTime();
+			attackTime = CG_PredictHitAttackTime();
 			if ( demoRewind ) {
 				CG_DemoHistory_BeginHitscanRewind( attackTime, cg.predictedPlayerState.clientNum );
 			}
 			CG_Trace( &trace, muzzlePoint, vec3_origin, vec3_origin, endPoint, cg.predictedPlayerState.clientNum, demoRewind ? MASK_SHOT : CONTENTS_SOLID );
 			if ( demoRewind ) {
 				CG_DemoHistory_EndHitscanRewind();
+			}
+
+			if ( CG_ShouldPredictHitSound( WP_RAILGUN ) ) {
+				int railVictim;
+
+				railVictim = CG_PredictHitTracePlayer( muzzlePoint, vec3_origin, vec3_origin, endPoint,
+					cg.predictedPlayerState.clientNum, attackTime );
+				if ( railVictim >= 0 ) {
+					CG_PredictWeaponEffects_PlayerHit( railVictim, WP_RAILGUN, attackTime );
+				}
 			}
 
 			// do the magic-number adjustment
@@ -958,23 +1237,6 @@ void CG_PredictWeaponEffects( centity_t *cent ) {
 				// predict an explosion
 				CG_MissileHitWall( ent->weapon, cg.predictedPlayerState.clientNum, trace.endpos, trace.plane.normal, IMPACTSOUND_DEFAULT, NULL );
 			}
-
-			{
-				trace_t hitTrace;
-
-				if ( demoRewind ) {
-					CG_DemoHistory_BeginHitscanRewind( attackTime, cg.predictedPlayerState.clientNum );
-				}
-				CG_Trace( &hitTrace, muzzlePoint, vec3_origin, vec3_origin, endPoint,
-					cg.predictedPlayerState.clientNum, MASK_SHOT );
-				if ( demoRewind ) {
-					CG_DemoHistory_EndHitscanRewind();
-				}
-				if ( hitTrace.fraction < 1.0f && hitTrace.entityNum < MAX_CLIENTS
-						&& !( hitTrace.surfaceFlags & SURF_NOIMPACT ) ) {
-					CG_PredictWeaponEffects_PlayerHit( hitTrace.entityNum, WP_RAILGUN, attackTime );
-				}
-			}
 		}
 	}
 	else if ( ent->weapon == WP_LIGHTNING ) {
@@ -987,7 +1249,7 @@ void CG_PredictWeaponEffects( centity_t *cent ) {
 
 			VectorMA( muzzlePoint, LIGHTNING_RANGE, forward, endPoint );
 			demoRewind = CG_DemoHistory_DemoDelagActive();
-			attackTime = CG_DemoAttackTime();
+			attackTime = CG_PredictHitAttackTime();
 			if ( demoRewind ) {
 				CG_DemoHistory_BeginHitscanRewind( attackTime, cg.predictedPlayerState.clientNum );
 			}
@@ -998,9 +1260,17 @@ void CG_PredictWeaponEffects( centity_t *cent ) {
 			if (trace.fraction < 1.0) {
 				if (trace.entityNum < MAX_CLIENTS) {
 					CG_MissileHitPlayer(WP_LIGHTNING, trace.endpos, trace.plane.normal, trace.entityNum, NULL);
-					CG_PredictWeaponEffects_PlayerHit( trace.entityNum, WP_LIGHTNING, attackTime );
 				} else if (!(trace.surfaceFlags & SURF_NOIMPACT)) {
 					CG_MissileHitWall(WP_LIGHTNING, 0, trace.endpos, trace.plane.normal, IMPACTSOUND_DEFAULT, NULL);
+				}
+			}
+			if ( CG_ShouldPredictHitSound( WP_LIGHTNING ) ) {
+				int lgVictim;
+
+				lgVictim = CG_PredictHitTracePlayer( muzzlePoint, vec3_origin, vec3_origin, endPoint,
+					cg.predictedPlayerState.clientNum, attackTime );
+				if ( lgVictim >= 0 ) {
+					CG_PredictWeaponEffects_PlayerHit( lgVictim, WP_LIGHTNING, attackTime );
 				}
 			}
 		}
@@ -1040,22 +1310,24 @@ void CG_PredictWeaponEffects( centity_t *cent ) {
 
 			// do the shotgun pellets
 			demoRewind = CG_DemoHistory_DemoDelagActive();
-			attackTime = CG_DemoAttackTime();
-			seed = demoRewind ? ( attackTime % 256 ) : ( cg.oldTime % 256 );
+			attackTime = CG_PredictHitAttackTime();
+			seed = attackTime % 256;
 			if ( demoRewind ) {
 				CG_DemoHistory_BeginHitscanRewind( attackTime, cg.predictedPlayerState.clientNum );
 			}
-			{
+			CG_ShotgunPattern( muzzlePoint, endPoint, seed, cg.predictedPlayerState.clientNum );
+			if ( demoRewind ) {
+				CG_DemoHistory_EndHitscanRewind();
+			}
+			if ( CG_ShouldPredictHitSound( WP_SHOTGUN ) ) {
 				int shotgunVictim;
 
-				CG_ShotgunPattern( muzzlePoint, endPoint, seed, cg.predictedPlayerState.clientNum );
+				CG_BeginPredictHitRewind( attackTime, cg.predictedPlayerState.clientNum );
 				shotgunVictim = CG_ShotgunPattern_PlayerHit( muzzlePoint, endPoint, seed, cg.predictedPlayerState.clientNum );
+				CG_EndPredictHitRewind();
 				if ( shotgunVictim >= 0 ) {
 					CG_PredictWeaponEffects_PlayerHit( shotgunVictim, WP_SHOTGUN, attackTime );
 				}
-			}
-			if ( demoRewind ) {
-				CG_DemoHistory_EndHitscanRewind();
 			}
 			//Com_Printf( "Predicted shotgun pattern\n" );
 		}
@@ -1077,8 +1349,8 @@ void CG_PredictWeaponEffects( centity_t *cent ) {
 			// do everything exactly like the server does
 
 			demoRewind = CG_DemoHistory_DemoDelagActive();
-			attackTime = CG_DemoAttackTime();
-			seed = demoRewind ? ( attackTime % 256 ) : ( cg.oldTime % 256 );
+			attackTime = CG_PredictHitAttackTime();
+			seed = attackTime % 256;
 			r = Q_random(&seed) * M_PI * 2.0f;
 			u = sin(r) * Q_crandom(&seed) * MACHINEGUN_SPREAD * 16;
 			r = cos(r) * Q_crandom(&seed) * MACHINEGUN_SPREAD * 16;
@@ -1112,8 +1384,14 @@ void CG_PredictWeaponEffects( centity_t *cent ) {
 
 			// do the bullet impact
 			CG_Bullet( tr.endpos, cg.predictedPlayerState.clientNum, tr.plane.normal, flesh, fleshEntityNum );
-			if ( flesh ) {
-				CG_PredictWeaponEffects_PlayerHit( fleshEntityNum, WP_MACHINEGUN, attackTime );
+			if ( CG_ShouldPredictHitSound( WP_MACHINEGUN ) ) {
+				int mgVictim;
+
+				mgVictim = CG_PredictHitTracePlayer( muzzlePoint, NULL, NULL, endPoint,
+					cg.predictedPlayerState.clientNum, attackTime );
+				if ( mgVictim >= 0 ) {
+					CG_PredictWeaponEffects_PlayerHit( mgVictim, WP_MACHINEGUN, attackTime );
+				}
 			}
 			//Com_Printf( "Predicted bullet\n" );
 		}
@@ -1136,8 +1414,8 @@ void CG_PredictWeaponEffects( centity_t *cent ) {
 			// do everything exactly like the server does
 
 			demoRewind = CG_DemoHistory_DemoDelagActive();
-			attackTime = CG_DemoAttackTime();
-			seed = demoRewind ? ( attackTime % 256 ) : ( cg.oldTime % 256 );
+			attackTime = CG_PredictHitAttackTime();
+			seed = attackTime % 256;
 			r = Q_random(&seed) * M_PI * 2.0f;
 			u = sin(r) * Q_crandom(&seed) * CHAINGUN_SPREAD * 16;
 			r = cos(r) * Q_crandom(&seed) * CHAINGUN_SPREAD * 16;
@@ -1171,8 +1449,14 @@ void CG_PredictWeaponEffects( centity_t *cent ) {
 
 			// do the bullet impact
 			CG_Bullet( tr.endpos, cg.predictedPlayerState.clientNum, tr.plane.normal, flesh, fleshEntityNum );
-			if ( flesh ) {
-				CG_PredictWeaponEffects_PlayerHit( fleshEntityNum, WP_CHAINGUN, attackTime );
+			if ( CG_ShouldPredictHitSound( WP_CHAINGUN ) ) {
+				int cgVictim;
+
+				cgVictim = CG_PredictHitTracePlayer( muzzlePoint, NULL, NULL, endPoint,
+					cg.predictedPlayerState.clientNum, attackTime );
+				if ( cgVictim >= 0 ) {
+					CG_PredictWeaponEffects_PlayerHit( cgVictim, WP_CHAINGUN, attackTime );
+				}
 			}
 			//Com_Printf( "Predicted bullet\n" );
 		}

--- a/ratoa_gamecode/code/cgame/cg_weapons.c
+++ b/ratoa_gamecode/code/cgame/cg_weapons.c
@@ -4624,16 +4624,10 @@ void CG_MissileHitWall( int weapon, int clientNum, vec3_t origin, vec3_t dir, im
 	}
 
 	if ( sfx ) {
-		int sndEnt = ENTITYNUM_WORLD;
-
-		if ( ( weapon == WP_ROCKET_LAUNCHER || weapon == WP_PLASMAGUN
-				|| weapon == WP_GRENADE_LAUNCHER || weapon == WP_BFG )
-				&& clientNum >= 0 && clientNum < MAX_CLIENTS ) {
-			sndEnt = clientNum;
-		}
-		trap_S_StartSound( origin, sndEnt, CHAN_AUTO, sfx );
+		// Q3e plays listener-entity sounds at full volume and ignores origin.
+		trap_S_StartSound( origin, ENTITYNUM_WORLD, CHAN_AUTO, sfx );
 		if ( sfx == cgs.media.sfx_rockexp ) {
-			CG_VisualSounds_NoteExplosion( origin, sndEnt, weapon );
+			CG_VisualSounds_NoteExplosion( origin, ENTITYNUM_WORLD, weapon );
 		}
 	}
 

--- a/ratoa_gamecode/code/tools/lcc/lburg/gram.c
+++ b/ratoa_gamecode/code/tools/lcc/lburg/gram.c
@@ -1,8 +1,9 @@
-/* A Bison parser, made by GNU Bison 3.0.2.  */
+/* A Bison parser, made by GNU Bison 3.8.2.  */
 
 /* Bison implementation for Yacc-like parsers in C
 
-   Copyright (C) 1984, 1989-1990, 2000-2013 Free Software Foundation, Inc.
+   Copyright (C) 1984, 1989-1990, 2000-2015, 2018-2021 Free Software Foundation,
+   Inc.
 
    This program is free software: you can redistribute it and/or modify
    it under the terms of the GNU General Public License as published by
@@ -15,7 +16,7 @@
    GNU General Public License for more details.
 
    You should have received a copy of the GNU General Public License
-   along with this program.  If not, see <http://www.gnu.org/licenses/>.  */
+   along with this program.  If not, see <https://www.gnu.org/licenses/>.  */
 
 /* As a special exception, you may create a larger work that contains
    part or all of the Bison parser skeleton and distribute that work
@@ -33,6 +34,10 @@
 /* C LALR(1) parser skeleton written by Richard Stallman, by
    simplifying the original so-called "semantic" parser.  */
 
+/* DO NOT RELY ON FEATURES THAT ARE NOT DOCUMENTED in the manual,
+   especially those whose name start with YY_ or yy_.  They are
+   private implementation details that can be changed or removed.  */
+
 /* All symbols defined below should begin with yy or YY, to avoid
    infringing on user name space.  This should be done even for local
    variables, as they might otherwise be expanded by user macros.
@@ -40,11 +45,11 @@
    define necessary library symbols; they are noted "INFRINGES ON
    USER NAME SPACE" below.  */
 
-/* Identify Bison output.  */
-#define YYBISON 1
+/* Identify Bison output, and Bison version.  */
+#define YYBISON 30802
 
-/* Bison version.  */
-#define YYBISON_VERSION "3.0.2"
+/* Bison version string.  */
+#define YYBISON_VERSION "3.8.2"
 
 /* Skeleton name.  */
 #define YYSKELETON_NAME "yacc.c"
@@ -61,32 +66,39 @@
 
 
 
-/* Copy the first part of user declarations.  */
-#line 1 "code/tools/lcc/lburg/gram.y" /* yacc.c:339  */
+/* First part of user prologue.  */
+#line 1 "code/tools/lcc/lburg/gram.y"
 
 #include <stdio.h>
 #include "lburg.h"
 //static char rcsid[] = "$Id: gram.y 145 2001-10-17 21:53:10Z timo $";
 /*lint -e616 -e527 -e652 -esym(552,yynerrs) -esym(563,yynewstate,yyerrlab) */
 static int yylineno = 0;
+/* Forward declaration to avoid implicit declaration warnings in generated parser */
+int yylex(void);
 
-#line 74 "y.tab.c" /* yacc.c:339  */
+#line 81 "y.tab.c"
 
-# ifndef YY_NULLPTR
-#  if defined __cplusplus && 201103L <= __cplusplus
-#   define YY_NULLPTR nullptr
+# ifndef YY_CAST
+#  ifdef __cplusplus
+#   define YY_CAST(Type, Val) static_cast<Type> (Val)
+#   define YY_REINTERPRET_CAST(Type, Val) reinterpret_cast<Type> (Val)
 #  else
-#   define YY_NULLPTR 0
+#   define YY_CAST(Type, Val) ((Type) (Val))
+#   define YY_REINTERPRET_CAST(Type, Val) ((Type) (Val))
 #  endif
 # endif
-
-/* Enabling verbose error messages.  */
-#ifdef YYERROR_VERBOSE
-# undef YYERROR_VERBOSE
-# define YYERROR_VERBOSE 1
-#else
-# define YYERROR_VERBOSE 0
-#endif
+# ifndef YY_NULLPTR
+#  if defined __cplusplus
+#   if 201103L <= __cplusplus
+#    define YY_NULLPTR nullptr
+#   else
+#    define YY_NULLPTR 0
+#   endif
+#  else
+#   define YY_NULLPTR ((void*)0)
+#  endif
+# endif
 
 
 /* Debug traces.  */
@@ -97,21 +109,30 @@ static int yylineno = 0;
 extern int yydebug;
 #endif
 
-/* Token type.  */
+/* Token kinds.  */
 #ifndef YYTOKENTYPE
 # define YYTOKENTYPE
   enum yytokentype
   {
-    TERMINAL = 258,
-    START = 259,
-    PPERCENT = 260,
-    ID = 261,
-    TEMPLATE = 262,
-    CODE = 263,
-    INT = 264
+    YYEMPTY = -2,
+    YYEOF = 0,                     /* "end of file"  */
+    YYerror = 256,                 /* error  */
+    YYUNDEF = 257,                 /* "invalid token"  */
+    TERMINAL = 258,                /* TERMINAL  */
+    START = 259,                   /* START  */
+    PPERCENT = 260,                /* PPERCENT  */
+    ID = 261,                      /* ID  */
+    TEMPLATE = 262,                /* TEMPLATE  */
+    CODE = 263,                    /* CODE  */
+    INT = 264                      /* INT  */
   };
+  typedef enum yytokentype yytoken_kind_t;
 #endif
-/* Tokens.  */
+/* Token kinds.  */
+#define YYEMPTY -2
+#define YYEOF 0
+#define YYerror 256
+#define YYUNDEF 257
 #define TERMINAL 258
 #define START 259
 #define PPERCENT 260
@@ -122,17 +143,18 @@ extern int yydebug;
 
 /* Value type.  */
 #if ! defined YYSTYPE && ! defined YYSTYPE_IS_DECLARED
-typedef union YYSTYPE YYSTYPE;
 union YYSTYPE
 {
-#line 8 "code/tools/lcc/lburg/gram.y" /* yacc.c:355  */
+#line 10 "code/tools/lcc/lburg/gram.y"
 
 	int n;
 	char *string;
 	Tree tree;
 
-#line 135 "y.tab.c" /* yacc.c:355  */
+#line 155 "y.tab.c"
+
 };
+typedef union YYSTYPE YYSTYPE;
 # define YYSTYPE_IS_TRIVIAL 1
 # define YYSTYPE_IS_DECLARED 1
 #endif
@@ -140,41 +162,131 @@ union YYSTYPE
 
 extern YYSTYPE yylval;
 
+
 int yyparse (void);
-int yylex(void);
 
 
 
-/* Copy the second part of user declarations.  */
+/* Symbol kind.  */
+enum yysymbol_kind_t
+{
+  YYSYMBOL_YYEMPTY = -2,
+  YYSYMBOL_YYEOF = 0,                      /* "end of file"  */
+  YYSYMBOL_YYerror = 1,                    /* error  */
+  YYSYMBOL_YYUNDEF = 2,                    /* "invalid token"  */
+  YYSYMBOL_TERMINAL = 3,                   /* TERMINAL  */
+  YYSYMBOL_START = 4,                      /* START  */
+  YYSYMBOL_PPERCENT = 5,                   /* PPERCENT  */
+  YYSYMBOL_ID = 6,                         /* ID  */
+  YYSYMBOL_TEMPLATE = 7,                   /* TEMPLATE  */
+  YYSYMBOL_CODE = 8,                       /* CODE  */
+  YYSYMBOL_INT = 9,                        /* INT  */
+  YYSYMBOL_10_n_ = 10,                     /* '\n'  */
+  YYSYMBOL_11_ = 11,                       /* '='  */
+  YYSYMBOL_12_ = 12,                       /* ':'  */
+  YYSYMBOL_13_ = 13,                       /* '('  */
+  YYSYMBOL_14_ = 14,                       /* ')'  */
+  YYSYMBOL_15_ = 15,                       /* ','  */
+  YYSYMBOL_YYACCEPT = 16,                  /* $accept  */
+  YYSYMBOL_spec = 17,                      /* spec  */
+  YYSYMBOL_decls = 18,                     /* decls  */
+  YYSYMBOL_decl = 19,                      /* decl  */
+  YYSYMBOL_blist = 20,                     /* blist  */
+  YYSYMBOL_rules = 21,                     /* rules  */
+  YYSYMBOL_nonterm = 22,                   /* nonterm  */
+  YYSYMBOL_tree = 23,                      /* tree  */
+  YYSYMBOL_cost = 24                       /* cost  */
+};
+typedef enum yysymbol_kind_t yysymbol_kind_t;
 
-#line 150 "y.tab.c" /* yacc.c:358  */
+
+
 
 #ifdef short
 # undef short
 #endif
 
-#ifdef YYTYPE_UINT8
-typedef YYTYPE_UINT8 yytype_uint8;
-#else
-typedef unsigned char yytype_uint8;
+/* On compilers that do not define __PTRDIFF_MAX__ etc., make sure
+   <limits.h> and (if available) <stdint.h> are included
+   so that the code can choose integer types of a good width.  */
+
+#ifndef __PTRDIFF_MAX__
+# include <limits.h> /* INFRINGES ON USER NAME SPACE */
+# if defined __STDC_VERSION__ && 199901 <= __STDC_VERSION__
+#  include <stdint.h> /* INFRINGES ON USER NAME SPACE */
+#  define YY_STDINT_H
+# endif
 #endif
 
-#ifdef YYTYPE_INT8
-typedef YYTYPE_INT8 yytype_int8;
+/* Narrow types that promote to a signed type and that can represent a
+   signed or unsigned integer of at least N bits.  In tables they can
+   save space and decrease cache pressure.  Promoting to a signed type
+   helps avoid bugs in integer arithmetic.  */
+
+#ifdef __INT_LEAST8_MAX__
+typedef __INT_LEAST8_TYPE__ yytype_int8;
+#elif defined YY_STDINT_H
+typedef int_least8_t yytype_int8;
 #else
 typedef signed char yytype_int8;
 #endif
 
-#ifdef YYTYPE_UINT16
-typedef YYTYPE_UINT16 yytype_uint16;
+#ifdef __INT_LEAST16_MAX__
+typedef __INT_LEAST16_TYPE__ yytype_int16;
+#elif defined YY_STDINT_H
+typedef int_least16_t yytype_int16;
 #else
-typedef unsigned short int yytype_uint16;
+typedef short yytype_int16;
 #endif
 
-#ifdef YYTYPE_INT16
-typedef YYTYPE_INT16 yytype_int16;
+/* Work around bug in HP-UX 11.23, which defines these macros
+   incorrectly for preprocessor constants.  This workaround can likely
+   be removed in 2023, as HPE has promised support for HP-UX 11.23
+   (aka HP-UX 11i v2) only through the end of 2022; see Table 2 of
+   <https://h20195.www2.hpe.com/V2/getpdf.aspx/4AA4-7673ENW.pdf>.  */
+#ifdef __hpux
+# undef UINT_LEAST8_MAX
+# undef UINT_LEAST16_MAX
+# define UINT_LEAST8_MAX 255
+# define UINT_LEAST16_MAX 65535
+#endif
+
+#if defined __UINT_LEAST8_MAX__ && __UINT_LEAST8_MAX__ <= __INT_MAX__
+typedef __UINT_LEAST8_TYPE__ yytype_uint8;
+#elif (!defined __UINT_LEAST8_MAX__ && defined YY_STDINT_H \
+       && UINT_LEAST8_MAX <= INT_MAX)
+typedef uint_least8_t yytype_uint8;
+#elif !defined __UINT_LEAST8_MAX__ && UCHAR_MAX <= INT_MAX
+typedef unsigned char yytype_uint8;
 #else
-typedef short int yytype_int16;
+typedef short yytype_uint8;
+#endif
+
+#if defined __UINT_LEAST16_MAX__ && __UINT_LEAST16_MAX__ <= __INT_MAX__
+typedef __UINT_LEAST16_TYPE__ yytype_uint16;
+#elif (!defined __UINT_LEAST16_MAX__ && defined YY_STDINT_H \
+       && UINT_LEAST16_MAX <= INT_MAX)
+typedef uint_least16_t yytype_uint16;
+#elif !defined __UINT_LEAST16_MAX__ && USHRT_MAX <= INT_MAX
+typedef unsigned short yytype_uint16;
+#else
+typedef int yytype_uint16;
+#endif
+
+#ifndef YYPTRDIFF_T
+# if defined __PTRDIFF_TYPE__ && defined __PTRDIFF_MAX__
+#  define YYPTRDIFF_T __PTRDIFF_TYPE__
+#  define YYPTRDIFF_MAXIMUM __PTRDIFF_MAX__
+# elif defined PTRDIFF_MAX
+#  ifndef ptrdiff_t
+#   include <stddef.h> /* INFRINGES ON USER NAME SPACE */
+#  endif
+#  define YYPTRDIFF_T ptrdiff_t
+#  define YYPTRDIFF_MAXIMUM PTRDIFF_MAX
+# else
+#  define YYPTRDIFF_T long
+#  define YYPTRDIFF_MAXIMUM LONG_MAX
+# endif
 #endif
 
 #ifndef YYSIZE_T
@@ -182,15 +294,28 @@ typedef short int yytype_int16;
 #  define YYSIZE_T __SIZE_TYPE__
 # elif defined size_t
 #  define YYSIZE_T size_t
-# elif ! defined YYSIZE_T
+# elif defined __STDC_VERSION__ && 199901 <= __STDC_VERSION__
 #  include <stddef.h> /* INFRINGES ON USER NAME SPACE */
 #  define YYSIZE_T size_t
 # else
-#  define YYSIZE_T unsigned int
+#  define YYSIZE_T unsigned
 # endif
 #endif
 
-#define YYSIZE_MAXIMUM ((YYSIZE_T) -1)
+#define YYSIZE_MAXIMUM                                  \
+  YY_CAST (YYPTRDIFF_T,                                 \
+           (YYPTRDIFF_MAXIMUM < YY_CAST (YYSIZE_T, -1)  \
+            ? YYPTRDIFF_MAXIMUM                         \
+            : YY_CAST (YYSIZE_T, -1)))
+
+#define YYSIZEOF(X) YY_CAST (YYPTRDIFF_T, sizeof (X))
+
+
+/* Stored state numbers (used for stacks). */
+typedef yytype_int8 yy_state_t;
+
+/* State numbers in computations.  */
+typedef int yy_state_fast_t;
 
 #ifndef YY_
 # if defined YYENABLE_NLS && YYENABLE_NLS
@@ -204,47 +329,43 @@ typedef short int yytype_int16;
 # endif
 #endif
 
-#ifndef YY_ATTRIBUTE
-# if (defined __GNUC__                                               \
-      && (2 < __GNUC__ || (__GNUC__ == 2 && 96 <= __GNUC_MINOR__)))  \
-     || defined __SUNPRO_C && 0x5110 <= __SUNPRO_C
-#  define YY_ATTRIBUTE(Spec) __attribute__(Spec)
+
+#ifndef YY_ATTRIBUTE_PURE
+# if defined __GNUC__ && 2 < __GNUC__ + (96 <= __GNUC_MINOR__)
+#  define YY_ATTRIBUTE_PURE __attribute__ ((__pure__))
 # else
-#  define YY_ATTRIBUTE(Spec) /* empty */
+#  define YY_ATTRIBUTE_PURE
 # endif
 #endif
 
-#ifndef YY_ATTRIBUTE_PURE
-# define YY_ATTRIBUTE_PURE   YY_ATTRIBUTE ((__pure__))
-#endif
-
 #ifndef YY_ATTRIBUTE_UNUSED
-# define YY_ATTRIBUTE_UNUSED YY_ATTRIBUTE ((__unused__))
-#endif
-
-#if !defined _Noreturn \
-     && (!defined __STDC_VERSION__ || __STDC_VERSION__ < 201112)
-# if defined _MSC_VER && 1200 <= _MSC_VER
-#  define _Noreturn __declspec (noreturn)
+# if defined __GNUC__ && 2 < __GNUC__ + (7 <= __GNUC_MINOR__)
+#  define YY_ATTRIBUTE_UNUSED __attribute__ ((__unused__))
 # else
-#  define _Noreturn YY_ATTRIBUTE ((__noreturn__))
+#  define YY_ATTRIBUTE_UNUSED
 # endif
 #endif
 
 /* Suppress unused-variable warnings by "using" E.  */
 #if ! defined lint || defined __GNUC__
-# define YYUSE(E) ((void) (E))
+# define YY_USE(E) ((void) (E))
 #else
-# define YYUSE(E) /* empty */
+# define YY_USE(E) /* empty */
 #endif
 
-#if defined __GNUC__ && 407 <= __GNUC__ * 100 + __GNUC_MINOR__
 /* Suppress an incorrect diagnostic about yylval being uninitialized.  */
-# define YY_IGNORE_MAYBE_UNINITIALIZED_BEGIN \
-    _Pragma ("GCC diagnostic push") \
-    _Pragma ("GCC diagnostic ignored \"-Wuninitialized\"")\
+#if defined __GNUC__ && ! defined __ICC && 406 <= __GNUC__ * 100 + __GNUC_MINOR__
+# if __GNUC__ * 100 + __GNUC_MINOR__ < 407
+#  define YY_IGNORE_MAYBE_UNINITIALIZED_BEGIN                           \
+    _Pragma ("GCC diagnostic push")                                     \
+    _Pragma ("GCC diagnostic ignored \"-Wuninitialized\"")
+# else
+#  define YY_IGNORE_MAYBE_UNINITIALIZED_BEGIN                           \
+    _Pragma ("GCC diagnostic push")                                     \
+    _Pragma ("GCC diagnostic ignored \"-Wuninitialized\"")              \
     _Pragma ("GCC diagnostic ignored \"-Wmaybe-uninitialized\"")
-# define YY_IGNORE_MAYBE_UNINITIALIZED_END \
+# endif
+# define YY_IGNORE_MAYBE_UNINITIALIZED_END      \
     _Pragma ("GCC diagnostic pop")
 #else
 # define YY_INITIAL_VALUE(Value) Value
@@ -257,8 +378,22 @@ typedef short int yytype_int16;
 # define YY_INITIAL_VALUE(Value) /* Nothing. */
 #endif
 
+#if defined __cplusplus && defined __GNUC__ && ! defined __ICC && 6 <= __GNUC__
+# define YY_IGNORE_USELESS_CAST_BEGIN                          \
+    _Pragma ("GCC diagnostic push")                            \
+    _Pragma ("GCC diagnostic ignored \"-Wuseless-cast\"")
+# define YY_IGNORE_USELESS_CAST_END            \
+    _Pragma ("GCC diagnostic pop")
+#endif
+#ifndef YY_IGNORE_USELESS_CAST_BEGIN
+# define YY_IGNORE_USELESS_CAST_BEGIN
+# define YY_IGNORE_USELESS_CAST_END
+#endif
 
-#if ! defined yyoverflow || YYERROR_VERBOSE
+
+#define YY_ASSERT(E) ((void) (0 && (E)))
+
+#if !defined yyoverflow
 
 /* The parser invokes alloca or malloc; define the necessary symbols.  */
 
@@ -323,8 +458,7 @@ void free (void *); /* INFRINGES ON USER NAME SPACE */
 #   endif
 #  endif
 # endif
-#endif /* ! defined yyoverflow || YYERROR_VERBOSE */
-
+#endif /* !defined yyoverflow */
 
 #if (! defined yyoverflow \
      && (! defined __cplusplus \
@@ -333,17 +467,17 @@ void free (void *); /* INFRINGES ON USER NAME SPACE */
 /* A type that is properly aligned for any stack member.  */
 union yyalloc
 {
-  yytype_int16 yyss_alloc;
+  yy_state_t yyss_alloc;
   YYSTYPE yyvs_alloc;
 };
 
 /* The size of the maximum gap between one aligned stack and the next.  */
-# define YYSTACK_GAP_MAXIMUM (sizeof (union yyalloc) - 1)
+# define YYSTACK_GAP_MAXIMUM (YYSIZEOF (union yyalloc) - 1)
 
 /* The size of an array large to enough to hold all stacks, each with
    N elements.  */
 # define YYSTACK_BYTES(N) \
-     ((N) * (sizeof (yytype_int16) + sizeof (YYSTYPE)) \
+     ((N) * (YYSIZEOF (yy_state_t) + YYSIZEOF (YYSTYPE)) \
       + YYSTACK_GAP_MAXIMUM)
 
 # define YYCOPY_NEEDED 1
@@ -356,11 +490,11 @@ union yyalloc
 # define YYSTACK_RELOCATE(Stack_alloc, Stack)                           \
     do                                                                  \
       {                                                                 \
-        YYSIZE_T yynewbytes;                                            \
+        YYPTRDIFF_T yynewbytes;                                         \
         YYCOPY (&yyptr->Stack_alloc, Stack, yysize);                    \
         Stack = &yyptr->Stack_alloc;                                    \
-        yynewbytes = yystacksize * sizeof (*Stack) + YYSTACK_GAP_MAXIMUM; \
-        yyptr += yynewbytes / sizeof (*yyptr);                          \
+        yynewbytes = yystacksize * YYSIZEOF (*Stack) + YYSTACK_GAP_MAXIMUM; \
+        yyptr += yynewbytes / YYSIZEOF (*yyptr);                        \
       }                                                                 \
     while (0)
 
@@ -372,12 +506,12 @@ union yyalloc
 # ifndef YYCOPY
 #  if defined __GNUC__ && 1 < __GNUC__
 #   define YYCOPY(Dst, Src, Count) \
-      __builtin_memcpy (Dst, Src, (Count) * sizeof (*(Src)))
+      __builtin_memcpy (Dst, Src, YY_CAST (YYSIZE_T, (Count)) * sizeof (*(Src)))
 #  else
 #   define YYCOPY(Dst, Src, Count)              \
       do                                        \
         {                                       \
-          YYSIZE_T yyi;                         \
+          YYPTRDIFF_T yyi;                      \
           for (yyi = 0; yyi < (Count); yyi++)   \
             (Dst)[yyi] = (Src)[yyi];            \
         }                                       \
@@ -400,17 +534,20 @@ union yyalloc
 /* YYNSTATES -- Number of states.  */
 #define YYNSTATES  37
 
-/* YYTRANSLATE[YYX] -- Symbol number corresponding to YYX as returned
-   by yylex, with out-of-bounds checking.  */
-#define YYUNDEFTOK  2
+/* YYMAXUTOK -- Last valid token kind.  */
 #define YYMAXUTOK   264
 
-#define YYTRANSLATE(YYX)                                                \
-  ((unsigned int) (YYX) <= YYMAXUTOK ? yytranslate[YYX] : YYUNDEFTOK)
+
+/* YYTRANSLATE(TOKEN-NUM) -- Symbol number corresponding to TOKEN-NUM
+   as returned by yylex, with out-of-bounds checking.  */
+#define YYTRANSLATE(YYX)                                \
+  (0 <= (YYX) && (YYX) <= YYMAXUTOK                     \
+   ? YY_CAST (yysymbol_kind_t, yytranslate[YYX])        \
+   : YYSYMBOL_YYUNDEF)
 
 /* YYTRANSLATE[TOKEN-NUM] -- Symbol number corresponding to TOKEN-NUM
-   as returned by yylex, without out-of-bounds checking.  */
-static const yytype_uint8 yytranslate[] =
+   as returned by yylex.  */
+static const yytype_int8 yytranslate[] =
 {
        0,     2,     2,     2,     2,     2,     2,     2,     2,     2,
       10,     2,     2,     2,     2,     2,     2,     2,     2,     2,
@@ -442,49 +579,52 @@ static const yytype_uint8 yytranslate[] =
 };
 
 #if YYDEBUG
-  /* YYRLINE[YYN] -- Source line where rule number YYN was defined.  */
-static const yytype_uint8 yyrline[] =
+/* YYRLINE[YYN] -- Source line where rule number YYN was defined.  */
+static const yytype_int8 yyrline[] =
 {
-       0,    22,    22,    23,    26,    27,    30,    31,    35,    36,
-      39,    40,    43,    44,    45,    46,    49,    52,    53,    54,
-      57
+       0,    25,    25,    26,    29,    30,    33,    34,    38,    39,
+      42,    43,    46,    47,    48,    49,    52,    55,    56,    57,
+      60
 };
 #endif
 
-#if YYDEBUG || YYERROR_VERBOSE || 0
+/** Accessing symbol of state STATE.  */
+#define YY_ACCESSING_SYMBOL(State) YY_CAST (yysymbol_kind_t, yystos[State])
+
+#if YYDEBUG || 0
+/* The user-facing name of the symbol whose (internal) number is
+   YYSYMBOL.  No bounds checking.  */
+static const char *yysymbol_name (yysymbol_kind_t yysymbol) YY_ATTRIBUTE_UNUSED;
+
 /* YYTNAME[SYMBOL-NUM] -- String name of the symbol SYMBOL-NUM.
    First, the terminals, then, starting at YYNTOKENS, nonterminals.  */
 static const char *const yytname[] =
 {
-  "$end", "error", "$undefined", "TERMINAL", "START", "PPERCENT", "ID",
-  "TEMPLATE", "CODE", "INT", "'\\n'", "'='", "':'", "'('", "')'", "','",
-  "$accept", "spec", "decls", "decl", "blist", "rules", "nonterm", "tree",
-  "cost", YY_NULLPTR
+  "\"end of file\"", "error", "\"invalid token\"", "TERMINAL", "START",
+  "PPERCENT", "ID", "TEMPLATE", "CODE", "INT", "'\\n'", "'='", "':'",
+  "'('", "')'", "','", "$accept", "spec", "decls", "decl", "blist",
+  "rules", "nonterm", "tree", "cost", YY_NULLPTR
 };
+
+static const char *
+yysymbol_name (yysymbol_kind_t yysymbol)
+{
+  return yytname[yysymbol];
+}
 #endif
 
-# ifdef YYPRINT
-/* YYTOKNUM[NUM] -- (External) token number corresponding to the
-   (internal) symbol number NUM (which must be that of a token).  */
-static const yytype_uint16 yytoknum[] =
-{
-       0,   256,   257,   258,   259,   260,   261,   262,   263,   264,
-      10,    61,    58,    40,    41,    44
-};
-# endif
+#define YYPACT_NINF (-26)
 
-#define YYPACT_NINF -26
+#define yypact_value_is_default(Yyn) \
+  ((Yyn) == YYPACT_NINF)
 
-#define yypact_value_is_default(Yystate) \
-  (!!((Yystate) == (-26)))
+#define YYTABLE_NINF (-4)
 
-#define YYTABLE_NINF -4
-
-#define yytable_value_is_error(Yytable_value) \
+#define yytable_value_is_error(Yyn) \
   0
 
-  /* YYPACT[STATE-NUM] -- Index in YYTABLE of the portion describing
-     STATE-NUM.  */
+/* YYPACT[STATE-NUM] -- Index in YYTABLE of the portion describing
+   STATE-NUM.  */
 static const yytype_int8 yypact[] =
 {
      -26,    11,     0,   -26,     5,   -26,     8,   -26,   -26,   -26,
@@ -493,10 +633,10 @@ static const yytype_int8 yypact[] =
      -26,    20,   -26,    15,   -26,    19,   -26
 };
 
-  /* YYDEFACT[STATE-NUM] -- Default reduction number in state STATE-NUM.
-     Performed when YYTABLE does not specify something else to do.  Zero
-     means the default is an error.  */
-static const yytype_uint8 yydefact[] =
+/* YYDEFACT[STATE-NUM] -- Default reduction number in state STATE-NUM.
+   Performed when YYTABLE does not specify something else to do.  Zero
+   means the default is an error.  */
+static const yytype_int8 yydefact[] =
 {
        4,     0,     0,     1,     0,    10,     0,    12,     8,     5,
        9,     0,    16,     0,     0,     0,     6,     7,     0,    14,
@@ -504,21 +644,21 @@ static const yytype_uint8 yydefact[] =
       20,     0,    18,     0,    13,     0,    19
 };
 
-  /* YYPGOTO[NTERM-NUM].  */
+/* YYPGOTO[NTERM-NUM].  */
 static const yytype_int8 yypgoto[] =
 {
      -26,   -26,   -26,   -26,   -26,   -26,    21,   -25,   -26
 };
 
-  /* YYDEFGOTO[NTERM-NUM].  */
+/* YYDEFGOTO[NTERM-NUM].  */
 static const yytype_int8 yydefgoto[] =
 {
-      -1,     1,     2,     9,    11,    14,    13,    26,    31
+       0,     1,     2,     9,    11,    14,    13,    26,    31
 };
 
-  /* YYTABLE[YYPACT[STATE-NUM]] -- What to do in state STATE-NUM.  If
-     positive, shift that token.  If negative, reduce the rule whose
-     number is the opposite.  If YYTABLE_NINF, syntax error.  */
+/* YYTABLE[YYPACT[STATE-NUM]] -- What to do in state STATE-NUM.  If
+   positive, shift that token.  If negative, reduce the rule whose
+   number is the opposite.  If YYTABLE_NINF, syntax error.  */
 static const yytype_int8 yytable[] =
 {
       -3,     4,    29,     5,     6,     7,    -2,    18,    35,    15,
@@ -535,9 +675,9 @@ static const yytype_int8 yycheck[] =
       10,    -1,    -1,    14,    -1,    14
 };
 
-  /* YYSTOS[STATE-NUM] -- The (internal number of the) accessing
-     symbol of state STATE-NUM.  */
-static const yytype_uint8 yystos[] =
+/* YYSTOS[STATE-NUM] -- The symbol kind of the accessing symbol of
+   state STATE-NUM.  */
+static const yytype_int8 yystos[] =
 {
        0,    17,    18,     0,     1,     3,     4,     5,    10,    19,
       10,    20,     6,    22,    21,     6,    10,    10,     1,    10,
@@ -545,16 +685,16 @@ static const yytype_uint8 yystos[] =
        8,    24,    14,    15,    10,    23,    14
 };
 
-  /* YYR1[YYN] -- Symbol number of symbol that rule YYN derives.  */
-static const yytype_uint8 yyr1[] =
+/* YYR1[RULE-NUM] -- Symbol kind of the left-hand side of rule RULE-NUM.  */
+static const yytype_int8 yyr1[] =
 {
        0,    16,    17,    17,    18,    18,    19,    19,    19,    19,
       20,    20,    21,    21,    21,    21,    22,    23,    23,    23,
       24
 };
 
-  /* YYR2[YYN] -- Number of symbols on the right hand side of rule YYN.  */
-static const yytype_uint8 yyr2[] =
+/* YYR2[RULE-NUM] -- Number of symbols on the right-hand side of rule RULE-NUM.  */
+static const yytype_int8 yyr2[] =
 {
        0,     2,     3,     1,     0,     2,     3,     3,     1,     2,
        0,     4,     0,     7,     2,     3,     1,     1,     4,     6,
@@ -562,39 +702,39 @@ static const yytype_uint8 yyr2[] =
 };
 
 
+enum { YYENOMEM = -2 };
+
 #define yyerrok         (yyerrstatus = 0)
 #define yyclearin       (yychar = YYEMPTY)
-#define YYEMPTY         (-2)
-#define YYEOF           0
 
 #define YYACCEPT        goto yyacceptlab
 #define YYABORT         goto yyabortlab
 #define YYERROR         goto yyerrorlab
+#define YYNOMEM         goto yyexhaustedlab
 
 
 #define YYRECOVERING()  (!!yyerrstatus)
 
-#define YYBACKUP(Token, Value)                                  \
-do                                                              \
-  if (yychar == YYEMPTY)                                        \
-    {                                                           \
-      yychar = (Token);                                         \
-      yylval = (Value);                                         \
-      YYPOPSTACK (yylen);                                       \
-      yystate = *yyssp;                                         \
-      goto yybackup;                                            \
-    }                                                           \
-  else                                                          \
-    {                                                           \
-      yyerror (YY_("syntax error: cannot back up")); \
-      YYERROR;                                                  \
-    }                                                           \
-while (0)
+#define YYBACKUP(Token, Value)                                    \
+  do                                                              \
+    if (yychar == YYEMPTY)                                        \
+      {                                                           \
+        yychar = (Token);                                         \
+        yylval = (Value);                                         \
+        YYPOPSTACK (yylen);                                       \
+        yystate = *yyssp;                                         \
+        goto yybackup;                                            \
+      }                                                           \
+    else                                                          \
+      {                                                           \
+        yyerror (YY_("syntax error: cannot back up")); \
+        YYERROR;                                                  \
+      }                                                           \
+  while (0)
 
-/* Error token number */
-#define YYTERROR        1
-#define YYERRCODE       256
-
+/* Backward compatibility with an undocumented macro.
+   Use YYerror or YYUNDEF. */
+#define YYERRCODE YYUNDEF
 
 
 /* Enable debugging if requested.  */
@@ -611,55 +751,52 @@ do {                                            \
     YYFPRINTF Args;                             \
 } while (0)
 
-/* This macro is provided for backward compatibility. */
-#ifndef YY_LOCATION_PRINT
-# define YY_LOCATION_PRINT(File, Loc) ((void) 0)
-#endif
 
 
-# define YY_SYMBOL_PRINT(Title, Type, Value, Location)                    \
+
+# define YY_SYMBOL_PRINT(Title, Kind, Value, Location)                    \
 do {                                                                      \
   if (yydebug)                                                            \
     {                                                                     \
       YYFPRINTF (stderr, "%s ", Title);                                   \
       yy_symbol_print (stderr,                                            \
-                  Type, Value); \
+                  Kind, Value); \
       YYFPRINTF (stderr, "\n");                                           \
     }                                                                     \
 } while (0)
 
 
-/*----------------------------------------.
-| Print this symbol's value on YYOUTPUT.  |
-`----------------------------------------*/
+/*-----------------------------------.
+| Print this symbol's value on YYO.  |
+`-----------------------------------*/
 
 static void
-yy_symbol_value_print (FILE *yyoutput, int yytype, YYSTYPE const * const yyvaluep)
+yy_symbol_value_print (FILE *yyo,
+                       yysymbol_kind_t yykind, YYSTYPE const * const yyvaluep)
 {
-  FILE *yyo = yyoutput;
-  YYUSE (yyo);
+  FILE *yyoutput = yyo;
+  YY_USE (yyoutput);
   if (!yyvaluep)
     return;
-# ifdef YYPRINT
-  if (yytype < YYNTOKENS)
-    YYPRINT (yyoutput, yytoknum[yytype], *yyvaluep);
-# endif
-  YYUSE (yytype);
+  YY_IGNORE_MAYBE_UNINITIALIZED_BEGIN
+  YY_USE (yykind);
+  YY_IGNORE_MAYBE_UNINITIALIZED_END
 }
 
 
-/*--------------------------------.
-| Print this symbol on YYOUTPUT.  |
-`--------------------------------*/
+/*---------------------------.
+| Print this symbol on YYO.  |
+`---------------------------*/
 
 static void
-yy_symbol_print (FILE *yyoutput, int yytype, YYSTYPE const * const yyvaluep)
+yy_symbol_print (FILE *yyo,
+                 yysymbol_kind_t yykind, YYSTYPE const * const yyvaluep)
 {
-  YYFPRINTF (yyoutput, "%s %s (",
-             yytype < YYNTOKENS ? "token" : "nterm", yytname[yytype]);
+  YYFPRINTF (yyo, "%s %s (",
+             yykind < YYNTOKENS ? "token" : "nterm", yysymbol_name (yykind));
 
-  yy_symbol_value_print (yyoutput, yytype, yyvaluep);
-  YYFPRINTF (yyoutput, ")");
+  yy_symbol_value_print (yyo, yykind, yyvaluep);
+  YYFPRINTF (yyo, ")");
 }
 
 /*------------------------------------------------------------------.
@@ -668,7 +805,7 @@ yy_symbol_print (FILE *yyoutput, int yytype, YYSTYPE const * const yyvaluep)
 `------------------------------------------------------------------*/
 
 static void
-yy_stack_print (yytype_int16 *yybottom, yytype_int16 *yytop)
+yy_stack_print (yy_state_t *yybottom, yy_state_t *yytop)
 {
   YYFPRINTF (stderr, "Stack now");
   for (; yybottom <= yytop; yybottom++)
@@ -691,21 +828,21 @@ do {                                                            \
 `------------------------------------------------*/
 
 static void
-yy_reduce_print (yytype_int16 *yyssp, YYSTYPE *yyvsp, int yyrule)
+yy_reduce_print (yy_state_t *yyssp, YYSTYPE *yyvsp,
+                 int yyrule)
 {
-  unsigned long int yylno = yyrline[yyrule];
+  int yylno = yyrline[yyrule];
   int yynrhs = yyr2[yyrule];
   int yyi;
-  YYFPRINTF (stderr, "Reducing stack by rule %d (line %lu):\n",
+  YYFPRINTF (stderr, "Reducing stack by rule %d (line %d):\n",
              yyrule - 1, yylno);
   /* The symbols being reduced.  */
   for (yyi = 0; yyi < yynrhs; yyi++)
     {
       YYFPRINTF (stderr, "   $%d = ", yyi + 1);
       yy_symbol_print (stderr,
-                       yystos[yyssp[yyi + 1 - yynrhs]],
-                       &(yyvsp[(yyi + 1) - (yynrhs)])
-                                              );
+                       YY_ACCESSING_SYMBOL (+yyssp[yyi + 1 - yynrhs]),
+                       &yyvsp[(yyi + 1) - (yynrhs)]);
       YYFPRINTF (stderr, "\n");
     }
 }
@@ -720,8 +857,8 @@ do {                                    \
    multiple parsers can coexist.  */
 int yydebug;
 #else /* !YYDEBUG */
-# define YYDPRINTF(Args)
-# define YY_SYMBOL_PRINT(Title, Type, Value, Location)
+# define YYDPRINTF(Args) ((void) 0)
+# define YY_SYMBOL_PRINT(Title, Kind, Value, Location)
 # define YY_STACK_PRINT(Bottom, Top)
 # define YY_REDUCE_PRINT(Rule)
 #endif /* !YYDEBUG */
@@ -744,255 +881,38 @@ int yydebug;
 #endif
 
 
-#if YYERROR_VERBOSE
 
-# ifndef yystrlen
-#  if defined __GLIBC__ && defined _STRING_H
-#   define yystrlen strlen
-#  else
-/* Return the length of YYSTR.  */
-static YYSIZE_T
-yystrlen (const char *yystr)
-{
-  YYSIZE_T yylen;
-  for (yylen = 0; yystr[yylen]; yylen++)
-    continue;
-  return yylen;
-}
-#  endif
-# endif
 
-# ifndef yystpcpy
-#  if defined __GLIBC__ && defined _STRING_H && defined _GNU_SOURCE
-#   define yystpcpy stpcpy
-#  else
-/* Copy YYSRC to YYDEST, returning the address of the terminating '\0' in
-   YYDEST.  */
-static char *
-yystpcpy (char *yydest, const char *yysrc)
-{
-  char *yyd = yydest;
-  const char *yys = yysrc;
 
-  while ((*yyd++ = *yys++) != '\0')
-    continue;
-
-  return yyd - 1;
-}
-#  endif
-# endif
-
-# ifndef yytnamerr
-/* Copy to YYRES the contents of YYSTR after stripping away unnecessary
-   quotes and backslashes, so that it's suitable for yyerror.  The
-   heuristic is that double-quoting is unnecessary unless the string
-   contains an apostrophe, a comma, or backslash (other than
-   backslash-backslash).  YYSTR is taken from yytname.  If YYRES is
-   null, do not copy; instead, return the length of what the result
-   would have been.  */
-static YYSIZE_T
-yytnamerr (char *yyres, const char *yystr)
-{
-  if (*yystr == '"')
-    {
-      YYSIZE_T yyn = 0;
-      char const *yyp = yystr;
-
-      for (;;)
-        switch (*++yyp)
-          {
-          case '\'':
-          case ',':
-            goto do_not_strip_quotes;
-
-          case '\\':
-            if (*++yyp != '\\')
-              goto do_not_strip_quotes;
-            /* Fall through.  */
-          default:
-            if (yyres)
-              yyres[yyn] = *yyp;
-            yyn++;
-            break;
-
-          case '"':
-            if (yyres)
-              yyres[yyn] = '\0';
-            return yyn;
-          }
-    do_not_strip_quotes: ;
-    }
-
-  if (! yyres)
-    return yystrlen (yystr);
-
-  return yystpcpy (yyres, yystr) - yyres;
-}
-# endif
-
-/* Copy into *YYMSG, which is of size *YYMSG_ALLOC, an error message
-   about the unexpected token YYTOKEN for the state stack whose top is
-   YYSSP.
-
-   Return 0 if *YYMSG was successfully written.  Return 1 if *YYMSG is
-   not large enough to hold the message.  In that case, also set
-   *YYMSG_ALLOC to the required number of bytes.  Return 2 if the
-   required number of bytes is too large to store.  */
-static int
-yysyntax_error (YYSIZE_T *yymsg_alloc, char **yymsg,
-                yytype_int16 *yyssp, int yytoken)
-{
-  YYSIZE_T yysize0 = yytnamerr (YY_NULLPTR, yytname[yytoken]);
-  YYSIZE_T yysize = yysize0;
-  enum { YYERROR_VERBOSE_ARGS_MAXIMUM = 5 };
-  /* Internationalized format string. */
-  const char *yyformat = YY_NULLPTR;
-  /* Arguments of yyformat. */
-  char const *yyarg[YYERROR_VERBOSE_ARGS_MAXIMUM];
-  /* Number of reported tokens (one for the "unexpected", one per
-     "expected"). */
-  int yycount = 0;
-
-  /* There are many possibilities here to consider:
-     - If this state is a consistent state with a default action, then
-       the only way this function was invoked is if the default action
-       is an error action.  In that case, don't check for expected
-       tokens because there are none.
-     - The only way there can be no lookahead present (in yychar) is if
-       this state is a consistent state with a default action.  Thus,
-       detecting the absence of a lookahead is sufficient to determine
-       that there is no unexpected or expected token to report.  In that
-       case, just report a simple "syntax error".
-     - Don't assume there isn't a lookahead just because this state is a
-       consistent state with a default action.  There might have been a
-       previous inconsistent state, consistent state with a non-default
-       action, or user semantic action that manipulated yychar.
-     - Of course, the expected token list depends on states to have
-       correct lookahead information, and it depends on the parser not
-       to perform extra reductions after fetching a lookahead from the
-       scanner and before detecting a syntax error.  Thus, state merging
-       (from LALR or IELR) and default reductions corrupt the expected
-       token list.  However, the list is correct for canonical LR with
-       one exception: it will still contain any token that will not be
-       accepted due to an error action in a later state.
-  */
-  if (yytoken != YYEMPTY)
-    {
-      int yyn = yypact[*yyssp];
-      yyarg[yycount++] = yytname[yytoken];
-      if (!yypact_value_is_default (yyn))
-        {
-          /* Start YYX at -YYN if negative to avoid negative indexes in
-             YYCHECK.  In other words, skip the first -YYN actions for
-             this state because they are default actions.  */
-          int yyxbegin = yyn < 0 ? -yyn : 0;
-          /* Stay within bounds of both yycheck and yytname.  */
-          int yychecklim = YYLAST - yyn + 1;
-          int yyxend = yychecklim < YYNTOKENS ? yychecklim : YYNTOKENS;
-          int yyx;
-
-          for (yyx = yyxbegin; yyx < yyxend; ++yyx)
-            if (yycheck[yyx + yyn] == yyx && yyx != YYTERROR
-                && !yytable_value_is_error (yytable[yyx + yyn]))
-              {
-                if (yycount == YYERROR_VERBOSE_ARGS_MAXIMUM)
-                  {
-                    yycount = 1;
-                    yysize = yysize0;
-                    break;
-                  }
-                yyarg[yycount++] = yytname[yyx];
-                {
-                  YYSIZE_T yysize1 = yysize + yytnamerr (YY_NULLPTR, yytname[yyx]);
-                  if (! (yysize <= yysize1
-                         && yysize1 <= YYSTACK_ALLOC_MAXIMUM))
-                    return 2;
-                  yysize = yysize1;
-                }
-              }
-        }
-    }
-
-  switch (yycount)
-    {
-# define YYCASE_(N, S)                      \
-      case N:                               \
-        yyformat = S;                       \
-      break
-      YYCASE_(0, YY_("syntax error"));
-      YYCASE_(1, YY_("syntax error, unexpected %s"));
-      YYCASE_(2, YY_("syntax error, unexpected %s, expecting %s"));
-      YYCASE_(3, YY_("syntax error, unexpected %s, expecting %s or %s"));
-      YYCASE_(4, YY_("syntax error, unexpected %s, expecting %s or %s or %s"));
-      YYCASE_(5, YY_("syntax error, unexpected %s, expecting %s or %s or %s or %s"));
-# undef YYCASE_
-    }
-
-  {
-    YYSIZE_T yysize1 = yysize + yystrlen (yyformat);
-    if (! (yysize <= yysize1 && yysize1 <= YYSTACK_ALLOC_MAXIMUM))
-      return 2;
-    yysize = yysize1;
-  }
-
-  if (*yymsg_alloc < yysize)
-    {
-      *yymsg_alloc = 2 * yysize;
-      if (! (yysize <= *yymsg_alloc
-             && *yymsg_alloc <= YYSTACK_ALLOC_MAXIMUM))
-        *yymsg_alloc = YYSTACK_ALLOC_MAXIMUM;
-      return 1;
-    }
-
-  /* Avoid sprintf, as that infringes on the user's name space.
-     Don't have undefined behavior even if the translation
-     produced a string with the wrong number of "%s"s.  */
-  {
-    char *yyp = *yymsg;
-    int yyi = 0;
-    while ((*yyp = *yyformat) != '\0')
-      if (*yyp == '%' && yyformat[1] == 's' && yyi < yycount)
-        {
-          yyp += yytnamerr (yyp, yyarg[yyi++]);
-          yyformat += 2;
-        }
-      else
-        {
-          yyp++;
-          yyformat++;
-        }
-  }
-  return 0;
-}
-#endif /* YYERROR_VERBOSE */
 
 /*-----------------------------------------------.
 | Release the memory associated to this symbol.  |
 `-----------------------------------------------*/
 
 static void
-yydestruct (const char *yymsg, int yytype, YYSTYPE *yyvaluep)
+yydestruct (const char *yymsg,
+            yysymbol_kind_t yykind, YYSTYPE *yyvaluep)
 {
-  YYUSE (yyvaluep);
+  YY_USE (yyvaluep);
   if (!yymsg)
     yymsg = "Deleting";
-  YY_SYMBOL_PRINT (yymsg, yytype, yyvaluep, yylocationp);
+  YY_SYMBOL_PRINT (yymsg, yykind, yyvaluep, yylocationp);
 
   YY_IGNORE_MAYBE_UNINITIALIZED_BEGIN
-  YYUSE (yytype);
+  YY_USE (yykind);
   YY_IGNORE_MAYBE_UNINITIALIZED_END
 }
 
 
-
-
-/* The lookahead symbol.  */
+/* Lookahead token kind.  */
 int yychar;
 
 /* The semantic value of the lookahead symbol.  */
 YYSTYPE yylval;
 /* Number of syntax errors so far.  */
 int yynerrs;
+
+
 
 
 /*----------.
@@ -1002,43 +922,36 @@ int yynerrs;
 int
 yyparse (void)
 {
-    int yystate;
+    yy_state_fast_t yystate = 0;
     /* Number of tokens to shift before error messages enabled.  */
-    int yyerrstatus;
+    int yyerrstatus = 0;
 
-    /* The stacks and their tools:
-       'yyss': related to states.
-       'yyvs': related to semantic values.
-
-       Refer to the stacks through separate pointers, to allow yyoverflow
+    /* Refer to the stacks through separate pointers, to allow yyoverflow
        to reallocate them elsewhere.  */
 
-    /* The state stack.  */
-    yytype_int16 yyssa[YYINITDEPTH];
-    yytype_int16 *yyss;
-    yytype_int16 *yyssp;
+    /* Their size.  */
+    YYPTRDIFF_T yystacksize = YYINITDEPTH;
 
-    /* The semantic value stack.  */
+    /* The state stack: array, bottom, top.  */
+    yy_state_t yyssa[YYINITDEPTH];
+    yy_state_t *yyss = yyssa;
+    yy_state_t *yyssp = yyss;
+
+    /* The semantic value stack: array, bottom, top.  */
     YYSTYPE yyvsa[YYINITDEPTH];
-    YYSTYPE *yyvs;
-    YYSTYPE *yyvsp;
-
-    YYSIZE_T yystacksize;
+    YYSTYPE *yyvs = yyvsa;
+    YYSTYPE *yyvsp = yyvs;
 
   int yyn;
+  /* The return value of yyparse.  */
   int yyresult;
-  /* Lookahead token as an internal (translated) token number.  */
-  int yytoken = 0;
+  /* Lookahead symbol kind.  */
+  yysymbol_kind_t yytoken = YYSYMBOL_YYEMPTY;
   /* The variables used to return semantic value and location from the
      action routines.  */
   YYSTYPE yyval;
 
-#if YYERROR_VERBOSE
-  /* Buffer for error messages, and its allocated size.  */
-  char yymsgbuf[128];
-  char *yymsg = yymsgbuf;
-  YYSIZE_T yymsg_alloc = sizeof yymsgbuf;
-#endif
+
 
 #define YYPOPSTACK(N)   (yyvsp -= (N), yyssp -= (N))
 
@@ -1046,71 +959,75 @@ yyparse (void)
      Keep to zero when no symbol should be popped.  */
   int yylen = 0;
 
-  yyssp = yyss = yyssa;
-  yyvsp = yyvs = yyvsa;
-  yystacksize = YYINITDEPTH;
-
   YYDPRINTF ((stderr, "Starting parse\n"));
 
-  yystate = 0;
-  yyerrstatus = 0;
-  yynerrs = 0;
   yychar = YYEMPTY; /* Cause a token to be read.  */
+
   goto yysetstate;
 
+
 /*------------------------------------------------------------.
-| yynewstate -- Push a new state, which is found in yystate.  |
+| yynewstate -- push a new state, which is found in yystate.  |
 `------------------------------------------------------------*/
- yynewstate:
+yynewstate:
   /* In all cases, when you get here, the value and location stacks
      have just been pushed.  So pushing a state here evens the stacks.  */
   yyssp++;
 
- yysetstate:
-  *yyssp = yystate;
+
+/*--------------------------------------------------------------------.
+| yysetstate -- set current state (the top of the stack) to yystate.  |
+`--------------------------------------------------------------------*/
+yysetstate:
+  YYDPRINTF ((stderr, "Entering state %d\n", yystate));
+  YY_ASSERT (0 <= yystate && yystate < YYNSTATES);
+  YY_IGNORE_USELESS_CAST_BEGIN
+  *yyssp = YY_CAST (yy_state_t, yystate);
+  YY_IGNORE_USELESS_CAST_END
+  YY_STACK_PRINT (yyss, yyssp);
 
   if (yyss + yystacksize - 1 <= yyssp)
+#if !defined yyoverflow && !defined YYSTACK_RELOCATE
+    YYNOMEM;
+#else
     {
       /* Get the current used size of the three stacks, in elements.  */
-      YYSIZE_T yysize = yyssp - yyss + 1;
+      YYPTRDIFF_T yysize = yyssp - yyss + 1;
 
-#ifdef yyoverflow
+# if defined yyoverflow
       {
         /* Give user a chance to reallocate the stack.  Use copies of
            these so that the &'s don't force the real ones into
            memory.  */
+        yy_state_t *yyss1 = yyss;
         YYSTYPE *yyvs1 = yyvs;
-        yytype_int16 *yyss1 = yyss;
 
         /* Each stack pointer address is followed by the size of the
            data in use in that stack, in bytes.  This used to be a
            conditional around just the two extra args, but that might
            be undefined if yyoverflow is a macro.  */
         yyoverflow (YY_("memory exhausted"),
-                    &yyss1, yysize * sizeof (*yyssp),
-                    &yyvs1, yysize * sizeof (*yyvsp),
+                    &yyss1, yysize * YYSIZEOF (*yyssp),
+                    &yyvs1, yysize * YYSIZEOF (*yyvsp),
                     &yystacksize);
-
         yyss = yyss1;
         yyvs = yyvs1;
       }
-#else /* no yyoverflow */
-# ifndef YYSTACK_RELOCATE
-      goto yyexhaustedlab;
-# else
+# else /* defined YYSTACK_RELOCATE */
       /* Extend the stack our own way.  */
       if (YYMAXDEPTH <= yystacksize)
-        goto yyexhaustedlab;
+        YYNOMEM;
       yystacksize *= 2;
       if (YYMAXDEPTH < yystacksize)
         yystacksize = YYMAXDEPTH;
 
       {
-        yytype_int16 *yyss1 = yyss;
+        yy_state_t *yyss1 = yyss;
         union yyalloc *yyptr =
-          (union yyalloc *) YYSTACK_ALLOC (YYSTACK_BYTES (yystacksize));
+          YY_CAST (union yyalloc *,
+                   YYSTACK_ALLOC (YY_CAST (YYSIZE_T, YYSTACK_BYTES (yystacksize))));
         if (! yyptr)
-          goto yyexhaustedlab;
+          YYNOMEM;
         YYSTACK_RELOCATE (yyss_alloc, yyss);
         YYSTACK_RELOCATE (yyvs_alloc, yyvs);
 #  undef YYSTACK_RELOCATE
@@ -1118,30 +1035,31 @@ yyparse (void)
           YYSTACK_FREE (yyss1);
       }
 # endif
-#endif /* no yyoverflow */
 
       yyssp = yyss + yysize - 1;
       yyvsp = yyvs + yysize - 1;
 
-      YYDPRINTF ((stderr, "Stack size increased to %lu\n",
-                  (unsigned long int) yystacksize));
+      YY_IGNORE_USELESS_CAST_BEGIN
+      YYDPRINTF ((stderr, "Stack size increased to %ld\n",
+                  YY_CAST (long, yystacksize)));
+      YY_IGNORE_USELESS_CAST_END
 
       if (yyss + yystacksize - 1 <= yyssp)
         YYABORT;
     }
+#endif /* !defined yyoverflow && !defined YYSTACK_RELOCATE */
 
-  YYDPRINTF ((stderr, "Entering state %d\n", yystate));
 
   if (yystate == YYFINAL)
     YYACCEPT;
 
   goto yybackup;
 
+
 /*-----------.
 | yybackup.  |
 `-----------*/
 yybackup:
-
   /* Do appropriate processing given the current state.  Read a
      lookahead token if we need one and don't already have one.  */
 
@@ -1152,17 +1070,28 @@ yybackup:
 
   /* Not known => get a lookahead token if don't already have one.  */
 
-  /* YYCHAR is either YYEMPTY or YYEOF or a valid lookahead symbol.  */
+  /* YYCHAR is either empty, or end-of-input, or a valid lookahead.  */
   if (yychar == YYEMPTY)
     {
-      YYDPRINTF ((stderr, "Reading a token: "));
+      YYDPRINTF ((stderr, "Reading a token\n"));
       yychar = yylex ();
     }
 
   if (yychar <= YYEOF)
     {
-      yychar = yytoken = YYEOF;
+      yychar = YYEOF;
+      yytoken = YYSYMBOL_YYEOF;
       YYDPRINTF ((stderr, "Now at end of input.\n"));
+    }
+  else if (yychar == YYerror)
+    {
+      /* The scanner already issued an error message, process directly
+         to error recovery.  But do not keep the error token as
+         lookahead, it is too special and may lead us to an endless
+         loop in error recovery. */
+      yychar = YYUNDEF;
+      yytoken = YYSYMBOL_YYerror;
+      goto yyerrlab1;
     }
   else
     {
@@ -1191,15 +1120,13 @@ yybackup:
 
   /* Shift the lookahead token.  */
   YY_SYMBOL_PRINT ("Shifting", yytoken, &yylval, &yylloc);
-
-  /* Discard the shifted token.  */
-  yychar = YYEMPTY;
-
   yystate = yyn;
   YY_IGNORE_MAYBE_UNINITIALIZED_BEGIN
   *++yyvsp = yylval;
   YY_IGNORE_MAYBE_UNINITIALIZED_END
 
+  /* Discard the shifted token.  */
+  yychar = YYEMPTY;
   goto yynewstate;
 
 
@@ -1214,7 +1141,7 @@ yydefault:
 
 
 /*-----------------------------.
-| yyreduce -- Do a reduction.  |
+| yyreduce -- do a reduction.  |
 `-----------------------------*/
 yyreduce:
   /* yyn is the number of a rule to reduce with.  */
@@ -1234,83 +1161,84 @@ yyreduce:
   YY_REDUCE_PRINT (yyn);
   switch (yyn)
     {
-        case 2:
-#line 22 "code/tools/lcc/lburg/gram.y" /* yacc.c:1646  */
-    { yylineno = 0; }
-#line 1240 "y.tab.c" /* yacc.c:1646  */
+  case 2: /* spec: decls PPERCENT rules  */
+#line 25 "code/tools/lcc/lburg/gram.y"
+                                        { yylineno = 0; }
+#line 1168 "y.tab.c"
     break;
 
-  case 3:
-#line 23 "code/tools/lcc/lburg/gram.y" /* yacc.c:1646  */
-    { yylineno = 0; }
-#line 1246 "y.tab.c" /* yacc.c:1646  */
+  case 3: /* spec: decls  */
+#line 26 "code/tools/lcc/lburg/gram.y"
+                                        { yylineno = 0; }
+#line 1174 "y.tab.c"
     break;
 
-  case 7:
-#line 31 "code/tools/lcc/lburg/gram.y" /* yacc.c:1646  */
-    {
+  case 7: /* decl: START nonterm '\n'  */
+#line 34 "code/tools/lcc/lburg/gram.y"
+                                        {
 		if (nonterm((yyvsp[-1].string))->number != 1)
 			yyerror("redeclaration of the start symbol\n");
 		}
-#line 1255 "y.tab.c" /* yacc.c:1646  */
+#line 1183 "y.tab.c"
     break;
 
-  case 9:
-#line 36 "code/tools/lcc/lburg/gram.y" /* yacc.c:1646  */
-    { yyerrok; }
-#line 1261 "y.tab.c" /* yacc.c:1646  */
+  case 9: /* decl: error '\n'  */
+#line 39 "code/tools/lcc/lburg/gram.y"
+                                        { yyerrok; }
+#line 1189 "y.tab.c"
     break;
 
-  case 11:
-#line 40 "code/tools/lcc/lburg/gram.y" /* yacc.c:1646  */
-    { term((yyvsp[-2].string), (yyvsp[0].n)); }
-#line 1267 "y.tab.c" /* yacc.c:1646  */
+  case 11: /* blist: blist ID '=' INT  */
+#line 43 "code/tools/lcc/lburg/gram.y"
+                                        { term((yyvsp[-2].string), (yyvsp[0].n)); }
+#line 1195 "y.tab.c"
     break;
 
-  case 13:
-#line 44 "code/tools/lcc/lburg/gram.y" /* yacc.c:1646  */
-    { rule((yyvsp[-5].string), (yyvsp[-3].tree), (yyvsp[-2].string), (yyvsp[-1].string)); }
-#line 1273 "y.tab.c" /* yacc.c:1646  */
+  case 13: /* rules: rules nonterm ':' tree TEMPLATE cost '\n'  */
+#line 47 "code/tools/lcc/lburg/gram.y"
+                                                        { rule((yyvsp[-5].string), (yyvsp[-3].tree), (yyvsp[-2].string), (yyvsp[-1].string)); }
+#line 1201 "y.tab.c"
     break;
 
-  case 15:
-#line 46 "code/tools/lcc/lburg/gram.y" /* yacc.c:1646  */
-    { yyerrok; }
-#line 1279 "y.tab.c" /* yacc.c:1646  */
+  case 15: /* rules: rules error '\n'  */
+#line 49 "code/tools/lcc/lburg/gram.y"
+                                        { yyerrok; }
+#line 1207 "y.tab.c"
     break;
 
-  case 16:
-#line 49 "code/tools/lcc/lburg/gram.y" /* yacc.c:1646  */
-    { nonterm((yyval.string) = (yyvsp[0].string)); }
-#line 1285 "y.tab.c" /* yacc.c:1646  */
+  case 16: /* nonterm: ID  */
+#line 52 "code/tools/lcc/lburg/gram.y"
+                                        { nonterm((yyval.string) = (yyvsp[0].string)); }
+#line 1213 "y.tab.c"
     break;
 
-  case 17:
-#line 52 "code/tools/lcc/lburg/gram.y" /* yacc.c:1646  */
-    { (yyval.tree) = tree((yyvsp[0].string),  0,  0); }
-#line 1291 "y.tab.c" /* yacc.c:1646  */
+  case 17: /* tree: ID  */
+#line 55 "code/tools/lcc/lburg/gram.y"
+                                        { (yyval.tree) = tree((yyvsp[0].string),  0,  0); }
+#line 1219 "y.tab.c"
     break;
 
-  case 18:
-#line 53 "code/tools/lcc/lburg/gram.y" /* yacc.c:1646  */
-    { (yyval.tree) = tree((yyvsp[-3].string), (yyvsp[-1].tree),  0); }
-#line 1297 "y.tab.c" /* yacc.c:1646  */
+  case 18: /* tree: ID '(' tree ')'  */
+#line 56 "code/tools/lcc/lburg/gram.y"
+                                        { (yyval.tree) = tree((yyvsp[-3].string), (yyvsp[-1].tree),  0); }
+#line 1225 "y.tab.c"
     break;
 
-  case 19:
-#line 54 "code/tools/lcc/lburg/gram.y" /* yacc.c:1646  */
-    { (yyval.tree) = tree((yyvsp[-5].string), (yyvsp[-3].tree), (yyvsp[-1].tree)); }
-#line 1303 "y.tab.c" /* yacc.c:1646  */
+  case 19: /* tree: ID '(' tree ',' tree ')'  */
+#line 57 "code/tools/lcc/lburg/gram.y"
+                                        { (yyval.tree) = tree((yyvsp[-5].string), (yyvsp[-3].tree), (yyvsp[-1].tree)); }
+#line 1231 "y.tab.c"
     break;
 
-  case 20:
-#line 57 "code/tools/lcc/lburg/gram.y" /* yacc.c:1646  */
-    { if (*(yyvsp[0].string) == 0) (yyval.string) = "0"; }
-#line 1309 "y.tab.c" /* yacc.c:1646  */
+  case 20: /* cost: CODE  */
+#line 60 "code/tools/lcc/lburg/gram.y"
+                                        { if (*(yyvsp[0].string) == 0) (yyval.string) = "0"; }
+#line 1237 "y.tab.c"
     break;
 
 
-#line 1313 "y.tab.c" /* yacc.c:1646  */
+#line 1241 "y.tab.c"
+
       default: break;
     }
   /* User semantic actions sometimes alter yychar, and that requires
@@ -1324,25 +1252,23 @@ yyreduce:
      case of YYERROR or YYBACKUP, subsequent parser actions might lead
      to an incorrect destructor call or verbose syntax error message
      before the lookahead is translated.  */
-  YY_SYMBOL_PRINT ("-> $$ =", yyr1[yyn], &yyval, &yyloc);
+  YY_SYMBOL_PRINT ("-> $$ =", YY_CAST (yysymbol_kind_t, yyr1[yyn]), &yyval, &yyloc);
 
   YYPOPSTACK (yylen);
   yylen = 0;
-  YY_STACK_PRINT (yyss, yyssp);
 
   *++yyvsp = yyval;
 
   /* Now 'shift' the result of the reduction.  Determine what state
      that goes to, based on the state we popped back to and the rule
      number reduced by.  */
-
-  yyn = yyr1[yyn];
-
-  yystate = yypgoto[yyn - YYNTOKENS] + *yyssp;
-  if (0 <= yystate && yystate <= YYLAST && yycheck[yystate] == *yyssp)
-    yystate = yytable[yystate];
-  else
-    yystate = yydefgoto[yyn - YYNTOKENS];
+  {
+    const int yylhs = yyr1[yyn] - YYNTOKENS;
+    const int yyi = yypgoto[yylhs] + *yyssp;
+    yystate = (0 <= yyi && yyi <= YYLAST && yycheck[yyi] == *yyssp
+               ? yytable[yyi]
+               : yydefgoto[yylhs]);
+  }
 
   goto yynewstate;
 
@@ -1353,49 +1279,13 @@ yyreduce:
 yyerrlab:
   /* Make sure we have latest lookahead translation.  See comments at
      user semantic actions for why this is necessary.  */
-  yytoken = yychar == YYEMPTY ? YYEMPTY : YYTRANSLATE (yychar);
-
+  yytoken = yychar == YYEMPTY ? YYSYMBOL_YYEMPTY : YYTRANSLATE (yychar);
   /* If not already recovering from an error, report this error.  */
   if (!yyerrstatus)
     {
       ++yynerrs;
-#if ! YYERROR_VERBOSE
       yyerror (YY_("syntax error"));
-#else
-# define YYSYNTAX_ERROR yysyntax_error (&yymsg_alloc, &yymsg, \
-                                        yyssp, yytoken)
-      {
-        char const *yymsgp = YY_("syntax error");
-        int yysyntax_error_status;
-        yysyntax_error_status = YYSYNTAX_ERROR;
-        if (yysyntax_error_status == 0)
-          yymsgp = yymsg;
-        else if (yysyntax_error_status == 1)
-          {
-            if (yymsg != yymsgbuf)
-              YYSTACK_FREE (yymsg);
-            yymsg = (char *) YYSTACK_ALLOC (yymsg_alloc);
-            if (!yymsg)
-              {
-                yymsg = yymsgbuf;
-                yymsg_alloc = sizeof yymsgbuf;
-                yysyntax_error_status = 2;
-              }
-            else
-              {
-                yysyntax_error_status = YYSYNTAX_ERROR;
-                yymsgp = yymsg;
-              }
-          }
-        yyerror (yymsgp);
-        if (yysyntax_error_status == 2)
-          goto yyexhaustedlab;
-      }
-# undef YYSYNTAX_ERROR
-#endif
     }
-
-
 
   if (yyerrstatus == 3)
     {
@@ -1425,12 +1315,11 @@ yyerrlab:
 | yyerrorlab -- error raised explicitly by YYERROR.  |
 `---------------------------------------------------*/
 yyerrorlab:
-
-  /* Pacify compilers like GCC when the user code never invokes
-     YYERROR and the label yyerrorlab therefore never appears in user
-     code.  */
-  if (/*CONSTCOND*/ 0)
-     goto yyerrorlab;
+  /* Pacify compilers when the user code never invokes YYERROR and the
+     label yyerrorlab therefore never appears in user code.  */
+  if (0)
+    YYERROR;
+  ++yynerrs;
 
   /* Do not reclaim the symbols of the rule whose action triggered
      this YYERROR.  */
@@ -1447,13 +1336,14 @@ yyerrorlab:
 yyerrlab1:
   yyerrstatus = 3;      /* Each real token shifted decrements this.  */
 
+  /* Pop stack until we find a state that shifts the error token.  */
   for (;;)
     {
       yyn = yypact[yystate];
       if (!yypact_value_is_default (yyn))
         {
-          yyn += YYTERROR;
-          if (0 <= yyn && yyn <= YYLAST && yycheck[yyn] == YYTERROR)
+          yyn += YYSYMBOL_YYerror;
+          if (0 <= yyn && yyn <= YYLAST && yycheck[yyn] == YYSYMBOL_YYerror)
             {
               yyn = yytable[yyn];
               if (0 < yyn)
@@ -1467,7 +1357,7 @@ yyerrlab1:
 
 
       yydestruct ("Error: popping",
-                  yystos[yystate], yyvsp);
+                  YY_ACCESSING_SYMBOL (yystate), yyvsp);
       YYPOPSTACK (1);
       yystate = *yyssp;
       YY_STACK_PRINT (yyss, yyssp);
@@ -1479,7 +1369,7 @@ yyerrlab1:
 
 
   /* Shift the error token.  */
-  YY_SYMBOL_PRINT ("Shifting", yystos[yyn], yyvsp, yylsp);
+  YY_SYMBOL_PRINT ("Shifting", YY_ACCESSING_SYMBOL (yyn), yyvsp, yylsp);
 
   yystate = yyn;
   goto yynewstate;
@@ -1490,26 +1380,30 @@ yyerrlab1:
 `-------------------------------------*/
 yyacceptlab:
   yyresult = 0;
-  goto yyreturn;
+  goto yyreturnlab;
+
 
 /*-----------------------------------.
 | yyabortlab -- YYABORT comes here.  |
 `-----------------------------------*/
 yyabortlab:
   yyresult = 1;
-  goto yyreturn;
+  goto yyreturnlab;
 
-#if !defined yyoverflow || YYERROR_VERBOSE
-/*-------------------------------------------------.
-| yyexhaustedlab -- memory exhaustion comes here.  |
-`-------------------------------------------------*/
+
+/*-----------------------------------------------------------.
+| yyexhaustedlab -- YYNOMEM (memory exhaustion) comes here.  |
+`-----------------------------------------------------------*/
 yyexhaustedlab:
   yyerror (YY_("memory exhausted"));
   yyresult = 2;
-  /* Fall through.  */
-#endif
+  goto yyreturnlab;
 
-yyreturn:
+
+/*----------------------------------------------------------.
+| yyreturnlab -- parsing is finished, clean up and return.  |
+`----------------------------------------------------------*/
+yyreturnlab:
   if (yychar != YYEMPTY)
     {
       /* Make sure we have latest lookahead translation.  See comments at
@@ -1525,20 +1419,18 @@ yyreturn:
   while (yyssp != yyss)
     {
       yydestruct ("Cleanup: popping",
-                  yystos[*yyssp], yyvsp);
+                  YY_ACCESSING_SYMBOL (+*yyssp), yyvsp);
       YYPOPSTACK (1);
     }
 #ifndef yyoverflow
   if (yyss != yyssa)
     YYSTACK_FREE (yyss);
 #endif
-#if YYERROR_VERBOSE
-  if (yymsg != yymsgbuf)
-    YYSTACK_FREE (yymsg);
-#endif
+
   return yyresult;
 }
-#line 59 "code/tools/lcc/lburg/gram.y" /* yacc.c:1906  */
+
+#line 62 "code/tools/lcc/lburg/gram.y"
 
 #include <assert.h>
 #include <stdarg.h>


### PR DESCRIPTION
Three minor fixes:
- Improved hit prediction by aligning the client-side hit check more closely to the server-side hit evaluation
- Disabled yacc regeneration in make (recent change triggered an attempt to rebuild, which msys2 can't do). Should be zero impact, just smooths the cross-platform build process.
- Fixed an unintended side effect of implementing vsound - Projectile explosions were happening local on the player in Quake3e, instead of out in the world. So every rocket explosion was full-volume in-ear. Fixed that, at the expense of the player's own projectiles causing a vsound icon to appear when they explode/impact.