### PR TITLE
Keep development release assets at a fixed filename

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -40,8 +40,19 @@ jobs:
       - name: Generate artifact metadata
         id: metadata
         run: |
-          GIT_DESCRIBE=$(git describe --tags --always)
-          ARTIFACT_NAME="devotion-${GIT_DESCRIBE}"
+          if [[ "$GITHUB_REF" == refs/tags/* ]]; then
+            GIT_DESCRIBE=$(git describe --tags --always)
+            ARTIFACT_NAME="devotion-${GIT_DESCRIBE}"
+          else
+            shopt -s nullglob
+            PK3_FILES=(build/*.pk3)
+            if [[ "${#PK3_FILES[@]}" -ne 1 ]]; then
+              echo "Expected exactly one PK3 file, found ${#PK3_FILES[@]}" >&2
+              exit 1
+            fi
+            mv "${PK3_FILES[0]}" build/devotion-development.pk3
+            ARTIFACT_NAME="devotion-development"
+          fi
           echo "artifact-name=${ARTIFACT_NAME}" >> $GITHUB_OUTPUT
           sha256sum build/*.pk3 > build/SHA256SUMS
           ls -la build/


### PR DESCRIPTION
## Why

Development builds use a rolling `development` release, but the generated PK3 filename can change when `git describe --tags` sees different tags or commits. That leaves old assets attached to the same release instead of replacing the current build.

## What changed

- Preserve `git describe --tags --always` naming for production tag pushes.
- Rename the single development PK3 to `devotion-development.pk3` for branch pushes.
- Use a stable Actions artifact name of `devotion-development` for those builds.
- Fail clearly if a development build produces anything other than exactly one PK3.

The workflow YAML parses successfully and the diff passes `git diff --check`.