### PR TITLE
More tweaks

### DIFF
--- a/BUILD_WINDOWS.md
+++ b/BUILD_WINDOWS.md
@@ -58,7 +58,7 @@ Artifacts:
 From the repo root in **PowerShell** (with MSYS2 on `PATH`, or `msys2_shell.cmd` available):
 
 ```powershell
-.\build_windows.ps1              # build only
+.\build_windows.ps1              # make clean, then parallel build
 .\build_windows.ps1 -Deploy      # build, then copy PK3 to test\devotion\
 .\build_windows.ps1 -NoBuild -Deploy   # deploy only (PK3 already built)
 .\build_windows.ps1 -Quiet       # suppress per-file compile lines and config banner (warnings/errors still print)

--- a/build_windows.ps1
+++ b/build_windows.ps1
@@ -4,8 +4,7 @@
 param(
     [switch]$Deploy,
     [switch]$NoBuild,
-    [switch]$Quiet,
-    [switch]$Clean
+    [switch]$Quiet
 )
 
 $ErrorActionPreference = "Stop"
@@ -44,8 +43,9 @@ try {
     if (-not $NoBuild) {
         # $(nproc) is expanded by the MSYS2 bash -c shell, not PowerShell.
         $quietFlag = if ($Quiet) { " QUIET=1" } else { "" }
-        $build = "make -j`$(nproc)$quietFlag"
-        $makeArgs = if ($Clean) { "make clean$quietFlag;$build" } else { $build }
+        # Always clean first. Incremental make often misses header-only changes
+        # (e.g. centity_t / cg_t layout), which can produce a broken cgame.
+        $makeArgs = "make clean$quietFlag;make -j`$(nproc)$quietFlag"
         # Compiler warnings go to stderr; merge streams without NativeCommandError noise.
         $prevEap = $ErrorActionPreference
         $ErrorActionPreference = 'Continue'

--- a/ratoa_gamecode/code/cgame/cg_demo_history.c
+++ b/ratoa_gamecode/code/cgame/cg_demo_history.c
@@ -198,7 +198,14 @@ qboolean CG_DemoHistory_DelayPlayerTeleportEvent( int clientNum, int event, cons
 	slot = &cg_demoDelayedTele[cg_demoDelayedTeleCount++];
 	slot->snapServerTime = cg.snap->serverTime;
 	slot->event = event;
-	slot->soundEntityNum = ( clientNum >= 0 && clientNum < MAX_CLIENTS ) ? clientNum : ENTITYNUM_WORLD;
+	/* Tele-out is a world cue at the entrance; do not bind it to the player. */
+	if ( event == EV_PLAYER_TELEPORT_OUT ) {
+		slot->soundEntityNum = ENTITYNUM_WORLD;
+	} else if ( clientNum >= 0 && clientNum < MAX_CLIENTS ) {
+		slot->soundEntityNum = clientNum;
+	} else {
+		slot->soundEntityNum = ENTITYNUM_WORLD;
+	}
 	VectorCopy( origin, slot->origin );
 	return qtrue;
 }

--- a/ratoa_gamecode/code/cgame/cg_demo_history.c
+++ b/ratoa_gamecode/code/cgame/cg_demo_history.c
@@ -44,9 +44,33 @@ typedef struct {
 static demoDelayedTele_t cg_demoDelayedTele[CG_DEMO_DELAYED_TELE_CAP];
 static int cg_demoDelayedTeleCount;
 
+/*
+ * Witnessed tele times, kept after FX fire so pose sampling still knows T
+ * when the player is missing from the teleport snapshot (exit out of PVS).
+ */
+#define CG_DEMO_WITNESSED_TELE_CAP 32
+
+typedef struct {
+	int		clientNum;
+	int		snapServerTime;
+} demoWitnessedTele_t;
+
+static demoWitnessedTele_t cg_demoWitnessedTele[CG_DEMO_WITNESSED_TELE_CAP];
+static int cg_demoWitnessedTeleCount;
+static qboolean cg_demoDelagPlayerGone[MAX_CLIENTS];
+
 static int demoDelagPingRawAlongInterpolation( void );
 static qboolean demoDelagResolvePingMs( int *outPing );
 static void demoDelagFlushDelayedTeleports( void );
+static void demoDelagNoteWitnessedTele( int clientNum, int snapServerTime );
+static void demoDelagPruneWitnessedTeles( void );
+static int demoDelagNextSnapTimeAfter( int t );
+static int demoDelagFirstTeleportHistoryTime( int entityNum, int flagsLo, int tLo, int tHi );
+static int demoDelagTeleportSwitchTime( int entityNum, int flagsLo, int tLo, int tHi );
+static int demoDelagLatestWitnessedTeleAtOrBefore( int clientNum, int t );
+static qboolean demoDelagEntityFlagsBefore( int entityNum, int t, int *outFlags );
+static qboolean demoDelagIsPostTeleFlags( int entityNum, int flags, int teleTime );
+static void demoDelagHidePlayerVisual( centity_t *cent );
 
 void CG_DemoHistory_Clear( void ) {
 	int i;
@@ -56,7 +80,9 @@ void CG_DemoHistory_Clear( void ) {
 	cg_demoHistoryLastServerTime = -1;
 	cg_demoRewindSaveCount = 0;
 	cg_demoDelayedTeleCount = 0;
+	cg_demoWitnessedTeleCount = 0;
 	cg_demoDelagPingSmoothed = -1;
+	Com_Memset( cg_demoDelagPlayerGone, 0, sizeof( cg_demoDelagPlayerGone ) );
 	for ( i = 0; i < MAX_GENTITIES; i++ ) {
 		cg_entities[i].demoDelagVisualCached = qfalse;
 		cg_entities[i].demoDelagDrawStateValid = qfalse;
@@ -93,6 +119,7 @@ void CG_DemoHistory_Frame( void ) {
 		cg_demoDelagPingSmoothed = -1;
 	}
 	cg_demoHistoryPrevPlayback = cg.demoPlayback;
+	demoDelagPruneWitnessedTeles();
 	demoDelagFlushDelayedTeleports();
 }
 
@@ -161,6 +188,9 @@ qboolean CG_DemoHistory_DelayPlayerTeleportEvent( int clientNum, int event, cons
 	if ( clientNum == cg.predictedPlayerState.clientNum || !demoDelagResolvePingMs( &ping ) ) {
 		return qfalse;
 	}
+
+	demoDelagNoteWitnessedTele( clientNum, cg.snap->serverTime );
+
 	if ( cg_demoDelayedTeleCount >= CG_DEMO_DELAYED_TELE_CAP ) {
 		return qtrue;
 	}
@@ -352,6 +382,73 @@ static void demoDelagFlushDelayedTeleports( void ) {
 	cg_demoDelayedTeleCount = kept;
 }
 
+static void demoDelagNoteWitnessedTele( int clientNum, int snapServerTime ) {
+	int i;
+	demoWitnessedTele_t *slot;
+
+	if ( clientNum < 0 || clientNum >= MAX_CLIENTS || snapServerTime <= 0 ) {
+		return;
+	}
+	for ( i = 0; i < cg_demoWitnessedTeleCount; i++ ) {
+		if ( cg_demoWitnessedTele[i].clientNum == clientNum
+			&& cg_demoWitnessedTele[i].snapServerTime == snapServerTime ) {
+			return;
+		}
+	}
+	if ( cg_demoWitnessedTeleCount >= CG_DEMO_WITNESSED_TELE_CAP ) {
+		for ( i = 0; i < CG_DEMO_WITNESSED_TELE_CAP - 1; i++ ) {
+			cg_demoWitnessedTele[i] = cg_demoWitnessedTele[i + 1];
+		}
+		cg_demoWitnessedTeleCount = CG_DEMO_WITNESSED_TELE_CAP - 1;
+	}
+	slot = &cg_demoWitnessedTele[cg_demoWitnessedTeleCount++];
+	slot->clientNum = clientNum;
+	slot->snapServerTime = snapServerTime;
+}
+
+static void demoDelagPruneWitnessedTeles( void ) {
+	int i, kept, oldest;
+	const snapshot_t *sn;
+
+	if ( cg_demoWitnessedTeleCount <= 0 ) {
+		return;
+	}
+	oldest = 0;
+	if ( CG_DemoHistory_GetCount() > 0 ) {
+		sn = CG_DemoHistory_GetByFramesAgo( CG_DemoHistory_GetCount() - 1 );
+		if ( sn ) {
+			oldest = sn->serverTime;
+		}
+	}
+	kept = 0;
+	for ( i = 0; i < cg_demoWitnessedTeleCount; i++ ) {
+		if ( oldest > 0 && cg_demoWitnessedTele[i].snapServerTime < oldest ) {
+			continue;
+		}
+		cg_demoWitnessedTele[kept++] = cg_demoWitnessedTele[i];
+	}
+	cg_demoWitnessedTeleCount = kept;
+}
+
+static int demoDelagLatestWitnessedTeleAtOrBefore( int clientNum, int t ) {
+	int i, best;
+
+	best = -1;
+	if ( clientNum < 0 || clientNum >= MAX_CLIENTS ) {
+		return -1;
+	}
+	for ( i = 0; i < cg_demoWitnessedTeleCount; i++ ) {
+		if ( cg_demoWitnessedTele[i].clientNum != clientNum ) {
+			continue;
+		}
+		if ( cg_demoWitnessedTele[i].snapServerTime <= t
+			&& cg_demoWitnessedTele[i].snapServerTime > best ) {
+			best = cg_demoWitnessedTele[i].snapServerTime;
+		}
+	}
+	return best;
+}
+
 static int demoDelagAttackerSampleTime( int attackServerTime ) {
 	int ping;
 
@@ -403,7 +500,7 @@ static void entityPoseFromBracket( int entityNum, int evalTime, const snapshot_t
 		}
 		/* Respawn and teleporters flip EF_TELEPORT_BIT; do not lerp through the world. */
 		if ( demoDelagEFlagsTeleported( esLo.eFlags, esHi.eFlags ) ) {
-			if ( frac < 1.0f ) {
+			if ( evalTime < demoDelagTeleportSwitchTime( entityNum, esLo.eFlags, sOld->serverTime, sNew->serverTime ) ) {
 				demoDelagEvalEsPose( &esLo, sOld->serverTime, outOrigin, outAnglesOpt, outSolidOpt, outEFlagsOpt, outEsOpt );
 			} else {
 				demoDelagEvalEsPose( &esHi, sNew->serverTime, outOrigin, outAnglesOpt, outSolidOpt, outEFlagsOpt, outEsOpt );
@@ -437,6 +534,18 @@ static void entityPoseFromBracket( int entityNum, int evalTime, const snapshot_t
 		return;
 	}
 	if ( hasLo ) {
+		int witnessedTele;
+
+		/*
+		 * After a witnessed tele, do not keep evaluating the last pre-tele
+		 * pose once delayed time has passed the tele snap.
+		 */
+		witnessedTele = ( entityNum >= 0 && entityNum < MAX_CLIENTS )
+			? demoDelagLatestWitnessedTeleAtOrBefore( entityNum, evalTime ) : -1;
+		if ( witnessedTele > sOld->serverTime && evalTime >= witnessedTele ) {
+			*outOk = qfalse;
+			return;
+		}
 		demoDelagEvalEsPose( &esLo, evalTime, outOrigin, outAnglesOpt, outSolidOpt, outEFlagsOpt, outEsOpt );
 		*outOk = qtrue;
 	} else if ( hasHi ) {
@@ -556,7 +665,7 @@ static qboolean demoDelagPoseFromHistoryEnvelope( int entityNum, int tHist, vec3
 		}
 		frac = (float)( tHist - tlo ) / (float)( thi - tlo );
 		if ( demoDelagEFlagsTeleported( esLo.eFlags, esHi.eFlags ) ) {
-			if ( frac < 1.0f ) {
+			if ( tHist < demoDelagTeleportSwitchTime( entityNum, esLo.eFlags, tlo, thi ) ) {
 				demoDelagEvalEsPose( &esLo, tlo, outOrigin, outAngles, NULL, outEFlags, outEs );
 			} else {
 				demoDelagEvalEsPose( &esHi, thi, outOrigin, outAngles, NULL, outEFlags, outEs );
@@ -582,6 +691,13 @@ static qboolean demoDelagPoseFromHistoryEnvelope( int entityNum, int tHist, vec3
 		return qtrue;
 	}
 	if ( hasLo ) {
+		int witnessedTele;
+
+		witnessedTele = ( entityNum >= 0 && entityNum < MAX_CLIENTS )
+			? demoDelagLatestWitnessedTeleAtOrBefore( entityNum, tHist ) : -1;
+		if ( snLo && witnessedTele > snLo->serverTime && tHist >= witnessedTele ) {
+			return qfalse;
+		}
 		demoDelagEvalEsPose( &esLo, tHist, outOrigin, outAngles, NULL, outEFlags, outEs );
 		return qtrue;
 	}
@@ -657,6 +773,44 @@ static void demoDelagApplyVisual( centity_t *cent, const vec3_t origin, const ve
 	cent->demoDelagLastVisualEFlagsValid = qtrue;
 }
 
+static void demoDelagHidePlayerVisual( centity_t *cent ) {
+	int n;
+
+	n = cent->currentState.number;
+	if ( n >= 0 && n < MAX_CLIENTS ) {
+		cg_demoDelagPlayerGone[n] = qtrue;
+	}
+	cent->demoDelagVisualCached = qfalse;
+	cent->demoDelagDrawStateValid = qfalse;
+}
+
+qboolean CG_DemoHistory_SkipPlayerDraw( centity_t *cent ) {
+	int n;
+
+	if ( !cent || cent->currentState.eType != ET_PLAYER ) {
+		return qfalse;
+	}
+	n = cent->currentState.number;
+	if ( n < 0 || n >= MAX_CLIENTS ) {
+		return qfalse;
+	}
+	return cg_demoDelagPlayerGone[n];
+}
+
+static int demoDelagNextSnapTimeAfter( int t ) {
+	int c, i;
+	const snapshot_t *sn;
+
+	c = CG_DemoHistory_GetCount();
+	for ( i = c - 1; i >= 0; i-- ) {
+		sn = CG_DemoHistory_GetByFramesAgo( i );
+		if ( sn && sn->serverTime > t ) {
+			return sn->serverTime;
+		}
+	}
+	return -1;
+}
+
 /*
  * Server time of the first history snap in (tLo, tHi] where this player's
  * teleport bit has flipped from flagsLo. That is the delayed-clock instant
@@ -682,6 +836,60 @@ static int demoDelagFirstTeleportHistoryTime( int entityNum, int flagsLo, int tL
 		}
 	}
 	return tHi;
+}
+
+/*
+ * Instant the delayed view should leave the pre-tele pose. If the player is
+ * missing from intervening snaps (exit out of PVS), the bit flip is only
+ * observed when they reappear; they actually left at the next snap after tLo.
+ */
+static int demoDelagTeleportSwitchTime( int entityNum, int flagsLo, int tLo, int tHi ) {
+	int t, nextSnap, witnessed;
+
+	t = demoDelagFirstTeleportHistoryTime( entityNum, flagsLo, tLo, tHi );
+	if ( entityNum >= 0 && entityNum < MAX_CLIENTS ) {
+		witnessed = demoDelagLatestWitnessedTeleAtOrBefore( entityNum, tHi );
+		if ( witnessed > tLo && witnessed < t ) {
+			t = witnessed;
+		}
+	}
+	nextSnap = demoDelagNextSnapTimeAfter( tLo );
+	if ( nextSnap > tLo && nextSnap < t ) {
+		t = nextSnap;
+	}
+	return t;
+}
+
+static qboolean demoDelagEntityFlagsBefore( int entityNum, int t, int *outFlags ) {
+	int c, i, e;
+	const snapshot_t *sn;
+
+	c = CG_DemoHistory_GetCount();
+	for ( i = 0; i < c; i++ ) {
+		sn = CG_DemoHistory_GetByFramesAgo( i );
+		if ( !sn || sn->serverTime >= t ) {
+			continue;
+		}
+		for ( e = 0; e < sn->numEntities; e++ ) {
+			if ( sn->entities[e].number == entityNum ) {
+				*outFlags = sn->entities[e].eFlags;
+				return qtrue;
+			}
+		}
+	}
+	return qfalse;
+}
+
+static qboolean demoDelagIsPostTeleFlags( int entityNum, int flags, int teleTime ) {
+	int preFlags;
+
+	if ( teleTime <= 0 ) {
+		return qtrue;
+	}
+	if ( !demoDelagEntityFlagsBefore( entityNum, teleTime, &preFlags ) ) {
+		return qtrue;
+	}
+	return demoDelagEFlagsTeleported( preFlags, flags );
 }
 
 void CG_DemoHistory_BeginHitscanRewind( int rewindToServerTime, int skipEntityNum ) {
@@ -743,7 +951,7 @@ void CG_DemoHistory_EndHitscanRewind( void ) {
 
 void CG_DemoHistory_AdjustPlayerLerpForDemoDelag( centity_t *cent ) {
 	int ping;
-	int tLo, tHi;
+	int tLo, tHi, delayed, teleTime, entityNum;
 	vec3_t originLo, anglesLo;
 	vec3_t originHi, anglesHi;
 	vec3_t origin, angles;
@@ -751,6 +959,11 @@ void CG_DemoHistory_AdjustPlayerLerpForDemoDelag( centity_t *cent ) {
 	float f;
 	qboolean okLo, okHi;
 	int flagsLo, flagsHi;
+
+	entityNum = cent->currentState.number;
+	if ( entityNum >= 0 && entityNum < MAX_CLIENTS ) {
+		cg_demoDelagPlayerGone[entityNum] = qfalse;
+	}
 
 	if ( !CG_DemoHistory_DemoDelagActive() || !cg.snap ) {
 		return;
@@ -780,19 +993,33 @@ void CG_DemoHistory_AdjustPlayerLerpForDemoDelag( centity_t *cent ) {
 		f = 1.0f;
 	}
 
+	delayed = cg.time - ping;
+
 	if ( cg.nextSnap && cg.nextSnap->serverTime > cg.snap->serverTime ) {
 		tLo = cg.snap->serverTime - ping;
 		tHi = cg.nextSnap->serverTime - ping;
-		okLo = demoDelagSamplePoseAtTime( cent, cent->currentState.number, tLo, originLo, anglesLo, &flagsLo, &esLo );
-		okHi = demoDelagSamplePoseAtTime( cent, cent->currentState.number, tHi, originHi, anglesHi, &flagsHi, &esHi );
-		if ( okLo && okHi ) {
-			if ( demoDelagEFlagsTeleported( flagsLo, flagsHi ) ) {
-				if ( cg.time - ping >= demoDelagFirstTeleportHistoryTime( cent->currentState.number, flagsLo, tLo, tHi ) ) {
-					demoDelagApplyVisual( cent, originHi, anglesHi, &esHi );
-				} else {
-					demoDelagApplyVisual( cent, originLo, anglesLo, &esLo );
-				}
-			} else {
+		okLo = demoDelagSamplePoseAtTime( cent, entityNum, tLo, originLo, anglesLo, &flagsLo, &esLo );
+		okHi = demoDelagSamplePoseAtTime( cent, entityNum, tHi, originHi, anglesHi, &flagsHi, &esHi );
+
+		teleTime = -1;
+		if ( okLo && okHi && demoDelagEFlagsTeleported( flagsLo, flagsHi ) ) {
+			teleTime = demoDelagTeleportSwitchTime( entityNum, flagsLo, tLo, tHi );
+			if ( delayed < teleTime ) {
+				demoDelagApplyVisual( cent, originLo, anglesLo, &esLo );
+				return;
+			}
+		} else {
+			teleTime = demoDelagLatestWitnessedTeleAtOrBefore( entityNum, delayed );
+		}
+
+		if ( teleTime > 0 && delayed >= teleTime ) {
+			if ( okLo && !demoDelagIsPostTeleFlags( entityNum, flagsLo, teleTime ) ) {
+				okLo = qfalse;
+			}
+			if ( okHi && !demoDelagIsPostTeleFlags( entityNum, flagsHi, teleTime ) ) {
+				okHi = qfalse;
+			}
+			if ( okLo && okHi ) {
 				origin[0] = originLo[0] + f * ( originHi[0] - originLo[0] );
 				origin[1] = originLo[1] + f * ( originHi[1] - originLo[1] );
 				origin[2] = originLo[2] + f * ( originHi[2] - originLo[2] );
@@ -801,7 +1028,29 @@ void CG_DemoHistory_AdjustPlayerLerpForDemoDelag( centity_t *cent ) {
 				angles[2] = LerpAngle( anglesLo[2], anglesHi[2], f );
 				drawEs = esLo;
 				demoDelagApplyVisual( cent, origin, angles, &drawEs );
+				return;
 			}
+			if ( okHi ) {
+				demoDelagApplyVisual( cent, originHi, anglesHi, &esHi );
+				return;
+			}
+			if ( okLo ) {
+				demoDelagApplyVisual( cent, originLo, anglesLo, &esLo );
+				return;
+			}
+			demoDelagHidePlayerVisual( cent );
+			return;
+		}
+
+		if ( okLo && okHi ) {
+			origin[0] = originLo[0] + f * ( originHi[0] - originLo[0] );
+			origin[1] = originLo[1] + f * ( originHi[1] - originLo[1] );
+			origin[2] = originLo[2] + f * ( originHi[2] - originLo[2] );
+			angles[0] = LerpAngle( anglesLo[0], anglesHi[0], f );
+			angles[1] = LerpAngle( anglesLo[1], anglesHi[1], f );
+			angles[2] = LerpAngle( anglesLo[2], anglesHi[2], f );
+			drawEs = esLo;
+			demoDelagApplyVisual( cent, origin, angles, &drawEs );
 			return;
 		}
 		if ( okLo ) {
@@ -814,8 +1063,18 @@ void CG_DemoHistory_AdjustPlayerLerpForDemoDelag( centity_t *cent ) {
 		}
 	} else {
 		tLo = cg.snap->serverTime - ping;
-		if ( demoDelagSamplePoseAtTime( cent, cent->currentState.number, tLo, origin, angles, &flagsLo, &esLo ) ) {
+		teleTime = demoDelagLatestWitnessedTeleAtOrBefore( entityNum, delayed );
+		if ( demoDelagSamplePoseAtTime( cent, entityNum, tLo, origin, angles, &flagsLo, &esLo ) ) {
+			if ( teleTime > 0 && delayed >= teleTime
+				&& !demoDelagIsPostTeleFlags( entityNum, flagsLo, teleTime ) ) {
+				demoDelagHidePlayerVisual( cent );
+				return;
+			}
 			demoDelagApplyVisual( cent, origin, angles, &esLo );
+			return;
+		}
+		if ( teleTime > 0 && delayed >= teleTime ) {
+			demoDelagHidePlayerVisual( cent );
 			return;
 		}
 	}

--- a/ratoa_gamecode/code/cgame/cg_demo_history.h
+++ b/ratoa_gamecode/code/cgame/cg_demo_history.h
@@ -27,5 +27,6 @@ void CG_DemoHistory_BeginHitscanRewind( int rewindToServerTime, int skipEntityNu
 void CG_DemoHistory_EndHitscanRewind( void );
 void CG_DemoHistory_AdjustPlayerLerpForDemoDelag( struct centity_s *cent );
 qboolean CG_DemoHistory_AdjustMissileLerpForDemoDelag( struct centity_s *cent );
+qboolean CG_DemoHistory_SkipPlayerDraw( struct centity_s *cent );
 
 #endif

--- a/ratoa_gamecode/code/cgame/cg_draw.c
+++ b/ratoa_gamecode/code/cgame/cg_draw.c
@@ -4814,6 +4814,11 @@ static void CG_DrawDisconnect( void ) {
 	const char		*s;
 	int			w;  // bk010215 - FIXME char message[1024];
 
+	/* Bypass this entirely during demo playback. Fixes false 'Connection Interrupted' message when using low timescale to slow down a replay. */
+	if ( cg.demoPlayback ) {
+		return;
+	}
+
 	// draw the phone jack if we are completely past our buffers
 	cmdNum = trap_GetCurrentCmdNumber() - CMD_BACKUP + 1;
 	trap_GetUserCmd( cmdNum, &cmd );

--- a/ratoa_gamecode/code/cgame/cg_ents.c
+++ b/ratoa_gamecode/code/cgame/cg_ents.c
@@ -1235,6 +1235,9 @@ static void CG_AddCEntity( centity_t *cent ) {
 	if ( cent->demoDelagMissileNotYet && cent->currentState.eType == ET_MISSILE ) {
 		return;
 	}
+	if ( CG_DemoHistory_SkipPlayerDraw( cent ) ) {
+		return;
+	}
 
 	swappedDrawState = qfalse;
 	if ( cent->demoDelagDrawStateValid && cent->currentState.eType == ET_PLAYER ) {

--- a/ratoa_gamecode/code/cgame/cg_event.c
+++ b/ratoa_gamecode/code/cgame/cg_event.c
@@ -1051,7 +1051,7 @@ void CG_EntityEvent( centity_t *cent, vec3_t position ) {
 		if ( CG_DemoHistory_DelayPlayerTeleportEvent( es->clientNum, EV_PLAYER_TELEPORT_OUT, position ) ) {
 			break;
 		}
-		trap_S_StartSound (NULL, es->number, CHAN_AUTO, cgs.media.teleOutSound );
+		trap_S_StartSound (position, es->number, CHAN_AUTO, cgs.media.teleOutSound );
 		CG_SpawnEffect(  position);
 		break;
 	

--- a/ratoa_gamecode/code/cgame/cg_snapshot.c
+++ b/ratoa_gamecode/code/cgame/cg_snapshot.c
@@ -36,6 +36,7 @@ static void CG_ResetEntity( centity_t *cent ) {
 	// if the previous snapshot this entity was updated in is at least
 	// an event window back in time then we can reset the previous event
 	cent->demoDelagVisualCached = qfalse;
+	cent->demoDelagDrawStateValid = qfalse;
 	if ( cent->snapShotTime < cg.time - EVENT_VALID_MSEC ) {
 		cent->previousEvent = 0;
 	}

--- a/ratoa_gamecode/code/cgame/cg_visualsounds.c
+++ b/ratoa_gamecode/code/cgame/cg_visualsounds.c
@@ -5,7 +5,7 @@
 #define VS_LABEL_LEN		8
 #define VS_GROW_MS		158
 #define VS_HOLD_MS		735
-#define VS_SHRINK_MS		315
+#define VS_SHRINK_MS		473
 #define VS_FADE_MS		( VS_GROW_MS + VS_HOLD_MS + VS_SHRINK_MS )
 #define VS_LOOP_HOLD_MS		80
 #define VS_RANGE		1800.0f
@@ -40,6 +40,7 @@ typedef struct {
 	vec3_t		rgb;
 	vec3_t		origin;
 	qboolean	dim;
+	qboolean	playerFire;
 	qboolean	yawValid;
 	float		worldYaw;
 } vsCue_t;
@@ -217,6 +218,33 @@ static qboolean VS_SfxIsWeaponHum( sfxHandle_t sfx, int *weaponOut ) {
 		if ( ( wi->readySound && wi->readySound == sfx )
 				|| ( wi->firingSound && wi->firingSound == sfx ) ) {
 			*weaponOut = w;
+			return qtrue;
+		}
+	}
+	return qfalse;
+}
+
+static qboolean VS_SfxIsPlayerFire( sfxHandle_t sfx ) {
+	int		w, i;
+	weaponInfo_t	*wi;
+
+	if ( !sfx ) {
+		return qfalse;
+	}
+	if ( sfx == cgs.media.vsGrappleFireSound || sfx == cgs.media.vsGrapplePullSound ) {
+		return qtrue;
+	}
+	for ( w = WP_GAUNTLET; w < WP_NUM_WEAPONS; w++ ) {
+		wi = &cg_weapons[w];
+		if ( !wi->registered ) {
+			continue;
+		}
+		for ( i = 0; i < 4; i++ ) {
+			if ( wi->flashSound[i] && wi->flashSound[i] == sfx ) {
+				return qtrue;
+			}
+		}
+		if ( wi->firingSound && wi->firingSound == sfx ) {
 			return qtrue;
 		}
 	}
@@ -650,11 +678,17 @@ static int VS_RingClass( vsKind_t kind, const char *label ) {
 	return 2;
 }
 
-static int VS_Priority( vsKind_t kind, const char *label, qboolean dim, qboolean looping ) {
+static int VS_Priority( vsKind_t kind, const char *label, qboolean dim, qboolean looping, qboolean playerFire ) {
 	if ( kind == VS_WORLD ) {
 		return 50;
 	}
-	if ( !Q_stricmp( label, "STEP" ) || !Q_stricmp( label, "SWAP" ) ) {
+	if ( !Q_stricmp( label, "STEP" ) ) {
+		return 90;
+	}
+	if ( playerFire ) {
+		return 80;
+	}
+	if ( !Q_stricmp( label, "SWAP" ) ) {
 		return 6;
 	}
 	if ( !Q_stricmp( label, "JUMP" ) || !Q_stricmp( label, "LAND" ) || !Q_stricmp( label, "FALL" )
@@ -719,7 +753,72 @@ static void VS_ContinueChain( vsCue_t *cue, qboolean newLooping, int entityNum, 
 	cue->startTime = oldStart;
 }
 
-static vsCue_t *VS_AcquireCue( int entityNum, const char *label, qboolean looping, vsKind_t kind, qboolean dim, const vec3_t origin, qboolean *rejected ) {
+static qboolean VS_IsStepLabel( const char *label ) {
+	return ( label && !Q_stricmp( label, "STEP" ) );
+}
+
+static qboolean VS_EntityHasNonStepCue( int entityNum ) {
+	int	i;
+
+	if ( entityNum < 0 || entityNum >= MAX_CLIENTS ) {
+		return qfalse;
+	}
+	for ( i = 0; i < VS_MAX_CUES; i++ ) {
+		if ( vsCues[i].active && vsCues[i].entityNum == entityNum
+				&& !VS_IsStepLabel( vsCues[i].label ) ) {
+			return qtrue;
+		}
+	}
+	return qfalse;
+}
+
+static qboolean VS_EntityHasOtherCue( int entityNum ) {
+	int	i;
+
+	if ( entityNum < 0 || entityNum >= MAX_CLIENTS ) {
+		return qfalse;
+	}
+	for ( i = 0; i < VS_MAX_CUES; i++ ) {
+		if ( !vsCues[i].active || vsCues[i].entityNum != entityNum ) {
+			continue;
+		}
+		if ( VS_IsStepLabel( vsCues[i].label ) || vsCues[i].playerFire ) {
+			continue;
+		}
+		return qtrue;
+	}
+	return qfalse;
+}
+
+static void VS_DropStepCuesForEntity( int entityNum ) {
+	int	i;
+
+	if ( entityNum < 0 || entityNum >= MAX_CLIENTS ) {
+		return;
+	}
+	for ( i = 0; i < VS_MAX_CUES; i++ ) {
+		if ( vsCues[i].active && vsCues[i].entityNum == entityNum
+				&& VS_IsStepLabel( vsCues[i].label ) ) {
+			vsCues[i].active = qfalse;
+		}
+	}
+}
+
+static void VS_DropFireCuesForEntity( int entityNum ) {
+	int	i;
+
+	if ( entityNum < 0 || entityNum >= MAX_CLIENTS ) {
+		return;
+	}
+	for ( i = 0; i < VS_MAX_CUES; i++ ) {
+		if ( vsCues[i].active && vsCues[i].entityNum == entityNum
+				&& vsCues[i].playerFire ) {
+			vsCues[i].active = qfalse;
+		}
+	}
+}
+
+static vsCue_t *VS_AcquireCue( int entityNum, const char *label, qboolean looping, vsKind_t kind, qboolean dim, qboolean playerFire, const vec3_t origin, qboolean *rejected ) {
 	int		i;
 	int		prio;
 	int		oldPrio;
@@ -730,7 +829,25 @@ static vsCue_t *VS_AcquireCue( int entityNum, const char *label, qboolean loopin
 	vsCue_t		*freeSlot;
 
 	*rejected = qfalse;
-	prio = VS_Priority( kind, label, dim, looping );
+	prio = VS_Priority( kind, label, dim, looping, playerFire );
+
+	if ( entityNum >= 0 && entityNum < MAX_CLIENTS ) {
+		if ( VS_IsStepLabel( label ) ) {
+			if ( VS_EntityHasNonStepCue( entityNum ) ) {
+				*rejected = qtrue;
+				return NULL;
+			}
+		} else if ( playerFire ) {
+			VS_DropStepCuesForEntity( entityNum );
+			if ( VS_EntityHasOtherCue( entityNum ) ) {
+				*rejected = qtrue;
+				return NULL;
+			}
+		} else if ( kind != VS_WORLD ) {
+			VS_DropStepCuesForEntity( entityNum );
+			VS_DropFireCuesForEntity( entityNum );
+		}
+	}
 
 	for ( i = 0; i < VS_MAX_CUES; i++ ) {
 		if ( vsCues[i].active && vsCues[i].entityNum == entityNum
@@ -752,7 +869,7 @@ static vsCue_t *VS_AcquireCue( int entityNum, const char *label, qboolean loopin
 					!= VS_RingClass( kind, label ) ) {
 				continue;
 			}
-			oldPrio = VS_Priority( vsCues[i].kind, vsCues[i].label, vsCues[i].dim, vsCues[i].looping );
+			oldPrio = VS_Priority( vsCues[i].kind, vsCues[i].label, vsCues[i].dim, vsCues[i].looping, vsCues[i].playerFire );
 			if ( prio > oldPrio ) {
 				*rejected = qtrue;
 				return NULL;
@@ -850,6 +967,7 @@ void CG_VisualSounds_Note( const vec3_t origin, int entityNum, sfxHandle_t sfx, 
 	vec3_t		rgb;
 	qhandle_t	icon;
 	qboolean	dim;
+	qboolean	playerFire;
 	qboolean	rejected;
 	vsCue_t		*cue;
 
@@ -869,7 +987,14 @@ void CG_VisualSounds_Note( const vec3_t origin, int entityNum, sfxHandle_t sfx, 
 		return;
 	}
 
-	cue = VS_AcquireCue( entityNum, label, looping, kind, dim, org, &rejected );
+	/* Pin teleporter entrance to the world so the icon cannot follow the player to the exit. */
+	if ( kind == VS_WORLD && !Q_stricmp( label, "TELE" ) ) {
+		entityNum = ENTITYNUM_WORLD;
+	}
+
+	playerFire = ( entityNum >= 0 && entityNum < MAX_CLIENTS && VS_SfxIsPlayerFire( sfx ) );
+
+	cue = VS_AcquireCue( entityNum, label, looping, kind, dim, playerFire, org, &rejected );
 	if ( rejected || !cue ) {
 		return;
 	}
@@ -880,6 +1005,7 @@ void CG_VisualSounds_Note( const vec3_t origin, int entityNum, sfxHandle_t sfx, 
 	cue->kind = kind;
 	cue->icon = icon;
 	cue->dim = dim;
+	cue->playerFire = playerFire;
 	VectorCopy( rgb, cue->rgb );
 	Q_strncpyz( cue->label, label, sizeof( cue->label ) );
 	VectorCopy( org, cue->origin );
@@ -905,7 +1031,7 @@ void CG_VisualSounds_NoteExplosion( const vec3_t origin, int clientNum, int weap
 	Q_strncpyz( label, "BOOM", sizeof( label ) );
 	VS_SetRgb( rgb, 1.00f, 1.00f, 1.00f );
 
-	cue = VS_AcquireCue( clientNum, label, qfalse, VS_WEAPON, qfalse, origin, &rejected );
+	cue = VS_AcquireCue( clientNum, label, qfalse, VS_WEAPON, qfalse, qfalse, origin, &rejected );
 	if ( rejected || !cue ) {
 		return;
 	}
@@ -915,6 +1041,7 @@ void CG_VisualSounds_NoteExplosion( const vec3_t origin, int clientNum, int weap
 	cue->entityNum = clientNum;
 	cue->kind = VS_WEAPON;
 	cue->dim = qfalse;
+	cue->playerFire = qfalse;
 	cue->icon = cgs.media.vsExplosionIcon;
 	VectorCopy( rgb, cue->rgb );
 	Q_strncpyz( cue->label, label, sizeof( cue->label ) );
@@ -1111,7 +1238,7 @@ void CG_DrawVisualSounds( void ) {
 		icon = 0;
 		rStart[nRoot] = vsCues[i].startTime;
 		rCue[nRoot] = i;
-		rPrio[nRoot] = VS_Priority( vsCues[i].kind, vsCues[i].label, vsCues[i].dim, vsCues[i].looping );
+		rPrio[nRoot] = VS_Priority( vsCues[i].kind, vsCues[i].label, vsCues[i].dim, vsCues[i].looping, vsCues[i].playerFire );
 		rEnt[nRoot] = vsCues[i].entityNum;
 		rLabel[nRoot] = vsCues[i].label;
 		rColor[nRoot][0] = rColor[nRoot][1] = rColor[nRoot][2] = 1.0f;
@@ -1142,7 +1269,7 @@ void CG_DrawVisualSounds( void ) {
 			if ( vsCues[j].startTime < rStart[nRoot] ) {
 				rStart[nRoot] = vsCues[j].startTime;
 			}
-			t = VS_Priority( vsCues[j].kind, vsCues[j].label, vsCues[j].dim, vsCues[j].looping );
+			t = VS_Priority( vsCues[j].kind, vsCues[j].label, vsCues[j].dim, vsCues[j].looping, vsCues[j].playerFire );
 			if ( t < rPrio[nRoot] ) {
 				rPrio[nRoot] = t;
 			}


### PR DESCRIPTION
Four distinct but small tweaks:
- Teleport events handled better during de-lagged replays - Players will no longer briefly 'pop' back to the entrance for a moment after teleporting.
- Re-introduced `make clean` during windows builds, it was a mistake to stop cleaning during build as stale files can cause unexpected issues with the output PK3.
- VSound tweaks - De-emphasized footsteps and weapon fire to make things a lot less cluttered
- Bypassed 'connection interrupted' overlay during demo playback so using `timescale` to slow the demo down now won't produce the annoying message.