### PR TITLE
Vsound tweaks

### DIFF
--- a/ratoa_assets/assets/scripts/vsound_icons.shader
+++ b/ratoa_assets/assets/scripts/vsound_icons.shader
@@ -3,9 +3,10 @@
 icons/vsound/light/bfg
 {
 	nopicmip
+	nomipmaps
 	cull none
 	{
-		map icons/vsound/light/bfg.tga
+		clampmap icons/vsound/light/bfg.tga
 		blendFunc GL_SRC_ALPHA GL_ONE_MINUS_SRC_ALPHA
 		rgbGen vertex
 		alphaGen vertex
@@ -16,9 +17,10 @@ icons/vsound/light/bfg
 icons/vsound/light/dead
 {
 	nopicmip
+	nomipmaps
 	cull none
 	{
-		map icons/vsound/light/dead.tga
+		clampmap icons/vsound/light/dead.tga
 		blendFunc GL_SRC_ALPHA GL_ONE_MINUS_SRC_ALPHA
 		rgbGen vertex
 		alphaGen vertex
@@ -29,9 +31,10 @@ icons/vsound/light/dead
 icons/vsound/light/envirosuit
 {
 	nopicmip
+	nomipmaps
 	cull none
 	{
-		map icons/vsound/light/envirosuit.tga
+		clampmap icons/vsound/light/envirosuit.tga
 		blendFunc GL_SRC_ALPHA GL_ONE_MINUS_SRC_ALPHA
 		rgbGen vertex
 		alphaGen vertex
@@ -42,9 +45,10 @@ icons/vsound/light/envirosuit
 icons/vsound/light/explosion
 {
 	nopicmip
+	nomipmaps
 	cull none
 	{
-		map icons/vsound/light/explosion.tga
+		clampmap icons/vsound/light/explosion.tga
 		blendFunc GL_SRC_ALPHA GL_ONE_MINUS_SRC_ALPHA
 		rgbGen vertex
 		alphaGen vertex
@@ -55,9 +59,10 @@ icons/vsound/light/explosion
 icons/vsound/light/footsteps
 {
 	nopicmip
+	nomipmaps
 	cull none
 	{
-		map icons/vsound/light/footsteps.tga
+		clampmap icons/vsound/light/footsteps.tga
 		blendFunc GL_SRC_ALPHA GL_ONE_MINUS_SRC_ALPHA
 		rgbGen vertex
 		alphaGen vertex
@@ -68,9 +73,10 @@ icons/vsound/light/footsteps
 icons/vsound/light/gauntlet
 {
 	nopicmip
+	nomipmaps
 	cull none
 	{
-		map icons/vsound/light/gauntlet.tga
+		clampmap icons/vsound/light/gauntlet.tga
 		blendFunc GL_SRC_ALPHA GL_ONE_MINUS_SRC_ALPHA
 		rgbGen vertex
 		alphaGen vertex
@@ -81,9 +87,10 @@ icons/vsound/light/gauntlet
 icons/vsound/light/grapple
 {
 	nopicmip
+	nomipmaps
 	cull none
 	{
-		map icons/vsound/light/grapple.tga
+		clampmap icons/vsound/light/grapple.tga
 		blendFunc GL_SRC_ALPHA GL_ONE_MINUS_SRC_ALPHA
 		rgbGen vertex
 		alphaGen vertex
@@ -94,9 +101,10 @@ icons/vsound/light/grapple
 icons/vsound/light/grenade
 {
 	nopicmip
+	nomipmaps
 	cull none
 	{
-		map icons/vsound/light/grenade.tga
+		clampmap icons/vsound/light/grenade.tga
 		blendFunc GL_SRC_ALPHA GL_ONE_MINUS_SRC_ALPHA
 		rgbGen vertex
 		alphaGen vertex
@@ -107,9 +115,10 @@ icons/vsound/light/grenade
 icons/vsound/light/haste
 {
 	nopicmip
+	nomipmaps
 	cull none
 	{
-		map icons/vsound/light/haste.tga
+		clampmap icons/vsound/light/haste.tga
 		blendFunc GL_SRC_ALPHA GL_ONE_MINUS_SRC_ALPHA
 		rgbGen vertex
 		alphaGen vertex
@@ -120,9 +129,10 @@ icons/vsound/light/haste
 icons/vsound/light/health_25
 {
 	nopicmip
+	nomipmaps
 	cull none
 	{
-		map icons/vsound/light/health_25.tga
+		clampmap icons/vsound/light/health_25.tga
 		blendFunc GL_SRC_ALPHA GL_ONE_MINUS_SRC_ALPHA
 		rgbGen vertex
 		alphaGen vertex
@@ -133,9 +143,10 @@ icons/vsound/light/health_25
 icons/vsound/light/health_5
 {
 	nopicmip
+	nomipmaps
 	cull none
 	{
-		map icons/vsound/light/health_5.tga
+		clampmap icons/vsound/light/health_5.tga
 		blendFunc GL_SRC_ALPHA GL_ONE_MINUS_SRC_ALPHA
 		rgbGen vertex
 		alphaGen vertex
@@ -146,9 +157,10 @@ icons/vsound/light/health_5
 icons/vsound/light/health_50
 {
 	nopicmip
+	nomipmaps
 	cull none
 	{
-		map icons/vsound/light/health_50.tga
+		clampmap icons/vsound/light/health_50.tga
 		blendFunc GL_SRC_ALPHA GL_ONE_MINUS_SRC_ALPHA
 		rgbGen vertex
 		alphaGen vertex
@@ -159,9 +171,10 @@ icons/vsound/light/health_50
 icons/vsound/light/icona_generic
 {
 	nopicmip
+	nomipmaps
 	cull none
 	{
-		map icons/vsound/light/icona_generic.tga
+		clampmap icons/vsound/light/icona_generic.tga
 		blendFunc GL_SRC_ALPHA GL_ONE_MINUS_SRC_ALPHA
 		rgbGen vertex
 		alphaGen vertex
@@ -172,9 +185,10 @@ icons/vsound/light/icona_generic
 icons/vsound/light/iconr_generic
 {
 	nopicmip
+	nomipmaps
 	cull none
 	{
-		map icons/vsound/light/iconr_generic.tga
+		clampmap icons/vsound/light/iconr_generic.tga
 		blendFunc GL_SRC_ALPHA GL_ONE_MINUS_SRC_ALPHA
 		rgbGen vertex
 		alphaGen vertex
@@ -185,9 +199,10 @@ icons/vsound/light/iconr_generic
 icons/vsound/light/iconw_generic
 {
 	nopicmip
+	nomipmaps
 	cull none
 	{
-		map icons/vsound/light/iconw_generic.tga
+		clampmap icons/vsound/light/iconw_generic.tga
 		blendFunc GL_SRC_ALPHA GL_ONE_MINUS_SRC_ALPHA
 		rgbGen vertex
 		alphaGen vertex
@@ -198,9 +213,10 @@ icons/vsound/light/iconw_generic
 icons/vsound/light/jump
 {
 	nopicmip
+	nomipmaps
 	cull none
 	{
-		map icons/vsound/light/jump.tga
+		clampmap icons/vsound/light/jump.tga
 		blendFunc GL_SRC_ALPHA GL_ONE_MINUS_SRC_ALPHA
 		rgbGen vertex
 		alphaGen vertex
@@ -211,9 +227,10 @@ icons/vsound/light/jump
 icons/vsound/light/jumppad
 {
 	nopicmip
+	nomipmaps
 	cull none
 	{
-		map icons/vsound/light/jumppad.tga
+		clampmap icons/vsound/light/jumppad.tga
 		blendFunc GL_SRC_ALPHA GL_ONE_MINUS_SRC_ALPHA
 		rgbGen vertex
 		alphaGen vertex
@@ -224,9 +241,10 @@ icons/vsound/light/jumppad
 icons/vsound/light/landing
 {
 	nopicmip
+	nomipmaps
 	cull none
 	{
-		map icons/vsound/light/landing.tga
+		clampmap icons/vsound/light/landing.tga
 		blendFunc GL_SRC_ALPHA GL_ONE_MINUS_SRC_ALPHA
 		rgbGen vertex
 		alphaGen vertex
@@ -237,9 +255,10 @@ icons/vsound/light/landing
 icons/vsound/light/lightning
 {
 	nopicmip
+	nomipmaps
 	cull none
 	{
-		map icons/vsound/light/lightning.tga
+		clampmap icons/vsound/light/lightning.tga
 		blendFunc GL_SRC_ALPHA GL_ONE_MINUS_SRC_ALPHA
 		rgbGen vertex
 		alphaGen vertex
@@ -250,9 +269,10 @@ icons/vsound/light/lightning
 icons/vsound/light/machinegun
 {
 	nopicmip
+	nomipmaps
 	cull none
 	{
-		map icons/vsound/light/machinegun.tga
+		clampmap icons/vsound/light/machinegun.tga
 		blendFunc GL_SRC_ALPHA GL_ONE_MINUS_SRC_ALPHA
 		rgbGen vertex
 		alphaGen vertex
@@ -263,9 +283,10 @@ icons/vsound/light/machinegun
 icons/vsound/light/megahealth
 {
 	nopicmip
+	nomipmaps
 	cull none
 	{
-		map icons/vsound/light/megahealth.tga
+		clampmap icons/vsound/light/megahealth.tga
 		blendFunc GL_SRC_ALPHA GL_ONE_MINUS_SRC_ALPHA
 		rgbGen vertex
 		alphaGen vertex
@@ -276,9 +297,10 @@ icons/vsound/light/megahealth
 icons/vsound/light/pain_100
 {
 	nopicmip
+	nomipmaps
 	cull none
 	{
-		map icons/vsound/light/pain_100.tga
+		clampmap icons/vsound/light/pain_100.tga
 		blendFunc GL_SRC_ALPHA GL_ONE_MINUS_SRC_ALPHA
 		rgbGen vertex
 		alphaGen vertex
@@ -289,9 +311,10 @@ icons/vsound/light/pain_100
 icons/vsound/light/pain_25
 {
 	nopicmip
+	nomipmaps
 	cull none
 	{
-		map icons/vsound/light/pain_25.tga
+		clampmap icons/vsound/light/pain_25.tga
 		blendFunc GL_SRC_ALPHA GL_ONE_MINUS_SRC_ALPHA
 		rgbGen vertex
 		alphaGen vertex
@@ -302,9 +325,10 @@ icons/vsound/light/pain_25
 icons/vsound/light/pain_50
 {
 	nopicmip
+	nomipmaps
 	cull none
 	{
-		map icons/vsound/light/pain_50.tga
+		clampmap icons/vsound/light/pain_50.tga
 		blendFunc GL_SRC_ALPHA GL_ONE_MINUS_SRC_ALPHA
 		rgbGen vertex
 		alphaGen vertex
@@ -315,9 +339,10 @@ icons/vsound/light/pain_50
 icons/vsound/light/pain_75
 {
 	nopicmip
+	nomipmaps
 	cull none
 	{
-		map icons/vsound/light/pain_75.tga
+		clampmap icons/vsound/light/pain_75.tga
 		blendFunc GL_SRC_ALPHA GL_ONE_MINUS_SRC_ALPHA
 		rgbGen vertex
 		alphaGen vertex
@@ -328,9 +353,10 @@ icons/vsound/light/pain_75
 icons/vsound/light/plasma
 {
 	nopicmip
+	nomipmaps
 	cull none
 	{
-		map icons/vsound/light/plasma.tga
+		clampmap icons/vsound/light/plasma.tga
 		blendFunc GL_SRC_ALPHA GL_ONE_MINUS_SRC_ALPHA
 		rgbGen vertex
 		alphaGen vertex
@@ -341,9 +367,10 @@ icons/vsound/light/plasma
 icons/vsound/light/powerup
 {
 	nopicmip
+	nomipmaps
 	cull none
 	{
-		map icons/vsound/light/powerup.tga
+		clampmap icons/vsound/light/powerup.tga
 		blendFunc GL_SRC_ALPHA GL_ONE_MINUS_SRC_ALPHA
 		rgbGen vertex
 		alphaGen vertex
@@ -354,9 +381,10 @@ icons/vsound/light/powerup
 icons/vsound/light/quad
 {
 	nopicmip
+	nomipmaps
 	cull none
 	{
-		map icons/vsound/light/quad.tga
+		clampmap icons/vsound/light/quad.tga
 		blendFunc GL_SRC_ALPHA GL_ONE_MINUS_SRC_ALPHA
 		rgbGen vertex
 		alphaGen vertex
@@ -367,9 +395,10 @@ icons/vsound/light/quad
 icons/vsound/light/railgun
 {
 	nopicmip
+	nomipmaps
 	cull none
 	{
-		map icons/vsound/light/railgun.tga
+		clampmap icons/vsound/light/railgun.tga
 		blendFunc GL_SRC_ALPHA GL_ONE_MINUS_SRC_ALPHA
 		rgbGen vertex
 		alphaGen vertex
@@ -380,9 +409,10 @@ icons/vsound/light/railgun
 icons/vsound/light/rocket
 {
 	nopicmip
+	nomipmaps
 	cull none
 	{
-		map icons/vsound/light/rocket.tga
+		clampmap icons/vsound/light/rocket.tga
 		blendFunc GL_SRC_ALPHA GL_ONE_MINUS_SRC_ALPHA
 		rgbGen vertex
 		alphaGen vertex
@@ -393,9 +423,10 @@ icons/vsound/light/rocket
 icons/vsound/light/shard
 {
 	nopicmip
+	nomipmaps
 	cull none
 	{
-		map icons/vsound/light/shard.tga
+		clampmap icons/vsound/light/shard.tga
 		blendFunc GL_SRC_ALPHA GL_ONE_MINUS_SRC_ALPHA
 		rgbGen vertex
 		alphaGen vertex
@@ -406,9 +437,10 @@ icons/vsound/light/shard
 icons/vsound/light/shotgun
 {
 	nopicmip
+	nomipmaps
 	cull none
 	{
-		map icons/vsound/light/shotgun.tga
+		clampmap icons/vsound/light/shotgun.tga
 		blendFunc GL_SRC_ALPHA GL_ONE_MINUS_SRC_ALPHA
 		rgbGen vertex
 		alphaGen vertex
@@ -419,9 +451,10 @@ icons/vsound/light/shotgun
 icons/vsound/light/spawn
 {
 	nopicmip
+	nomipmaps
 	cull none
 	{
-		map icons/vsound/light/spawn.tga
+		clampmap icons/vsound/light/spawn.tga
 		blendFunc GL_SRC_ALPHA GL_ONE_MINUS_SRC_ALPHA
 		rgbGen vertex
 		alphaGen vertex
@@ -432,9 +465,10 @@ icons/vsound/light/spawn
 icons/vsound/light/taunt
 {
 	nopicmip
+	nomipmaps
 	cull none
 	{
-		map icons/vsound/light/taunt.tga
+		clampmap icons/vsound/light/taunt.tga
 		blendFunc GL_SRC_ALPHA GL_ONE_MINUS_SRC_ALPHA
 		rgbGen vertex
 		alphaGen vertex
@@ -445,9 +479,10 @@ icons/vsound/light/taunt
 icons/vsound/light/teleport
 {
 	nopicmip
+	nomipmaps
 	cull none
 	{
-		map icons/vsound/light/teleport.tga
+		clampmap icons/vsound/light/teleport.tga
 		blendFunc GL_SRC_ALPHA GL_ONE_MINUS_SRC_ALPHA
 		rgbGen vertex
 		alphaGen vertex
@@ -458,9 +493,10 @@ icons/vsound/light/teleport
 icons/vsound/light/weapon_swap
 {
 	nopicmip
+	nomipmaps
 	cull none
 	{
-		map icons/vsound/light/weapon_swap.tga
+		clampmap icons/vsound/light/weapon_swap.tga
 		blendFunc GL_SRC_ALPHA GL_ONE_MINUS_SRC_ALPHA
 		rgbGen vertex
 		alphaGen vertex
@@ -471,9 +507,10 @@ icons/vsound/light/weapon_swap
 icons/vsound/dark/bfg
 {
 	nopicmip
+	nomipmaps
 	cull none
 	{
-		map icons/vsound/dark/bfg.tga
+		clampmap icons/vsound/dark/bfg.tga
 		blendFunc GL_SRC_ALPHA GL_ONE_MINUS_SRC_ALPHA
 		rgbGen vertex
 		alphaGen vertex
@@ -484,9 +521,10 @@ icons/vsound/dark/bfg
 icons/vsound/dark/dead
 {
 	nopicmip
+	nomipmaps
 	cull none
 	{
-		map icons/vsound/dark/dead.tga
+		clampmap icons/vsound/dark/dead.tga
 		blendFunc GL_SRC_ALPHA GL_ONE_MINUS_SRC_ALPHA
 		rgbGen vertex
 		alphaGen vertex
@@ -497,9 +535,10 @@ icons/vsound/dark/dead
 icons/vsound/dark/envirosuit
 {
 	nopicmip
+	nomipmaps
 	cull none
 	{
-		map icons/vsound/dark/envirosuit.tga
+		clampmap icons/vsound/dark/envirosuit.tga
 		blendFunc GL_SRC_ALPHA GL_ONE_MINUS_SRC_ALPHA
 		rgbGen vertex
 		alphaGen vertex
@@ -510,9 +549,10 @@ icons/vsound/dark/envirosuit
 icons/vsound/dark/explosion
 {
 	nopicmip
+	nomipmaps
 	cull none
 	{
-		map icons/vsound/dark/explosion.tga
+		clampmap icons/vsound/dark/explosion.tga
 		blendFunc GL_SRC_ALPHA GL_ONE_MINUS_SRC_ALPHA
 		rgbGen vertex
 		alphaGen vertex
@@ -523,9 +563,10 @@ icons/vsound/dark/explosion
 icons/vsound/dark/footsteps
 {
 	nopicmip
+	nomipmaps
 	cull none
 	{
-		map icons/vsound/dark/footsteps.tga
+		clampmap icons/vsound/dark/footsteps.tga
 		blendFunc GL_SRC_ALPHA GL_ONE_MINUS_SRC_ALPHA
 		rgbGen vertex
 		alphaGen vertex
@@ -536,9 +577,10 @@ icons/vsound/dark/footsteps
 icons/vsound/dark/gauntlet
 {
 	nopicmip
+	nomipmaps
 	cull none
 	{
-		map icons/vsound/dark/gauntlet.tga
+		clampmap icons/vsound/dark/gauntlet.tga
 		blendFunc GL_SRC_ALPHA GL_ONE_MINUS_SRC_ALPHA
 		rgbGen vertex
 		alphaGen vertex
@@ -549,9 +591,10 @@ icons/vsound/dark/gauntlet
 icons/vsound/dark/grapple
 {
 	nopicmip
+	nomipmaps
 	cull none
 	{
-		map icons/vsound/dark/grapple.tga
+		clampmap icons/vsound/dark/grapple.tga
 		blendFunc GL_SRC_ALPHA GL_ONE_MINUS_SRC_ALPHA
 		rgbGen vertex
 		alphaGen vertex
@@ -562,9 +605,10 @@ icons/vsound/dark/grapple
 icons/vsound/dark/grenade
 {
 	nopicmip
+	nomipmaps
 	cull none
 	{
-		map icons/vsound/dark/grenade.tga
+		clampmap icons/vsound/dark/grenade.tga
 		blendFunc GL_SRC_ALPHA GL_ONE_MINUS_SRC_ALPHA
 		rgbGen vertex
 		alphaGen vertex
@@ -575,9 +619,10 @@ icons/vsound/dark/grenade
 icons/vsound/dark/haste
 {
 	nopicmip
+	nomipmaps
 	cull none
 	{
-		map icons/vsound/dark/haste.tga
+		clampmap icons/vsound/dark/haste.tga
 		blendFunc GL_SRC_ALPHA GL_ONE_MINUS_SRC_ALPHA
 		rgbGen vertex
 		alphaGen vertex
@@ -588,9 +633,10 @@ icons/vsound/dark/haste
 icons/vsound/dark/health_25
 {
 	nopicmip
+	nomipmaps
 	cull none
 	{
-		map icons/vsound/dark/health_25.tga
+		clampmap icons/vsound/dark/health_25.tga
 		blendFunc GL_SRC_ALPHA GL_ONE_MINUS_SRC_ALPHA
 		rgbGen vertex
 		alphaGen vertex
@@ -601,9 +647,10 @@ icons/vsound/dark/health_25
 icons/vsound/dark/health_5
 {
 	nopicmip
+	nomipmaps
 	cull none
 	{
-		map icons/vsound/dark/health_5.tga
+		clampmap icons/vsound/dark/health_5.tga
 		blendFunc GL_SRC_ALPHA GL_ONE_MINUS_SRC_ALPHA
 		rgbGen vertex
 		alphaGen vertex
@@ -614,9 +661,10 @@ icons/vsound/dark/health_5
 icons/vsound/dark/health_50
 {
 	nopicmip
+	nomipmaps
 	cull none
 	{
-		map icons/vsound/dark/health_50.tga
+		clampmap icons/vsound/dark/health_50.tga
 		blendFunc GL_SRC_ALPHA GL_ONE_MINUS_SRC_ALPHA
 		rgbGen vertex
 		alphaGen vertex
@@ -627,9 +675,10 @@ icons/vsound/dark/health_50
 icons/vsound/dark/icona_generic
 {
 	nopicmip
+	nomipmaps
 	cull none
 	{
-		map icons/vsound/dark/icona_generic.tga
+		clampmap icons/vsound/dark/icona_generic.tga
 		blendFunc GL_SRC_ALPHA GL_ONE_MINUS_SRC_ALPHA
 		rgbGen vertex
 		alphaGen vertex
@@ -640,9 +689,10 @@ icons/vsound/dark/icona_generic
 icons/vsound/dark/iconr_generic
 {
 	nopicmip
+	nomipmaps
 	cull none
 	{
-		map icons/vsound/dark/iconr_generic.tga
+		clampmap icons/vsound/dark/iconr_generic.tga
 		blendFunc GL_SRC_ALPHA GL_ONE_MINUS_SRC_ALPHA
 		rgbGen vertex
 		alphaGen vertex
@@ -653,9 +703,10 @@ icons/vsound/dark/iconr_generic
 icons/vsound/dark/iconw_generic
 {
 	nopicmip
+	nomipmaps
 	cull none
 	{
-		map icons/vsound/dark/iconw_generic.tga
+		clampmap icons/vsound/dark/iconw_generic.tga
 		blendFunc GL_SRC_ALPHA GL_ONE_MINUS_SRC_ALPHA
 		rgbGen vertex
 		alphaGen vertex
@@ -666,9 +717,10 @@ icons/vsound/dark/iconw_generic
 icons/vsound/dark/jump
 {
 	nopicmip
+	nomipmaps
 	cull none
 	{
-		map icons/vsound/dark/jump.tga
+		clampmap icons/vsound/dark/jump.tga
 		blendFunc GL_SRC_ALPHA GL_ONE_MINUS_SRC_ALPHA
 		rgbGen vertex
 		alphaGen vertex
@@ -679,9 +731,10 @@ icons/vsound/dark/jump
 icons/vsound/dark/jumppad
 {
 	nopicmip
+	nomipmaps
 	cull none
 	{
-		map icons/vsound/dark/jumppad.tga
+		clampmap icons/vsound/dark/jumppad.tga
 		blendFunc GL_SRC_ALPHA GL_ONE_MINUS_SRC_ALPHA
 		rgbGen vertex
 		alphaGen vertex
@@ -692,9 +745,10 @@ icons/vsound/dark/jumppad
 icons/vsound/dark/landing
 {
 	nopicmip
+	nomipmaps
 	cull none
 	{
-		map icons/vsound/dark/landing.tga
+		clampmap icons/vsound/dark/landing.tga
 		blendFunc GL_SRC_ALPHA GL_ONE_MINUS_SRC_ALPHA
 		rgbGen vertex
 		alphaGen vertex
@@ -705,9 +759,10 @@ icons/vsound/dark/landing
 icons/vsound/dark/lightning
 {
 	nopicmip
+	nomipmaps
 	cull none
 	{
-		map icons/vsound/dark/lightning.tga
+		clampmap icons/vsound/dark/lightning.tga
 		blendFunc GL_SRC_ALPHA GL_ONE_MINUS_SRC_ALPHA
 		rgbGen vertex
 		alphaGen vertex
@@ -718,9 +773,10 @@ icons/vsound/dark/lightning
 icons/vsound/dark/machinegun
 {
 	nopicmip
+	nomipmaps
 	cull none
 	{
-		map icons/vsound/dark/machinegun.tga
+		clampmap icons/vsound/dark/machinegun.tga
 		blendFunc GL_SRC_ALPHA GL_ONE_MINUS_SRC_ALPHA
 		rgbGen vertex
 		alphaGen vertex
@@ -731,9 +787,10 @@ icons/vsound/dark/machinegun
 icons/vsound/dark/megahealth
 {
 	nopicmip
+	nomipmaps
 	cull none
 	{
-		map icons/vsound/dark/megahealth.tga
+		clampmap icons/vsound/dark/megahealth.tga
 		blendFunc GL_SRC_ALPHA GL_ONE_MINUS_SRC_ALPHA
 		rgbGen vertex
 		alphaGen vertex
@@ -744,9 +801,10 @@ icons/vsound/dark/megahealth
 icons/vsound/dark/pain_100
 {
 	nopicmip
+	nomipmaps
 	cull none
 	{
-		map icons/vsound/dark/pain_100.tga
+		clampmap icons/vsound/dark/pain_100.tga
 		blendFunc GL_SRC_ALPHA GL_ONE_MINUS_SRC_ALPHA
 		rgbGen vertex
 		alphaGen vertex
@@ -757,9 +815,10 @@ icons/vsound/dark/pain_100
 icons/vsound/dark/pain_25
 {
 	nopicmip
+	nomipmaps
 	cull none
 	{
-		map icons/vsound/dark/pain_25.tga
+		clampmap icons/vsound/dark/pain_25.tga
 		blendFunc GL_SRC_ALPHA GL_ONE_MINUS_SRC_ALPHA
 		rgbGen vertex
 		alphaGen vertex
@@ -770,9 +829,10 @@ icons/vsound/dark/pain_25
 icons/vsound/dark/pain_50
 {
 	nopicmip
+	nomipmaps
 	cull none
 	{
-		map icons/vsound/dark/pain_50.tga
+		clampmap icons/vsound/dark/pain_50.tga
 		blendFunc GL_SRC_ALPHA GL_ONE_MINUS_SRC_ALPHA
 		rgbGen vertex
 		alphaGen vertex
@@ -783,9 +843,10 @@ icons/vsound/dark/pain_50
 icons/vsound/dark/pain_75
 {
 	nopicmip
+	nomipmaps
 	cull none
 	{
-		map icons/vsound/dark/pain_75.tga
+		clampmap icons/vsound/dark/pain_75.tga
 		blendFunc GL_SRC_ALPHA GL_ONE_MINUS_SRC_ALPHA
 		rgbGen vertex
 		alphaGen vertex
@@ -796,9 +857,10 @@ icons/vsound/dark/pain_75
 icons/vsound/dark/plasma
 {
 	nopicmip
+	nomipmaps
 	cull none
 	{
-		map icons/vsound/dark/plasma.tga
+		clampmap icons/vsound/dark/plasma.tga
 		blendFunc GL_SRC_ALPHA GL_ONE_MINUS_SRC_ALPHA
 		rgbGen vertex
 		alphaGen vertex
@@ -809,9 +871,10 @@ icons/vsound/dark/plasma
 icons/vsound/dark/powerup
 {
 	nopicmip
+	nomipmaps
 	cull none
 	{
-		map icons/vsound/dark/powerup.tga
+		clampmap icons/vsound/dark/powerup.tga
 		blendFunc GL_SRC_ALPHA GL_ONE_MINUS_SRC_ALPHA
 		rgbGen vertex
 		alphaGen vertex
@@ -822,9 +885,10 @@ icons/vsound/dark/powerup
 icons/vsound/dark/quad
 {
 	nopicmip
+	nomipmaps
 	cull none
 	{
-		map icons/vsound/dark/quad.tga
+		clampmap icons/vsound/dark/quad.tga
 		blendFunc GL_SRC_ALPHA GL_ONE_MINUS_SRC_ALPHA
 		rgbGen vertex
 		alphaGen vertex
@@ -835,9 +899,10 @@ icons/vsound/dark/quad
 icons/vsound/dark/railgun
 {
 	nopicmip
+	nomipmaps
 	cull none
 	{
-		map icons/vsound/dark/railgun.tga
+		clampmap icons/vsound/dark/railgun.tga
 		blendFunc GL_SRC_ALPHA GL_ONE_MINUS_SRC_ALPHA
 		rgbGen vertex
 		alphaGen vertex
@@ -848,9 +913,10 @@ icons/vsound/dark/railgun
 icons/vsound/dark/rocket
 {
 	nopicmip
+	nomipmaps
 	cull none
 	{
-		map icons/vsound/dark/rocket.tga
+		clampmap icons/vsound/dark/rocket.tga
 		blendFunc GL_SRC_ALPHA GL_ONE_MINUS_SRC_ALPHA
 		rgbGen vertex
 		alphaGen vertex
@@ -861,9 +927,10 @@ icons/vsound/dark/rocket
 icons/vsound/dark/shard
 {
 	nopicmip
+	nomipmaps
 	cull none
 	{
-		map icons/vsound/dark/shard.tga
+		clampmap icons/vsound/dark/shard.tga
 		blendFunc GL_SRC_ALPHA GL_ONE_MINUS_SRC_ALPHA
 		rgbGen vertex
 		alphaGen vertex
@@ -874,9 +941,10 @@ icons/vsound/dark/shard
 icons/vsound/dark/shotgun
 {
 	nopicmip
+	nomipmaps
 	cull none
 	{
-		map icons/vsound/dark/shotgun.tga
+		clampmap icons/vsound/dark/shotgun.tga
 		blendFunc GL_SRC_ALPHA GL_ONE_MINUS_SRC_ALPHA
 		rgbGen vertex
 		alphaGen vertex
@@ -887,9 +955,10 @@ icons/vsound/dark/shotgun
 icons/vsound/dark/spawn
 {
 	nopicmip
+	nomipmaps
 	cull none
 	{
-		map icons/vsound/dark/spawn.tga
+		clampmap icons/vsound/dark/spawn.tga
 		blendFunc GL_SRC_ALPHA GL_ONE_MINUS_SRC_ALPHA
 		rgbGen vertex
 		alphaGen vertex
@@ -900,9 +969,10 @@ icons/vsound/dark/spawn
 icons/vsound/dark/taunt
 {
 	nopicmip
+	nomipmaps
 	cull none
 	{
-		map icons/vsound/dark/taunt.tga
+		clampmap icons/vsound/dark/taunt.tga
 		blendFunc GL_SRC_ALPHA GL_ONE_MINUS_SRC_ALPHA
 		rgbGen vertex
 		alphaGen vertex
@@ -913,9 +983,10 @@ icons/vsound/dark/taunt
 icons/vsound/dark/teleport
 {
 	nopicmip
+	nomipmaps
 	cull none
 	{
-		map icons/vsound/dark/teleport.tga
+		clampmap icons/vsound/dark/teleport.tga
 		blendFunc GL_SRC_ALPHA GL_ONE_MINUS_SRC_ALPHA
 		rgbGen vertex
 		alphaGen vertex
@@ -926,9 +997,10 @@ icons/vsound/dark/teleport
 icons/vsound/dark/weapon_swap
 {
 	nopicmip
+	nomipmaps
 	cull none
 	{
-		map icons/vsound/dark/weapon_swap.tga
+		clampmap icons/vsound/dark/weapon_swap.tga
 		blendFunc GL_SRC_ALPHA GL_ONE_MINUS_SRC_ALPHA
 		rgbGen vertex
 		alphaGen vertex
@@ -939,9 +1011,10 @@ icons/vsound/dark/weapon_swap
 icons/vsound/color/bfg
 {
 	nopicmip
+	nomipmaps
 	cull none
 	{
-		map icons/vsound/color/bfg.tga
+		clampmap icons/vsound/color/bfg.tga
 		blendFunc GL_SRC_ALPHA GL_ONE_MINUS_SRC_ALPHA
 		rgbGen vertex
 		alphaGen vertex
@@ -952,9 +1025,10 @@ icons/vsound/color/bfg
 icons/vsound/color/dead
 {
 	nopicmip
+	nomipmaps
 	cull none
 	{
-		map icons/vsound/color/dead.tga
+		clampmap icons/vsound/color/dead.tga
 		blendFunc GL_SRC_ALPHA GL_ONE_MINUS_SRC_ALPHA
 		rgbGen vertex
 		alphaGen vertex
@@ -965,9 +1039,10 @@ icons/vsound/color/dead
 icons/vsound/color/envirosuit
 {
 	nopicmip
+	nomipmaps
 	cull none
 	{
-		map icons/vsound/color/envirosuit.tga
+		clampmap icons/vsound/color/envirosuit.tga
 		blendFunc GL_SRC_ALPHA GL_ONE_MINUS_SRC_ALPHA
 		rgbGen vertex
 		alphaGen vertex
@@ -978,9 +1053,10 @@ icons/vsound/color/envirosuit
 icons/vsound/color/explosion
 {
 	nopicmip
+	nomipmaps
 	cull none
 	{
-		map icons/vsound/color/explosion.tga
+		clampmap icons/vsound/color/explosion.tga
 		blendFunc GL_SRC_ALPHA GL_ONE_MINUS_SRC_ALPHA
 		rgbGen vertex
 		alphaGen vertex
@@ -991,9 +1067,10 @@ icons/vsound/color/explosion
 icons/vsound/color/footsteps
 {
 	nopicmip
+	nomipmaps
 	cull none
 	{
-		map icons/vsound/color/footsteps.tga
+		clampmap icons/vsound/color/footsteps.tga
 		blendFunc GL_SRC_ALPHA GL_ONE_MINUS_SRC_ALPHA
 		rgbGen vertex
 		alphaGen vertex
@@ -1004,9 +1081,10 @@ icons/vsound/color/footsteps
 icons/vsound/color/gauntlet
 {
 	nopicmip
+	nomipmaps
 	cull none
 	{
-		map icons/vsound/color/gauntlet.tga
+		clampmap icons/vsound/color/gauntlet.tga
 		blendFunc GL_SRC_ALPHA GL_ONE_MINUS_SRC_ALPHA
 		rgbGen vertex
 		alphaGen vertex
@@ -1017,9 +1095,10 @@ icons/vsound/color/gauntlet
 icons/vsound/color/grapple
 {
 	nopicmip
+	nomipmaps
 	cull none
 	{
-		map icons/vsound/color/grapple.tga
+		clampmap icons/vsound/color/grapple.tga
 		blendFunc GL_SRC_ALPHA GL_ONE_MINUS_SRC_ALPHA
 		rgbGen vertex
 		alphaGen vertex
@@ -1030,9 +1109,10 @@ icons/vsound/color/grapple
 icons/vsound/color/grenade
 {
 	nopicmip
+	nomipmaps
 	cull none
 	{
-		map icons/vsound/color/grenade.tga
+		clampmap icons/vsound/color/grenade.tga
 		blendFunc GL_SRC_ALPHA GL_ONE_MINUS_SRC_ALPHA
 		rgbGen vertex
 		alphaGen vertex
@@ -1043,9 +1123,10 @@ icons/vsound/color/grenade
 icons/vsound/color/haste
 {
 	nopicmip
+	nomipmaps
 	cull none
 	{
-		map icons/vsound/color/haste.tga
+		clampmap icons/vsound/color/haste.tga
 		blendFunc GL_SRC_ALPHA GL_ONE_MINUS_SRC_ALPHA
 		rgbGen vertex
 		alphaGen vertex
@@ -1056,9 +1137,10 @@ icons/vsound/color/haste
 icons/vsound/color/health_25
 {
 	nopicmip
+	nomipmaps
 	cull none
 	{
-		map icons/vsound/color/health_25.tga
+		clampmap icons/vsound/color/health_25.tga
 		blendFunc GL_SRC_ALPHA GL_ONE_MINUS_SRC_ALPHA
 		rgbGen vertex
 		alphaGen vertex
@@ -1069,9 +1151,10 @@ icons/vsound/color/health_25
 icons/vsound/color/health_5
 {
 	nopicmip
+	nomipmaps
 	cull none
 	{
-		map icons/vsound/color/health_5.tga
+		clampmap icons/vsound/color/health_5.tga
 		blendFunc GL_SRC_ALPHA GL_ONE_MINUS_SRC_ALPHA
 		rgbGen vertex
 		alphaGen vertex
@@ -1082,9 +1165,10 @@ icons/vsound/color/health_5
 icons/vsound/color/health_50
 {
 	nopicmip
+	nomipmaps
 	cull none
 	{
-		map icons/vsound/color/health_50.tga
+		clampmap icons/vsound/color/health_50.tga
 		blendFunc GL_SRC_ALPHA GL_ONE_MINUS_SRC_ALPHA
 		rgbGen vertex
 		alphaGen vertex
@@ -1095,9 +1179,10 @@ icons/vsound/color/health_50
 icons/vsound/color/icona_generic
 {
 	nopicmip
+	nomipmaps
 	cull none
 	{
-		map icons/vsound/color/icona_generic.tga
+		clampmap icons/vsound/color/icona_generic.tga
 		blendFunc GL_SRC_ALPHA GL_ONE_MINUS_SRC_ALPHA
 		rgbGen vertex
 		alphaGen vertex
@@ -1108,9 +1193,10 @@ icons/vsound/color/icona_generic
 icons/vsound/color/iconr_generic
 {
 	nopicmip
+	nomipmaps
 	cull none
 	{
-		map icons/vsound/color/iconr_generic.tga
+		clampmap icons/vsound/color/iconr_generic.tga
 		blendFunc GL_SRC_ALPHA GL_ONE_MINUS_SRC_ALPHA
 		rgbGen vertex
 		alphaGen vertex
@@ -1121,9 +1207,10 @@ icons/vsound/color/iconr_generic
 icons/vsound/color/iconw_generic
 {
 	nopicmip
+	nomipmaps
 	cull none
 	{
-		map icons/vsound/color/iconw_generic.tga
+		clampmap icons/vsound/color/iconw_generic.tga
 		blendFunc GL_SRC_ALPHA GL_ONE_MINUS_SRC_ALPHA
 		rgbGen vertex
 		alphaGen vertex
@@ -1134,9 +1221,10 @@ icons/vsound/color/iconw_generic
 icons/vsound/color/jump
 {
 	nopicmip
+	nomipmaps
 	cull none
 	{
-		map icons/vsound/color/jump.tga
+		clampmap icons/vsound/color/jump.tga
 		blendFunc GL_SRC_ALPHA GL_ONE_MINUS_SRC_ALPHA
 		rgbGen vertex
 		alphaGen vertex
@@ -1147,9 +1235,10 @@ icons/vsound/color/jump
 icons/vsound/color/jumppad
 {
 	nopicmip
+	nomipmaps
 	cull none
 	{
-		map icons/vsound/color/jumppad.tga
+		clampmap icons/vsound/color/jumppad.tga
 		blendFunc GL_SRC_ALPHA GL_ONE_MINUS_SRC_ALPHA
 		rgbGen vertex
 		alphaGen vertex
@@ -1160,9 +1249,10 @@ icons/vsound/color/jumppad
 icons/vsound/color/landing
 {
 	nopicmip
+	nomipmaps
 	cull none
 	{
-		map icons/vsound/color/landing.tga
+		clampmap icons/vsound/color/landing.tga
 		blendFunc GL_SRC_ALPHA GL_ONE_MINUS_SRC_ALPHA
 		rgbGen vertex
 		alphaGen vertex
@@ -1173,9 +1263,10 @@ icons/vsound/color/landing
 icons/vsound/color/lightning
 {
 	nopicmip
+	nomipmaps
 	cull none
 	{
-		map icons/vsound/color/lightning.tga
+		clampmap icons/vsound/color/lightning.tga
 		blendFunc GL_SRC_ALPHA GL_ONE_MINUS_SRC_ALPHA
 		rgbGen vertex
 		alphaGen vertex
@@ -1186,9 +1277,10 @@ icons/vsound/color/lightning
 icons/vsound/color/machinegun
 {
 	nopicmip
+	nomipmaps
 	cull none
 	{
-		map icons/vsound/color/machinegun.tga
+		clampmap icons/vsound/color/machinegun.tga
 		blendFunc GL_SRC_ALPHA GL_ONE_MINUS_SRC_ALPHA
 		rgbGen vertex
 		alphaGen vertex
@@ -1199,9 +1291,10 @@ icons/vsound/color/machinegun
 icons/vsound/color/megahealth
 {
 	nopicmip
+	nomipmaps
 	cull none
 	{
-		map icons/vsound/color/megahealth.tga
+		clampmap icons/vsound/color/megahealth.tga
 		blendFunc GL_SRC_ALPHA GL_ONE_MINUS_SRC_ALPHA
 		rgbGen vertex
 		alphaGen vertex
@@ -1212,9 +1305,10 @@ icons/vsound/color/megahealth
 icons/vsound/color/pain_100
 {
 	nopicmip
+	nomipmaps
 	cull none
 	{
-		map icons/vsound/color/pain_100.tga
+		clampmap icons/vsound/color/pain_100.tga
 		blendFunc GL_SRC_ALPHA GL_ONE_MINUS_SRC_ALPHA
 		rgbGen vertex
 		alphaGen vertex
@@ -1225,9 +1319,10 @@ icons/vsound/color/pain_100
 icons/vsound/color/pain_25
 {
 	nopicmip
+	nomipmaps
 	cull none
 	{
-		map icons/vsound/color/pain_25.tga
+		clampmap icons/vsound/color/pain_25.tga
 		blendFunc GL_SRC_ALPHA GL_ONE_MINUS_SRC_ALPHA
 		rgbGen vertex
 		alphaGen vertex
@@ -1238,9 +1333,10 @@ icons/vsound/color/pain_25
 icons/vsound/color/pain_50
 {
 	nopicmip
+	nomipmaps
 	cull none
 	{
-		map icons/vsound/color/pain_50.tga
+		clampmap icons/vsound/color/pain_50.tga
 		blendFunc GL_SRC_ALPHA GL_ONE_MINUS_SRC_ALPHA
 		rgbGen vertex
 		alphaGen vertex
@@ -1251,9 +1347,10 @@ icons/vsound/color/pain_50
 icons/vsound/color/pain_75
 {
 	nopicmip
+	nomipmaps
 	cull none
 	{
-		map icons/vsound/color/pain_75.tga
+		clampmap icons/vsound/color/pain_75.tga
 		blendFunc GL_SRC_ALPHA GL_ONE_MINUS_SRC_ALPHA
 		rgbGen vertex
 		alphaGen vertex
@@ -1264,9 +1361,10 @@ icons/vsound/color/pain_75
 icons/vsound/color/plasma
 {
 	nopicmip
+	nomipmaps
 	cull none
 	{
-		map icons/vsound/color/plasma.tga
+		clampmap icons/vsound/color/plasma.tga
 		blendFunc GL_SRC_ALPHA GL_ONE_MINUS_SRC_ALPHA
 		rgbGen vertex
 		alphaGen vertex
@@ -1277,9 +1375,10 @@ icons/vsound/color/plasma
 icons/vsound/color/powerup
 {
 	nopicmip
+	nomipmaps
 	cull none
 	{
-		map icons/vsound/color/powerup.tga
+		clampmap icons/vsound/color/powerup.tga
 		blendFunc GL_SRC_ALPHA GL_ONE_MINUS_SRC_ALPHA
 		rgbGen vertex
 		alphaGen vertex
@@ -1290,9 +1389,10 @@ icons/vsound/color/powerup
 icons/vsound/color/quad
 {
 	nopicmip
+	nomipmaps
 	cull none
 	{
-		map icons/vsound/color/quad.tga
+		clampmap icons/vsound/color/quad.tga
 		blendFunc GL_SRC_ALPHA GL_ONE_MINUS_SRC_ALPHA
 		rgbGen vertex
 		alphaGen vertex
@@ -1303,9 +1403,10 @@ icons/vsound/color/quad
 icons/vsound/color/railgun
 {
 	nopicmip
+	nomipmaps
 	cull none
 	{
-		map icons/vsound/color/railgun.tga
+		clampmap icons/vsound/color/railgun.tga
 		blendFunc GL_SRC_ALPHA GL_ONE_MINUS_SRC_ALPHA
 		rgbGen vertex
 		alphaGen vertex
@@ -1316,9 +1417,10 @@ icons/vsound/color/railgun
 icons/vsound/color/rocket
 {
 	nopicmip
+	nomipmaps
 	cull none
 	{
-		map icons/vsound/color/rocket.tga
+		clampmap icons/vsound/color/rocket.tga
 		blendFunc GL_SRC_ALPHA GL_ONE_MINUS_SRC_ALPHA
 		rgbGen vertex
 		alphaGen vertex
@@ -1329,9 +1431,10 @@ icons/vsound/color/rocket
 icons/vsound/color/shard
 {
 	nopicmip
+	nomipmaps
 	cull none
 	{
-		map icons/vsound/color/shard.tga
+		clampmap icons/vsound/color/shard.tga
 		blendFunc GL_SRC_ALPHA GL_ONE_MINUS_SRC_ALPHA
 		rgbGen vertex
 		alphaGen vertex
@@ -1342,9 +1445,10 @@ icons/vsound/color/shard
 icons/vsound/color/shotgun
 {
 	nopicmip
+	nomipmaps
 	cull none
 	{
-		map icons/vsound/color/shotgun.tga
+		clampmap icons/vsound/color/shotgun.tga
 		blendFunc GL_SRC_ALPHA GL_ONE_MINUS_SRC_ALPHA
 		rgbGen vertex
 		alphaGen vertex
@@ -1355,9 +1459,10 @@ icons/vsound/color/shotgun
 icons/vsound/color/spawn
 {
 	nopicmip
+	nomipmaps
 	cull none
 	{
-		map icons/vsound/color/spawn.tga
+		clampmap icons/vsound/color/spawn.tga
 		blendFunc GL_SRC_ALPHA GL_ONE_MINUS_SRC_ALPHA
 		rgbGen vertex
 		alphaGen vertex
@@ -1368,9 +1473,10 @@ icons/vsound/color/spawn
 icons/vsound/color/taunt
 {
 	nopicmip
+	nomipmaps
 	cull none
 	{
-		map icons/vsound/color/taunt.tga
+		clampmap icons/vsound/color/taunt.tga
 		blendFunc GL_SRC_ALPHA GL_ONE_MINUS_SRC_ALPHA
 		rgbGen vertex
 		alphaGen vertex
@@ -1381,9 +1487,10 @@ icons/vsound/color/taunt
 icons/vsound/color/teleport
 {
 	nopicmip
+	nomipmaps
 	cull none
 	{
-		map icons/vsound/color/teleport.tga
+		clampmap icons/vsound/color/teleport.tga
 		blendFunc GL_SRC_ALPHA GL_ONE_MINUS_SRC_ALPHA
 		rgbGen vertex
 		alphaGen vertex
@@ -1394,9 +1501,10 @@ icons/vsound/color/teleport
 icons/vsound/color/weapon_swap
 {
 	nopicmip
+	nomipmaps
 	cull none
 	{
-		map icons/vsound/color/weapon_swap.tga
+		clampmap icons/vsound/color/weapon_swap.tga
 		blendFunc GL_SRC_ALPHA GL_ONE_MINUS_SRC_ALPHA
 		rgbGen vertex
 		alphaGen vertex

--- a/ratoa_gamecode/code/cgame/cg_visualsounds.c
+++ b/ratoa_gamecode/code/cgame/cg_visualsounds.c
@@ -11,9 +11,6 @@
 #define VS_RANGE		1800.0f
 #define VS_RADIUS		70.0f
 #define VS_CLUSTER_DEG		38.0f
-#define VS_STACK_DEG		16.0f
-#define VS_STACK_MAX		3
-#define VS_STACK_GAP		16.0f
 #define VS_ARC_SPAN		34.0f
 #define VS_ARC_SEGS		16
 #define VS_ARC_INSET		12.0f
@@ -1139,9 +1136,9 @@ void CG_DrawVisualSounds( void ) {
 	qboolean	live[VS_MAX_CUES];
 	vec3_t		delta;
 	vec4_t		color;
-	float		yaw, dist, radius, cx, cy, x, y, ang, dAng;
+	float		yaw, dist, cx, cy, x, y, ang, dAng;
 	float		cw, ch, sz, sumSin, sumCos, bestLoud, bestFade, weight;
-	int		len, count, nRoot, r, s, t, nMem, kept, swap;
+	int		len, count, nRoot, r, s, t, nMem, kept;
 	qhandle_t	icon;
 	const char	*label;
 	float		rAng[VS_MAX_CUES];
@@ -1294,9 +1291,7 @@ void CG_DrawVisualSounds( void ) {
 
 	for ( r = 0; r < nRoot; r++ ) {
 		for ( s = r + 1; s < nRoot; s++ ) {
-			dAng = Q_fabs( AngleNormalize180( rAng[r] - rAng[s] ) );
-			if ( dAng > VS_STACK_DEG
-					&& !( rEnt[r] >= 0 && rEnt[r] < MAX_CLIENTS && rEnt[r] == rEnt[s] ) ) {
+			if ( rEnt[r] < 0 || rEnt[r] >= MAX_CLIENTS || rEnt[r] != rEnt[s] ) {
 				continue;
 			}
 			stackPar[VS_ClusterRoot( stackPar, s )] = VS_ClusterRoot( stackPar, r );
@@ -1315,29 +1310,15 @@ void CG_DrawVisualSounds( void ) {
 			mem[nMem] = s;
 			nMem++;
 		}
-		while ( nMem > VS_STACK_MAX ) {
-			kept = 0;
-			for ( t = 1; t < nMem; t++ ) {
-				if ( rPrio[mem[t]] > rPrio[mem[kept]]
-						|| ( rPrio[mem[t]] == rPrio[mem[kept]] && rStart[mem[t]] > rStart[mem[kept]] ) ) {
-					kept = t;
-				}
-			}
-			mem[kept] = mem[nMem - 1];
-			nMem--;
-		}
-		for ( s = 0; s < nMem; s++ ) {
-			for ( t = s + 1; t < nMem; t++ ) {
-				if ( rStart[mem[t]] < rStart[mem[s]] ) {
-					swap = mem[s];
-					mem[s] = mem[t];
-					mem[t] = swap;
-				}
+		kept = mem[0];
+		for ( t = 1; t < nMem; t++ ) {
+			if ( rPrio[mem[t]] < rPrio[kept]
+					|| ( rPrio[mem[t]] == rPrio[kept] && rStart[mem[t]] < rStart[kept] ) ) {
+				kept = mem[t];
 			}
 		}
 		sumSin = 0.0f;
 		sumCos = 0.0f;
-		weight = 0.0f;
 		for ( s = 0; s < nMem; s++ ) {
 			t = mem[s];
 			sumSin += (float)sin( rAng[t] * ( M_PI / 180.0f ) ) * ( rLoud[t] + 0.05f );
@@ -1378,50 +1359,37 @@ void CG_DrawVisualSounds( void ) {
 			}
 		}
 		ang = AngleNormalize180( worldCur - viewYaw );
-		bestFade = 0.0f;
-		bestLoud = 0.0f;
-		for ( s = 0; s < nMem; s++ ) {
-			t = mem[s];
-			if ( rFade[t] > bestFade ) {
-				bestFade = rFade[t];
-			}
-			if ( rColor[t][3] > bestLoud ) {
-				bestLoud = rColor[t][3];
-			}
-		}
+		bestFade = rFade[kept];
+		bestLoud = rColor[kept][3];
 		VS_DrawStackArc( cx, cy, ang, bestLoud * bestFade );
-		for ( s = 0; s < nMem; s++ ) {
-			t = mem[s];
-			radius = VS_RADIUS + (float)s * VS_STACK_GAP;
-			x = cx - (float)sin( ang * ( M_PI / 180.0f ) ) * radius;
-			y = cy - (float)cos( ang * ( M_PI / 180.0f ) ) * radius;
-			color[0] = rColor[t][0];
-			color[1] = rColor[t][1];
-			color[2] = rColor[t][2];
-			color[3] = rColor[t][3];
-			if ( rIcon[t] ) {
-				sz = VS_ICON_SIZE * rFade[t];
-				if ( sz < 1.0f ) {
-					sz = 1.0f;
-				}
-				trap_R_SetColor( color );
-				CG_DrawPic( x - CG_HeightToWidth( sz ) * 0.5f, y - sz * 0.5f,
-						CG_HeightToWidth( sz ), sz, rIcon[t] );
-				trap_R_SetColor( NULL );
-				continue;
+		x = cx - (float)sin( ang * ( M_PI / 180.0f ) ) * VS_RADIUS;
+		y = cy - (float)cos( ang * ( M_PI / 180.0f ) ) * VS_RADIUS;
+		color[0] = rColor[kept][0];
+		color[1] = rColor[kept][1];
+		color[2] = rColor[kept][2];
+		color[3] = rColor[kept][3];
+		if ( rIcon[kept] ) {
+			sz = VS_ICON_SIZE * rFade[kept];
+			if ( sz < 1.0f ) {
+				sz = 1.0f;
 			}
-			label = rLabel[t];
-			color[0] = color[1] = color[2] = 1.00f;
-			ch = TINYCHAR_HEIGHT * rFade[t];
-			cw = CG_HeightToWidth( TINYCHAR_WIDTH ) * rFade[t];
-			if ( ch < 1.0f ) {
-				ch = 1.0f;
-				cw = CG_HeightToWidth( 1.0f );
-			}
-			len = CG_DrawStrlen( label );
-			CG_DrawStringExtFloat( x - cw * len * 0.5f, y - ch * 0.5f, label, color,
-					qtrue, qtrue, cw, ch, 0 );
+			trap_R_SetColor( color );
+			CG_DrawPic( x - CG_HeightToWidth( sz ) * 0.5f, y - sz * 0.5f,
+					CG_HeightToWidth( sz ), sz, rIcon[kept] );
+			trap_R_SetColor( NULL );
+			continue;
 		}
+		label = rLabel[kept];
+		color[0] = color[1] = color[2] = 1.00f;
+		ch = TINYCHAR_HEIGHT * rFade[kept];
+		cw = CG_HeightToWidth( TINYCHAR_WIDTH ) * rFade[kept];
+		if ( ch < 1.0f ) {
+			ch = 1.0f;
+			cw = CG_HeightToWidth( 1.0f );
+		}
+		len = CG_DrawStrlen( label );
+		CG_DrawStringExtFloat( x - cw * len * 0.5f, y - ch * 0.5f, label, color,
+				qtrue, qtrue, cw, ch, 0 );
 	}
 }
 

--- a/ratoa_gamecode/code/cgame/cg_visualsounds.c
+++ b/ratoa_gamecode/code/cgame/cg_visualsounds.c
@@ -1185,13 +1185,14 @@ void CG_DrawVisualSounds( void ) {
 		}
 
 		VectorSubtract( vsCues[i].origin, cg.refdef.vieworg, delta );
-		dist = VectorLength( delta );
-		loud[i] = 1.0f - dist / VS_RANGE;
-		if ( loud[i] < 0.0f ) {
-			loud[i] = 0.0f;
-		} else if ( loud[i] > 1.0f ) {
-			loud[i] = 1.0f;
+		dist = VectorLength( delta ) / VS_RANGE;
+		if ( dist < 0.0f ) {
+			dist = 0.0f;
+		} else if ( dist > 1.0f ) {
+			dist = 1.0f;
 		}
+		loud[i] = 1.0f - dist;
+		loud[i] *= loud[i];
 
 		yaw = atan2( delta[1], delta[0] ) * ( 180.0f / M_PI );
 		rel[i] = AngleNormalize180( yaw - cg.refdefViewAngles[1] );


### PR DESCRIPTION
Three VSound-related improvements:
- Squashed icon rendering so they only appear on a single ring centered around the crosshair. Multiple sounds from the same source won't stack outwards, they'll replace each other in priority order (e.g. footsteps low priority, pain sounds high priority). This significantly cuts down the clutter on the vsound hud and ensures the player gets a more limited amount of just the important information.
- Adjusted vsound distance falloff from linear to a curve. Sounds will now fall off more aggressively as they move further away, with the icons being commensurately less visible as a result. Further cuts down on vsound clutter and makes it more balanced.
- Fixed icon bleeding bug by adjusting shaders from map to clampmap and adding nomipmap declaration to each. Icons are now sharper and render more correctly.