### PR TITLE
Fix colors again

### DIFF
--- a/build_windows.ps1
+++ b/build_windows.ps1
@@ -4,7 +4,8 @@
 param(
     [switch]$Deploy,
     [switch]$NoBuild,
-    [switch]$Quiet
+    [switch]$Quiet,
+    [switch]$Clean
 )
 
 $ErrorActionPreference = "Stop"
@@ -41,12 +42,10 @@ function Deploy-TestPk3 {
 Push-Location $RepoRoot
 try {
     if (-not $NoBuild) {
-        $quietFlag = if ($Quiet) { "QUIET=1" } else { "" }
-        $makeArgs = if ($quietFlag) {
-            "make clean $quietFlag;make $quietFlag"
-        } else {
-            "make clean;make"
-        }
+        # $(nproc) is expanded by the MSYS2 bash -c shell, not PowerShell.
+        $quietFlag = if ($Quiet) { " QUIET=1" } else { "" }
+        $build = "make -j`$(nproc)$quietFlag"
+        $makeArgs = if ($Clean) { "make clean$quietFlag;$build" } else { $build }
         # Compiler warnings go to stderr; merge streams without NativeCommandError noise.
         $prevEap = $ErrorActionPreference
         $ErrorActionPreference = 'Continue'

--- a/ratoa_gamecode/code/cgame/cg_draw.c
+++ b/ratoa_gamecode/code/cgame/cg_draw.c
@@ -404,49 +404,39 @@ void CG_Draw3DHead( float x, float y, float w, float h, qhandle_t model, qhandle
 	}
 	*/
 
-	//////////////////////////////////////////////////////////////////////////////////////////
-	//duffman91 - make this a function to catch the headmodel cases....?	
-	// Team Game
-	if ( CG_IsTeamGametype() ){
-		//set starting colors
+	if ( ci == &cgs.clientinfo[cg.clientNum] ) {
+		ent.shaderRGBA[0] = (byte)(ci->headColor[0] * 255);
+		ent.shaderRGBA[1] = (byte)(ci->headColor[1] * 255);
+		ent.shaderRGBA[2] = (byte)(ci->headColor[2] * 255);
+		ent.shaderRGBA[3] = 255;
+	} else if ( CG_IsTeamGametype() ){
+		int myteam = (cg.snap) ? cg.snap->ps.persistant[PERS_TEAM] : TEAM_SPECTATOR;
+
 		if ( ci->team == TEAM_BLUE ){
 			CG_IntColorToRGBA( 4, ent.shaderRGBA );
 		}
 		else if ( ci->team == TEAM_RED ){
 			CG_IntColorToRGBA( 1, ent.shaderRGBA );
 		}
-		else {             // spectators are set to white
+		else {
 			CG_IntColorToRGBA( 7, ent.shaderRGBA );
 		}
-		
-		// set enemy & team colors if available
-		if ( cg_enemyColor.string[0] ){
-			char colorNumEnemy = cg_enemyColor.string[0];
 
-			if ( ci-> team != cg.snap->ps.persistant[PERS_TEAM] && cg.snap->ps.persistant[PERS_TEAM] != TEAM_SPECTATOR){
-				CG_IntColorToRGBA( atoi(&colorNumEnemy), ent.shaderRGBA ); 
-			}	
+		if ( myteam != TEAM_SPECTATOR ){
+			if ( ci->team != myteam && cg_enemyColor.string[0] ){
+				CG_IntColorToRGBA( cg_enemyColor.string[0] - '0', ent.shaderRGBA );
+			} else if ( ci->team == myteam && cg_teamColor.string[0] ){
+				CG_IntColorToRGBA( cg_teamColor.string[0] - '0', ent.shaderRGBA );
+			}
 		}
-		
-		if ( cg_teamColor.string[0] ){
-			char colorNumTeam = cg_teamColor.string[0];
-
-			if ( ci-> team == cg.snap->ps.persistant[PERS_TEAM] && cg.snap->ps.persistant[PERS_TEAM] != TEAM_SPECTATOR){
-				CG_IntColorToRGBA( atoi(&colorNumTeam), ent.shaderRGBA ); 
-			}	
-		}
-	}
-	// Not Team Game
-	else{
+	} else {
 		if ( cg_enemyColor.string[0] ){
-			char colorNum = cg_enemyColor.string[0];
-			CG_IntColorToRGBA ( atoi(&colorNum), ent.shaderRGBA );
+			CG_IntColorToRGBA( cg_enemyColor.string[0] - '0', ent.shaderRGBA );
 		}
 		else{
-			CG_IntColorToRGBA ( 7, ent.shaderRGBA );
+			CG_IntColorToRGBA( 7, ent.shaderRGBA );
 		}
-	}	
-	/////////////////////////////////////////////////////////////////////////////////////////
+	}
 
 	refdef.rdflags = RDF_NOWORLDMODEL;
 

--- a/ratoa_gamecode/code/cgame/cg_draw.c
+++ b/ratoa_gamecode/code/cgame/cg_draw.c
@@ -407,7 +407,7 @@ void CG_Draw3DHead( float x, float y, float w, float h, qhandle_t model, qhandle
 	//////////////////////////////////////////////////////////////////////////////////////////
 	//duffman91 - make this a function to catch the headmodel cases....?	
 	// Team Game
-	if ( cgs.gametype >= GT_TEAM ){
+	if ( CG_IsTeamGametype() ){
 		//set starting colors
 		if ( ci->team == TEAM_BLUE ){
 			CG_IntColorToRGBA( 4, ent.shaderRGBA );

--- a/ratoa_gamecode/code/cgame/cg_event.c
+++ b/ratoa_gamecode/code/cgame/cg_event.c
@@ -613,19 +613,14 @@ footstep_t CG_Footsteps(clientInfo_t *ci) {
 		int myteam;
 		clientInfo_t *myself;
 
-		if (cg.snap->ps.pm_flags & PMF_FOLLOW && cg.snap->ps.persistant[PERS_TEAM] == TEAM_SPECTATOR) {
-			myteam = cgs.clientinfo[cg.snap->ps.clientNum].team;
-			myself = &cgs.clientinfo[cg.snap->ps.clientNum];
-		} else {
-			myteam = cg.snap->ps.persistant[PERS_TEAM];
-			myself = &cgs.clientinfo[cg.clientNum];
-		}
+		myself = &cgs.clientinfo[cg.clientNum];
+		myteam = cg.snap ? cg.snap->ps.persistant[PERS_TEAM] : myself->team;
 
 		if (ci == myself) {
 			footsteps = cg_myFootsteps.integer;
-		} else if ((myteam != TEAM_FREE && ci->team == myteam)) {
+		} else if (CG_IsTeamGametype() && myteam != TEAM_SPECTATOR && ci->team == myteam) {
 			footsteps = cg_teamFootsteps.integer;
-		} else if (((ci->team != myteam) || (myteam == TEAM_FREE && ci != myself))) {
+		} else {
 			footsteps = cg_enemyFootsteps.integer;
 		}
 

--- a/ratoa_gamecode/code/cgame/cg_players.c
+++ b/ratoa_gamecode/code/cgame/cg_players.c
@@ -90,13 +90,8 @@ sfxHandle_t	CG_CustomSound( int clientNum, const char *soundName ) {
 	int myteam;
 	clientInfo_t *myself;
 
-	if (cg.snap->ps.pm_flags & PMF_FOLLOW && cg.snap->ps.persistant[PERS_TEAM] == TEAM_SPECTATOR) {
-		myteam = cgs.clientinfo[cg.snap->ps.clientNum].team;
-		myself = &cgs.clientinfo[cg.snap->ps.clientNum];
-	} else {
-		myteam = cg.snap->ps.persistant[PERS_TEAM];
-		myself = &cgs.clientinfo[cg.clientNum];
-	}
+	myself = &cgs.clientinfo[cg.clientNum];
+	myteam = cg.snap ? cg.snap->ps.persistant[PERS_TEAM] : myself->team;
 
 	if ( soundName[0] != '*' ) {
 		return trap_S_RegisterSound( soundName, qfalse );
@@ -110,14 +105,17 @@ sfxHandle_t	CG_CustomSound( int clientNum, const char *soundName ) {
 	for ( i = 0 ; i < MAX_CUSTOM_SOUNDS && cg_customSoundNames[i] ; i++ ) {
 		if ( !strcmp( soundName, cg_customSoundNames[i] ) ) {
 			if ((cgs.ratFlags & RAT_ALLOWFORCEDMODELS)) {
-				if (ci == myself && cgs.mySounds[i]) {
-					return cgs.mySounds[i];
-				} else if ((myteam != TEAM_FREE && ci->team == myteam) && cgs.teamSounds[i]) {
+				if (ci == myself) {
+					if (cgs.mySounds[i]) {
+						return cgs.mySounds[i];
+					}
+				} else if (CG_IsTeamGametype() && myteam != TEAM_SPECTATOR
+						&& ci->team == myteam && cgs.teamSounds[i]) {
 					return cgs.teamSounds[i];
-				} else if (((ci->team != myteam) || (myteam == TEAM_FREE && ci != myself)) && cgs.enemySounds[i]) {
+				} else if (cgs.enemySounds[i]) {
 					return cgs.enemySounds[i];
 				}
-			} 
+			}
 			return ci->sounds[i];
 		}
 	}
@@ -1168,7 +1166,7 @@ static void CG_SetSkinAndModel( clientInfo_t *newInfo,
 
 				} 
 				
-				if ( cg_teamModel.string[0] && currentTeam == myTeam ) {
+				if ( cg_teamModel.string[0] && currentTeam == myTeam && clientNum != cg.clientNum ) {
 					if ( cg_teamColor.string[0] ){
 						colors = CG_GetTeamColorsOSP( cg_teamColor.string );
 						CG_SetColorInfo( colors, newInfo );
@@ -1267,7 +1265,7 @@ static void CG_SetSkinAndModel( clientInfo_t *newInfo,
 				} 
 
 		} else { // not team game
-			if ( cg_enemyColor.string[0] ){
+			if ( cg_enemyColor.string[0] && clientNum != cg.clientNum ){
 				colors = CG_GetTeamColorsOSP( cg_enemyColor.string );
 				CG_SetColorInfo( colors, newInfo );
 				newInfo->coloredSkin = qtrue;
@@ -1331,6 +1329,7 @@ clientInfo_t *ci;
 	int 	local_team;
 	team_t	viewerTeam;
 	qboolean enemy = qfalse;
+	qboolean useForcedModel;
 
 	qboolean allowNativeModel;
 
@@ -1347,9 +1346,6 @@ clientInfo_t *ci;
 	local_team = atoi(v);
 
 	viewerTeam = (team_t)local_team;
-	if ( viewerTeam == TEAM_SPECTATOR && cg.snap ) {
-		viewerTeam = cg.snap->ps.persistant[PERS_TEAM];
-	}
 
 	allowNativeModel = qfalse;
 	if ( !CG_IsTeamGametype() ) {
@@ -1366,6 +1362,9 @@ clientInfo_t *ci;
 
 	newInfo.forcedModel = qfalse;
 	newInfo.forcedBrightModel = qfalse;
+	VectorSet( newInfo.headColor, 1.0f, 1.0f, 1.0f );
+	VectorSet( newInfo.bodyColor, 1.0f, 1.0f, 1.0f );
+	VectorSet( newInfo.legsColor, 1.0f, 1.0f, 1.0f );
 
 #ifdef WITH_MULTITOURNAMENT
 	// gameId for GT_MULTITOURNAMENT
@@ -1431,21 +1430,15 @@ clientInfo_t *ci;
 		newInfo.modelName, sizeof( newInfo.modelName ),	newInfo.skinName, sizeof( newInfo.skinName ) );
 
 	if (CG_IsTeamGametype()) {
-		if (local_team != newInfo.team)
-			enemy = 1;
-		else
-			enemy = 0;
+		enemy = ( local_team != TEAM_SPECTATOR && local_team != newInfo.team );
 	} else {
-		if (cg.clientNum == clientNum) {
-			enemy = 0;
-		} else {
-			enemy = 1;
-		}
+		enemy = ( cg.clientNum != clientNum );
 	}
 
 	/* Local player keeps userinfo color1/color2. Enemies/teammates use
-	 * cg_enemyColor / cg_teamColor digits 4-5 when present. */
-	if ( clientNum != cg.clientNum ) {
+	 * cg_enemyColor / cg_teamColor digits 4-5 when present. Spectating a
+	 * team game leaves each player's own rail colors. */
+	if ( clientNum != cg.clientNum && local_team != TEAM_SPECTATOR ) {
 		if ( enemy && cg_enemyColor.string[0] ) {
 			CG_SetRailColors( cg_enemyColor.string, &newInfo );
 		} else if ( !enemy && CG_IsTeamGametype() && cg_teamColor.string[0] ) {
@@ -1453,10 +1446,16 @@ clientInfo_t *ci;
 		}
 	}
 
-	if (cgs.ratFlags & RAT_ALLOWFORCEDMODELS && 
-			(  (!enemy && cg_teamModel.string[0]) ||
-			   ( enemy && cg_enemyModel.string[0])
-			)) {
+	/* Never force enemy/team models onto the local player. In FFA, team
+	 * model must not apply to self either. Spectating a team game keeps
+	 * native models (red/blue colors come from CG_SetSkinAndModel). */
+	useForcedModel = (cgs.ratFlags & RAT_ALLOWFORCEDMODELS)
+		&& clientNum != cg.clientNum
+		&& !( CG_IsTeamGametype() && local_team == TEAM_SPECTATOR )
+		&& ( ( enemy && cg_enemyModel.string[0] )
+			|| ( !enemy && CG_IsTeamGametype() && cg_teamModel.string[0] ) );
+
+	if (useForcedModel) {
 		if (enemy) {
 			Q_strncpyz( newInfo.modelName, cg_enemyModel.string, sizeof( newInfo.modelName ) );
 		} else {
@@ -1538,10 +1537,7 @@ clientInfo_t *ci;
 	CG_SetSkinAndModel( &newInfo, headModelConfig, allowNativeModel, viewerTeam, clientNum, qtrue,
 		newInfo.headModelName, sizeof( newInfo.headModelName ),	newInfo.headSkinName, sizeof( newInfo.headSkinName ) );
 
-	if (cgs.ratFlags & RAT_ALLOWFORCEDMODELS && 
-			(  (!enemy && cg_teamModel.string[0]) ||
-			   ( enemy && cg_enemyModel.string[0])
-			)) {
+	if (useForcedModel) {
 		if (enemy) {
 			Q_strncpyz( newInfo.headModelName, cg_enemyModel.string, sizeof( newInfo.headModelName ) );
 		} else {

--- a/ratoa_gamecode/code/cgame/cg_players.c
+++ b/ratoa_gamecode/code/cgame/cg_players.c
@@ -1135,7 +1135,7 @@ static void CG_SetSkinAndModel( clientInfo_t *newInfo,
 
 	if ( cg_forceModel.integer || cg_enemyModel.string[0] || cg_teamModel.string[0] )
 	{
-		if ( cgs.gametype >= GT_TEAM )
+		if ( CG_IsTeamGametype() )
 		{
 			// enemy model
 			if( myTeam != TEAM_SPECTATOR ) {
@@ -1365,7 +1365,7 @@ clientInfo_t *ci;
 	}
 
 	allowNativeModel = qfalse;
-	if ( cgs.gametype < GT_TEAM ) {
+	if ( !CG_IsTeamGametype() ) {
 		if ( !cg.snap || ( cg.snap->ps.persistant[PERS_TEAM] == TEAM_FREE && cg.snap->ps.clientNum == clientNum ) ) {
 			if ( cg.demoPlayback || ( cg.snap && cg.snap->ps.pm_flags & PMF_FOLLOW ) ) {
 				allowNativeModel = qtrue;

--- a/ratoa_gamecode/code/cgame/cg_players.c
+++ b/ratoa_gamecode/code/cgame/cg_players.c
@@ -1094,9 +1094,12 @@ static void CG_SetColorInfo( const char *color, clientInfo_t *info )
 	if ( !color[2] )
 		return;
 	CG_ColorFromChar( color[2], info->legsColor );
+}
 
-	// override color1/color2 if specified
-	if ( !color[3] )
+/* Digits 4-5 of cg_enemyColor / cg_teamColor: rail core and spiral. */
+static void CG_SetRailColors( const char *color, clientInfo_t *info )
+{
+	if ( !color || !color[3] )
 		return;
 	CG_ColorFromChar( color[3], info->color1 );
 
@@ -1330,9 +1333,6 @@ clientInfo_t *ci;
 	qboolean enemy = qfalse;
 
 	qboolean allowNativeModel;
-	int myClientNum;
-	team_t team;
-	int len;
 
 	ci = &cgs.clientinfo[clientNum];
 
@@ -1349,19 +1349,6 @@ clientInfo_t *ci;
 	viewerTeam = (team_t)local_team;
 	if ( viewerTeam == TEAM_SPECTATOR && cg.snap ) {
 		viewerTeam = cg.snap->ps.persistant[PERS_TEAM];
-	}
-
-	if ( cg.snap ) {                             //duffman91 - There is something up with this.
-		myClientNum = cg.snap->ps.clientNum;
-		team = ci->team;	
-	} else {
-		myClientNum = cg.clientNum;
-		team = TEAM_SPECTATOR;
-	}
-
-	// "join" team if spectating
-	if ( team == TEAM_SPECTATOR && cg.snap ) {
-		team = cg.snap->ps.persistant[ PERS_TEAM ];
 	}
 
 	allowNativeModel = qfalse;
@@ -1443,17 +1430,6 @@ clientInfo_t *ci;
 	CG_SetSkinAndModel( &newInfo, modelConfig, allowNativeModel, viewerTeam, clientNum, qtrue,
 		newInfo.modelName, sizeof( newInfo.modelName ),	newInfo.skinName, sizeof( newInfo.skinName ) );
 
-	if ( cg_teamColor.string[0] && team != TEAM_SPECTATOR ) {
-		const char *ospColors;
-
-		ospColors = CG_GetTeamColorsOSP( cg_teamColor.string );
-		len = strlen( ospColors );
-		if ( len >= 4 )
-			CG_ColorFromChar( ospColors[3], newInfo.color1 );
-		if ( len >= 5 )
-			CG_ColorFromChar( ospColors[4], newInfo.color2 );
-	}
-
 	if (CG_IsTeamGametype()) {
 		if (local_team != newInfo.team)
 			enemy = 1;
@@ -1464,6 +1440,16 @@ clientInfo_t *ci;
 			enemy = 0;
 		} else {
 			enemy = 1;
+		}
+	}
+
+	/* Local player keeps userinfo color1/color2. Enemies/teammates use
+	 * cg_enemyColor / cg_teamColor digits 4-5 when present. */
+	if ( clientNum != cg.clientNum ) {
+		if ( enemy && cg_enemyColor.string[0] ) {
+			CG_SetRailColors( cg_enemyColor.string, &newInfo );
+		} else if ( !enemy && CG_IsTeamGametype() && cg_teamColor.string[0] ) {
+			CG_SetRailColors( cg_teamColor.string, &newInfo );
 		}
 	}
 


### PR DESCRIPTION
Several color-related bugfixes:
- Fixed colors not being applied at all in LMS (black player models bug)
- Fixed rail colors for the player being overriden by cg_enemyColors
- Aligned color application across the gamecode so SELF, TEAM, and ENEMY colors are treated distinctly and applied separately, instead of being a hierarchical tree of inherited settings.

An important note: \cg_forceModel should be 0 to ensure consistent application of the various settings. It fights most of them in various ways if left enabled.

Also made a small tweak to the windows build process so qvms can build in parallel rather than series.

Tested in Quake3e client on localhost,