### PR TITLE
Publish development releases for every build

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -65,3 +65,22 @@ jobs:
             build/SHA256SUMS
           draft: false
           prerelease: false
+
+      - name: Publish development release
+        if: github.event_name == 'push' && !startsWith(github.ref, 'refs/tags/')
+        uses: softprops/action-gh-release@v3
+        with:
+          tag_name: development-${{ github.sha }}
+          target_commitish: ${{ github.sha }}
+          name: Development build ${{ github.sha }}
+          body: |
+            Development build from `${{ github.ref_name }}` at `${{ github.sha }}`.
+
+            This prerelease is generated automatically from every branch push.
+          files: |
+            build/*.pk3
+            build/SHA256SUMS
+          draft: false
+          prerelease: true
+          make_latest: false
+          generate_release_notes: false

--- a/README.md
+++ b/README.md
@@ -26,6 +26,10 @@ Devotion began as a partial conversion of [RatArena](https://github.com/rdntcntr
 
 **Note:** We recommend starting from a clean mod folder during upgrades.
 
+Development builds are published as prereleases for every push to `main` or `develop`.
+They are available from the [releases page](https://github.com/alcachofass/devotion/releases)
+alongside the stable releases.
+
 ### Alternative method
 1. Load Quake 3 (Quake3e or IOQ3 client recommended)
 2. Pull down the console (`~` key, generally found below `ESC` on a US QWERTY keyboard layout)


### PR DESCRIPTION
## Why

The workflow currently makes build artifacts available only through short-lived Actions artifacts unless a version tag is pushed. This makes it difficult to download and share the latest development build.

## What changed

- Publish a GitHub prerelease for every push to `main` or `develop`.
- Use a commit-SHA-based tag (`development-<sha>`) so every build has a stable, unique release without changing stable tagged releases.
- Keep pull request builds as Actions artifacts only.
- Document where development builds can be downloaded.

The workflow YAML was parsed successfully and the diff passes `git diff --check`.