### PR TITLE
Use a rolling development release

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -70,9 +70,9 @@ jobs:
         if: github.event_name == 'push' && !startsWith(github.ref, 'refs/tags/')
         uses: softprops/action-gh-release@v3
         with:
-          tag_name: development-${{ github.sha }}
+          tag_name: development
           target_commitish: ${{ github.sha }}
-          name: Development build ${{ github.sha }}
+          name: Development
           body: |
             Development build from `${{ github.ref_name }}` at `${{ github.sha }}`.
 
@@ -84,3 +84,4 @@ jobs:
           prerelease: true
           make_latest: false
           generate_release_notes: false
+          overwrite_files: true


### PR DESCRIPTION
## Why

The development release should provide one stable download location for the newest build instead of accumulating a separate prerelease for every commit.

## What changed

- Use the fixed `development` tag for non-tag branch pushes.
- Set the release name to `Development`.
- Replace existing release assets on each build with `overwrite_files: true`.
- Keep the release marked as a prerelease and leave stable tagged releases unchanged.

This follow-up is based on the merged development-release workflow and contains only the rolling-tag change.